### PR TITLE
lenovo-accessory: Convert from hidraw to USB HID transport

### DIFF
--- a/plugins/lenovo-accessory/README.md
+++ b/plugins/lenovo-accessory/README.md
@@ -9,7 +9,7 @@ This protocol is MCU-agnostic and supports both HID and BLE transports.
 
 This plugin enables firmware management across different connection types:
 
-* **USB HID**: Communicates via Get/Set Feature reports on the `hidraw` subsystem.
+* **USB HID**: Communicates via Get/Set Feature reports over the interface-3 control endpoint, using the `usb` subsystem.
 * **Bluetooth LE (BLE)**: Uses a custom service with dedicated Write/Read characteristics.
 
 ## Supported Devices
@@ -19,10 +19,10 @@ The plugin identifies devices using specific hardware IDs:
 ### HID Devices (Single-bank)
 
 * **Normal Mode**:
-  * `HIDRAW\VEN_17EF&DEV_629D`
-  * `HIDRAW\VEN_17EF&DEV_6201`
+  * `USB\VID_17EF&PID_629D`
+  * `USB\VID_17EF&PID_6201`
 * **Bootloader Mode**:
-  * `HIDRAW\VEN_17EF&DEV_6194` (Common bootloader PID)
+  * `USB\VID_17EF&PID_6194` (Common bootloader PID)
 
 ### BLE Devices (Dual-bank)
 
@@ -37,7 +37,7 @@ The update strategy differs based on the device's memory architecture:
 
 HID devices utilize a **single-bank** design. For these devices:
 
-1. The device must reboot into a dedicated **bootloader mode** (`DEV_6194`) to receive firmware.
+1. The device must reboot into a dedicated **bootloader mode** (`PID_6194`) to receive firmware.
 2. The plugin uses `CounterpartGuid` logic to map the runtime device to its bootloader interface.
 3. A final restart is performed to jump back to the new application code.
 

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-ble-device.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-ble-device.c
@@ -27,7 +27,7 @@ G_DEFINE_TYPE_WITH_CODE(FuLenovoAccessoryBleDevice,
 
 static gboolean
 fu_lenovo_accessory_ble_device_write_files(FuLenovoAccessoryBleDevice *self,
-					   FuLenovoDfuFileType file_type,
+					   FuLenovoAccessoryDfuFileType file_type,
 					   GInputStream *stream,
 					   FuProgress *progress,
 					   GError **error)
@@ -70,6 +70,7 @@ fu_lenovo_accessory_ble_device_write_firmware(FuDevice *device,
 	gsize fw_size = 0;
 	guint32 file_crc = 0xFFFFFFFF;
 	guint32 device_crc = 0;
+	FuLenovoAccessoryDeviceMode mode;
 	g_autoptr(GInputStream) stream = NULL;
 
 	/* progress */
@@ -84,10 +85,25 @@ fu_lenovo_accessory_ble_device_write_firmware(FuDevice *device,
 		return FALSE;
 	if (!fu_input_stream_compute_crc32(stream, FU_CRC_KIND_B32_STANDARD, &file_crc, error))
 		return FALSE;
-	if (!fu_lenovo_accessory_impl_dfu_entry(FU_LENOVO_ACCESSORY_IMPL(device), error))
+
+	/* only enter DFU mode if not already there */
+	if (!fu_lenovo_accessory_impl_get_mode(FU_LENOVO_ACCESSORY_IMPL(device), &mode, error))
+		return FALSE;
+	if (mode != FU_LENOVO_ACCESSORY_DEVICE_MODE_DFU_MODE) {
+		if (!fu_lenovo_accessory_impl_dfu_entry(FU_LENOVO_ACCESSORY_IMPL(device), error))
+			return FALSE;
+	}
+	if (!fu_lenovo_accessory_impl_dfu_attribute(FU_LENOVO_ACCESSORY_IMPL(device),
+						    NULL,
+						    NULL,
+						    NULL,
+						    NULL,
+						    NULL,
+						    NULL,
+						    error))
 		return FALSE;
 	if (!fu_lenovo_accessory_impl_dfu_prepare(FU_LENOVO_ACCESSORY_IMPL(device),
-						  FU_LENOVO_DFU_FILE_TYPE_BIN_FILE,
+						  FU_LENOVO_ACCESSORY_DFU_FILE_TYPE_BIN_FILE,
 						  0x0,
 						  (guint32)fw_size,
 						  file_crc,
@@ -95,11 +111,14 @@ fu_lenovo_accessory_ble_device_write_firmware(FuDevice *device,
 		return FALSE;
 	fu_progress_step_done(progress);
 	if (!fu_lenovo_accessory_ble_device_write_files(self,
-							FU_LENOVO_DFU_FILE_TYPE_BIN_FILE,
+							FU_LENOVO_ACCESSORY_DFU_FILE_TYPE_BIN_FILE,
 							stream,
 							fu_progress_get_child(progress),
 							error))
 		return FALSE;
+
+	/* give the device time to finalize the flash before reading back CRC */
+	fu_device_sleep(FU_DEVICE(self), 2000);
 	if (!fu_lenovo_accessory_impl_dfu_crc(FU_LENOVO_ACCESSORY_IMPL(device),
 					      &device_crc,
 					      error)) {
@@ -125,7 +144,7 @@ static gboolean
 fu_lenovo_accessory_ble_device_attach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	if (!fu_lenovo_accessory_impl_dfu_exit(FU_LENOVO_ACCESSORY_IMPL(device),
-					       FU_LENOVO_DFU_EXIT_CODE_DFU_SUCCESS,
+					       FU_LENOVO_ACCESSORY_DFU_EXIT_CODE_DFU_SUCCESS,
 					       error)) {
 		g_prefix_error_literal(error, "failed to exit: ");
 		return FALSE;
@@ -182,7 +201,7 @@ static gboolean
 fu_lenovo_accessory_ble_device_poll_cb(FuDevice *device, gpointer user_data, GError **error)
 {
 	GByteArray *buf_rsp = (GByteArray *)user_data;
-	FuLenovoStatus status;
+	FuLenovoAccessoryStatus status;
 	gsize offset = 0x0;
 	g_autoptr(GByteArray) buf = NULL;
 	g_autoptr(FuStructLenovoAccessoryCmd) st_cmd = NULL;
@@ -198,11 +217,11 @@ fu_lenovo_accessory_ble_device_poll_cb(FuDevice *device, gpointer user_data, GEr
 	if (st_cmd == NULL)
 		return FALSE;
 	status = fu_struct_lenovo_accessory_cmd_get_target_status(st_cmd) & 0x0F;
-	if (status == FU_LENOVO_STATUS_COMMAND_BUSY) {
+	if (status == FU_LENOVO_ACCESSORY_STATUS_COMMAND_BUSY) {
 		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_BUSY, "command busy");
 		return FALSE;
 	}
-	if (status != FU_LENOVO_STATUS_COMMAND_SUCCESSFUL) {
+	if (status != FU_LENOVO_ACCESSORY_STATUS_COMMAND_SUCCESSFUL) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_WRITE,

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-hid-bootloader.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-hid-bootloader.c
@@ -11,7 +11,7 @@
 #include "fu-lenovo-accessory-hid-common.h"
 
 struct _FuLenovoAccessoryHidBootloader {
-	FuHidrawDevice parent_instance;
+	FuHidDevice parent_instance;
 };
 
 static void
@@ -19,13 +19,13 @@ fu_lenovo_accessory_hid_bootloader_impl_iface_init(FuLenovoAccessoryImplInterfac
 
 G_DEFINE_TYPE_WITH_CODE(FuLenovoAccessoryHidBootloader,
 			fu_lenovo_accessory_hid_bootloader,
-			FU_TYPE_HIDRAW_DEVICE,
+			FU_TYPE_HID_DEVICE,
 			G_IMPLEMENT_INTERFACE(FU_TYPE_LENOVO_ACCESSORY_IMPL,
 					      fu_lenovo_accessory_hid_bootloader_impl_iface_init))
 
 static gboolean
 fu_lenovo_accessory_hid_bootloader_write_files(FuLenovoAccessoryHidBootloader *self,
-					       FuLenovoDfuFileType file_type,
+					       FuLenovoAccessoryDfuFileType file_type,
 					       GInputStream *stream,
 					       FuProgress *progress,
 					       GError **error)
@@ -58,7 +58,7 @@ static gboolean
 fu_lenovo_accessory_hid_bootloader_attach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	if (!fu_lenovo_accessory_impl_dfu_exit(FU_LENOVO_ACCESSORY_IMPL(device),
-					       FU_LENOVO_DFU_EXIT_CODE_DFU_SUCCESS,
+					       FU_LENOVO_ACCESSORY_DFU_EXIT_CODE_DFU_SUCCESS,
 					       error))
 		return FALSE;
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
@@ -72,26 +72,42 @@ fu_lenovo_accessory_hid_bootloader_setup(FuDevice *device, GError **error)
 	guint8 major = 0;
 	guint8 minor = 0;
 	guint8 micro = 0;
-	g_autoptr(FuHidDescriptor) desc = NULL;
-	g_autoptr(FuHidReport) report = NULL;
 	g_autofree gchar *version = NULL;
+	g_autoptr(GPtrArray) descriptors = NULL;
+	gboolean found_report = FALSE;
 
-	desc = fu_hidraw_device_parse_descriptor(FU_HIDRAW_DEVICE(device), error);
-	if (desc == NULL)
+	/* the command interface is a vendor HID collection (UsagePage 0xFF00,
+	 * Usage 0x02) carrying a 64-byte report; confirm it is present so we
+	 * fail early on a device that does not speak this protocol */
+	descriptors = fu_hid_device_parse_descriptors(FU_HID_DEVICE(device), error);
+	if (descriptors == NULL)
 		return FALSE;
-	report = fu_hid_descriptor_find_report(desc,
-					       error,
-					       "usage-page",
-					       0xFF00,
-					       "usage",
-					       0x02,
-					       "report-size",
-					       8,
-					       "report-count",
-					       0x40,
-					       NULL);
-	if (report == NULL)
+	for (guint i = 0; i < descriptors->len; i++) {
+		FuHidDescriptor *desc = g_ptr_array_index(descriptors, i);
+		g_autoptr(FuHidReport) report = NULL;
+		report = fu_hid_descriptor_find_report(desc,
+						       NULL,
+						       "usage-page",
+						       0xFF00,
+						       "usage",
+						       0x02,
+						       "report-size",
+						       8,
+						       "report-count",
+						       0x40,
+						       NULL);
+		if (report != NULL) {
+			found_report = TRUE;
+			break;
+		}
+	}
+	if (!found_report) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no vendor command report (0xFF00/0x02) found");
 		return FALSE;
+	}
 
 	/* add runtime counterpart */
 	if (!fu_lenovo_accessory_impl_dfu_attribute(FU_LENOVO_ACCESSORY_IMPL(device),
@@ -103,14 +119,16 @@ fu_lenovo_accessory_hid_bootloader_setup(FuDevice *device, GError **error)
 						    NULL,
 						    error))
 		return FALSE;
-	fu_device_add_instance_u16(device, "DEV", usb_pid);
+	fu_device_add_instance_u16(device, "PID", usb_pid);
 	if (!fu_device_build_instance_id_full(device,
 					      FU_DEVICE_INSTANCE_FLAG_COUNTERPART,
 					      error,
-					      "HIDRAW",
-					      "VEN",
-					      "DEV",
+					      "USB",
+					      "VID",
+					      "PID",
 					      NULL))
+		return FALSE;
+	if (!fu_device_build_instance_id(device, error, "USB", "VID", "PID", NULL))
 		return FALSE;
 
 	/* ensure always recoverable */
@@ -152,7 +170,7 @@ fu_lenovo_accessory_hid_bootloader_write_firmware(FuDevice *device,
 	if (!fu_input_stream_compute_crc32(stream, FU_CRC_KIND_B32_STANDARD, &file_crc, error))
 		return FALSE;
 	if (!fu_lenovo_accessory_impl_dfu_prepare(FU_LENOVO_ACCESSORY_IMPL(device),
-						  FU_LENOVO_DFU_FILE_TYPE_BIN_FILE,
+						  FU_LENOVO_ACCESSORY_DFU_FILE_TYPE_BIN_FILE,
 						  0x0,
 						  (guint32)fw_size,
 						  file_crc,
@@ -162,7 +180,7 @@ fu_lenovo_accessory_hid_bootloader_write_firmware(FuDevice *device,
 
 	if (!fu_lenovo_accessory_hid_bootloader_write_files(
 		FU_LENOVO_ACCESSORY_HID_BOOTLOADER(device),
-		FU_LENOVO_DFU_FILE_TYPE_BIN_FILE,
+		FU_LENOVO_ACCESSORY_DFU_FILE_TYPE_BIN_FILE,
 		stream,
 		fu_progress_get_child(progress),
 		error))
@@ -187,6 +205,7 @@ fu_lenovo_accessory_hid_bootloader_init(FuLenovoAccessoryHidBootloader *self)
 	fu_device_set_firmware_size_min(FU_DEVICE(self), 0x4000);
 	fu_device_set_name(FU_DEVICE(self), "HID Bootloader");
 	fu_device_set_remove_delay(FU_DEVICE(self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
+	fu_hid_device_set_interface(FU_HID_DEVICE(self), FU_LENOVO_ACCESSORY_IFACE_BL);
 }
 
 static void

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-hid-bootloader.h
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-hid-bootloader.h
@@ -13,4 +13,4 @@ G_DECLARE_FINAL_TYPE(FuLenovoAccessoryHidBootloader,
 		     fu_lenovo_accessory_hid_bootloader,
 		     FU,
 		     LENOVO_ACCESSORY_HID_BOOTLOADER,
-		     FuHidrawDevice)
+		     FuHidDevice)

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-hid-common.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-hid-common.c
@@ -9,20 +9,22 @@
 
 #include "fu-lenovo-accessory-hid-common.h"
 
-#define FU_LENOVO_ACCESSORY_HID_BUFSZ	  65
-#define FU_LENOVO_ACCESSORY_HID_REPORT_ID 0x00
-
 GByteArray *
 fu_lenovo_accessory_hid_read(FuLenovoAccessoryImpl *impl, GError **error)
 {
 	guint8 buf[FU_LENOVO_ACCESSORY_HID_BUFSZ] = {0x0};
 	g_autoptr(GByteArray) buf_res = g_byte_array_new();
 
-	if (!fu_hidraw_device_get_feature(FU_HIDRAW_DEVICE(impl),
-					  buf,
-					  sizeof(buf),
-					  FU_IOCTL_FLAG_NONE,
-					  error))
+	/* GET_REPORT (Feature) over the interface-3 control endpoint; the
+	 * report-id is carried in wValue, so the buffer is the raw 64-byte
+	 * frame with no report-id prefix */
+	if (!fu_hid_device_get_report(FU_HID_DEVICE(impl),
+				      FU_LENOVO_ACCESSORY_HID_REPORT_ID,
+				      buf,
+				      sizeof(buf),
+				      FU_LENOVO_ACCESSORY_HID_TIMEOUT,
+				      FU_HID_DEVICE_FLAG_IS_FEATURE,
+				      error))
 		return NULL;
 	g_byte_array_append(buf_res, buf, sizeof(buf));
 	return g_steal_pointer(&buf_res);
@@ -33,21 +35,25 @@ fu_lenovo_accessory_hid_write(FuLenovoAccessoryImpl *impl, GByteArray *buf, GErr
 {
 	g_autoptr(GByteArray) buf_req = g_byte_array_new();
 
-	fu_byte_array_append_uint8(buf_req, FU_LENOVO_ACCESSORY_HID_REPORT_ID);
+	/* SET_REPORT (Feature) over the interface-3 control endpoint; no
+	 * report-id prefix, frame padded to the fixed 64-byte length */
 	g_byte_array_append(buf_req, buf->data, buf->len);
 	fu_byte_array_set_size(buf_req, FU_LENOVO_ACCESSORY_HID_BUFSZ, 0x00);
-	return fu_hidraw_device_set_feature(FU_HIDRAW_DEVICE(impl),
-					    buf_req->data,
-					    buf_req->len,
-					    FU_IOCTL_FLAG_RETRY,
-					    error);
+	return fu_hid_device_set_report(FU_HID_DEVICE(impl),
+					FU_LENOVO_ACCESSORY_HID_REPORT_ID,
+					buf_req->data,
+					buf_req->len,
+					FU_LENOVO_ACCESSORY_HID_TIMEOUT,
+					FU_HID_DEVICE_FLAG_IS_FEATURE |
+					    FU_HID_DEVICE_FLAG_RETRY_FAILURE,
+					error);
 }
 
 static gboolean
 fu_lenovo_accessory_hid_poll_cb(FuDevice *device, gpointer user_data, GError **error)
 {
 	GByteArray *buf_rsp = (GByteArray *)user_data;
-	FuLenovoStatus status;
+	FuLenovoAccessoryStatus status;
 	gsize offset = 0x0;
 	g_autoptr(GByteArray) buf = NULL;
 	g_autoptr(FuStructLenovoAccessoryCmd) st_cmd = NULL;
@@ -55,16 +61,15 @@ fu_lenovo_accessory_hid_poll_cb(FuDevice *device, gpointer user_data, GError **e
 	buf = fu_lenovo_accessory_hid_read(FU_LENOVO_ACCESSORY_IMPL(device), error);
 	if (buf == NULL)
 		return FALSE;
-	offset += 1;
 	st_cmd = fu_struct_lenovo_accessory_cmd_parse(buf->data, buf->len, offset, error);
 	if (st_cmd == NULL)
 		return FALSE;
 	status = fu_struct_lenovo_accessory_cmd_get_target_status(st_cmd) & 0x0F;
-	if (status == FU_LENOVO_STATUS_COMMAND_BUSY) {
+	if (status == FU_LENOVO_ACCESSORY_STATUS_COMMAND_BUSY) {
 		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_BUSY, "command busy");
 		return FALSE;
 	}
-	if (status != FU_LENOVO_STATUS_COMMAND_SUCCESSFUL) {
+	if (status != FU_LENOVO_ACCESSORY_STATUS_COMMAND_SUCCESSFUL) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_WRITE,

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-hid-common.h
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-hid-common.h
@@ -8,6 +8,23 @@
 
 #include "fu-lenovo-accessory-impl.h"
 
+/* HID feature report
+ *
+ * Commands are carried as HID Feature reports over the interface-3 control
+ * endpoint (EP0). The control-transfer data buffer does NOT include the
+ * report-id byte (unlike the hidraw ioctl path), so the on-wire frame is a
+ * flat 64 bytes starting at the command header. The report-id (0x00) is
+ * passed out-of-band through the SET_REPORT/GET_REPORT wValue low byte. */
+#define FU_LENOVO_ACCESSORY_HID_REPORT_ID 0x00
+#define FU_LENOVO_ACCESSORY_HID_BUFSZ	  64
+#define FU_LENOVO_ACCESSORY_HID_TIMEOUT	  1000 /* ms */
+
+/* USB interface assignment (stable across firmware revisions) */
+#define FU_LENOVO_ACCESSORY_IFACE_CMD 0x03 /* vendor HID, Feature report */
+
+/* the bootloader exposes a single HID interface, so commands go to iface 0 */
+#define FU_LENOVO_ACCESSORY_IFACE_BL 0x00
+
 GByteArray *
 fu_lenovo_accessory_hid_read(FuLenovoAccessoryImpl *impl, GError **error) G_GNUC_NON_NULL(1);
 gboolean

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-hid-device.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-hid-device.c
@@ -11,7 +11,7 @@
 #include "fu-lenovo-accessory-hid-device.h"
 
 struct _FuLenovoAccessoryHidDevice {
-	FuHidrawDevice parent_instance;
+	FuHidDevice parent_instance;
 };
 
 static void
@@ -19,7 +19,7 @@ fu_lenovo_accessory_hid_device_impl_iface_init(FuLenovoAccessoryImplInterface *i
 
 G_DEFINE_TYPE_WITH_CODE(FuLenovoAccessoryHidDevice,
 			fu_lenovo_accessory_hid_device,
-			FU_TYPE_HIDRAW_DEVICE,
+			FU_TYPE_HID_DEVICE,
 			G_IMPLEMENT_INTERFACE(FU_TYPE_LENOVO_ACCESSORY_IMPL,
 					      fu_lenovo_accessory_hid_device_impl_iface_init))
 
@@ -31,25 +31,41 @@ fu_lenovo_accessory_hid_device_setup(FuDevice *device, GError **error)
 	guint8 minor = 0;
 	guint8 micro = 0;
 	g_autofree gchar *version = NULL;
-	g_autoptr(FuHidDescriptor) desc = NULL;
-	g_autoptr(FuHidReport) report = NULL;
+	g_autoptr(GPtrArray) descriptors = NULL;
+	gboolean found_report = FALSE;
 
-	desc = fu_hidraw_device_parse_descriptor(FU_HIDRAW_DEVICE(self), error);
-	if (desc == NULL)
+	/* the command interface is a vendor HID collection (UsagePage 0xFF00,
+	 * Usage 0x02) carrying a 64-byte report; confirm it is present so we
+	 * fail early on a device that does not speak this protocol */
+	descriptors = fu_hid_device_parse_descriptors(FU_HID_DEVICE(self), error);
+	if (descriptors == NULL)
 		return FALSE;
-	report = fu_hid_descriptor_find_report(desc,
-					       error,
-					       "usage-page",
-					       0xFF00,
-					       "usage",
-					       0x02,
-					       "report-size",
-					       8,
-					       "report-count",
-					       0x40,
-					       NULL);
-	if (report == NULL)
+	for (guint i = 0; i < descriptors->len; i++) {
+		FuHidDescriptor *desc = g_ptr_array_index(descriptors, i);
+		g_autoptr(FuHidReport) report = NULL;
+		report = fu_hid_descriptor_find_report(desc,
+						       NULL,
+						       "usage-page",
+						       0xFF00,
+						       "usage",
+						       0x02,
+						       "report-size",
+						       8,
+						       "report-count",
+						       0x40,
+						       NULL);
+		if (report != NULL) {
+			found_report = TRUE;
+			break;
+		}
+	}
+	if (!found_report) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no vendor command report (0xFF00/0x02) found");
 		return FALSE;
+	}
 	if (!fu_lenovo_accessory_impl_get_fwversion(FU_LENOVO_ACCESSORY_IMPL(device),
 						    &major,
 						    &minor,
@@ -67,7 +83,7 @@ fu_lenovo_accessory_hid_device_detach(FuDevice *device, FuProgress *progress, GE
 	FuLenovoAccessoryHidDevice *self = FU_LENOVO_ACCESSORY_HID_DEVICE(device);
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_RESTART);
 	if (!fu_lenovo_accessory_impl_set_mode(FU_LENOVO_ACCESSORY_IMPL(self),
-					       FU_LENOVO_DEVICE_MODE_DFU_MODE,
+					       FU_LENOVO_ACCESSORY_DEVICE_MODE_DFU_MODE,
 					       error))
 		return FALSE;
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
@@ -114,6 +130,5 @@ fu_lenovo_accessory_hid_device_init(FuLenovoAccessoryHidDevice *self)
 	fu_device_set_install_duration(FU_DEVICE(self), 30);
 	fu_device_add_icon(FU_DEVICE(self), FU_DEVICE_ICON_USB_RECEIVER);
 	fu_device_set_remove_delay(FU_DEVICE(self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
-	fu_udev_device_add_open_flag(FU_UDEV_DEVICE(self), FU_IO_CHANNEL_OPEN_FLAG_READ);
-	fu_udev_device_add_open_flag(FU_UDEV_DEVICE(self), FU_IO_CHANNEL_OPEN_FLAG_WRITE);
+	fu_hid_device_set_interface(FU_HID_DEVICE(self), FU_LENOVO_ACCESSORY_IFACE_CMD);
 }

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-hid-device.h
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-hid-device.h
@@ -13,4 +13,4 @@ G_DECLARE_FINAL_TYPE(FuLenovoAccessoryHidDevice,
 		     fu_lenovo_accessory_hid_device,
 		     FU,
 		     LENOVO_ACCESSORY_HID_DEVICE,
-		     FuHidrawDevice)
+		     FuHidDevice)

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-impl.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-impl.c
@@ -106,9 +106,10 @@ fu_lenovo_accessory_impl_get_fwversion(FuLenovoAccessoryImpl *self,
 	return TRUE;
 }
 
-#if 0
 gboolean
-fu_lenovo_accessory_impl_get_mode(FuLenovoAccessoryImpl *self, FuLenovoDeviceMode *mode, GError **error)
+fu_lenovo_accessory_impl_get_mode(FuLenovoAccessoryImpl *self,
+				  FuLenovoAccessoryDeviceMode *mode,
+				  GError **error)
 {
 	g_autoptr(FuStructLenovoAccessoryCmd) st_cmd = fu_struct_lenovo_accessory_cmd_new();
 	g_autoptr(FuStructLenovoDevicemodeRsp) st_rsp = NULL;
@@ -120,10 +121,12 @@ fu_lenovo_accessory_impl_get_mode(FuLenovoAccessoryImpl *self, FuLenovoDeviceMod
 	    FU_LENOVO_ACCESSORY_COMMAND_CLASS_DEVICE_INFORMATION);
 	fu_struct_lenovo_accessory_cmd_set_command_id(
 	    st_cmd,
-	    FU_LENOVO_ACCESSORY_INFO_ID_DEVICE_MODE | (FU_LENOVO_ACCESSORY_CMD_DIR_CMD_SET << 7));
+	    FU_LENOVO_ACCESSORY_INFO_ID_DEVICE_MODE | (FU_LENOVO_ACCESSORY_CMD_DIR_CMD_GET << 7));
 	buf = fu_lenovo_accessory_impl_process(self, st_cmd->buf, error);
-	if (buf == NULL)
+	if (buf == NULL) {
+		g_prefix_error_literal(error, "get device mode: ");
 		return FALSE;
+	}
 	st_rsp = fu_struct_lenovo_devicemode_rsp_parse(buf->data, buf->len, 0x0, error);
 	if (st_rsp == NULL)
 		return FALSE;
@@ -132,11 +135,10 @@ fu_lenovo_accessory_impl_get_mode(FuLenovoAccessoryImpl *self, FuLenovoDeviceMod
 	/* success */
 	return TRUE;
 }
-#endif
 
 gboolean
 fu_lenovo_accessory_impl_set_mode(FuLenovoAccessoryImpl *self,
-				  FuLenovoDeviceMode mode,
+				  FuLenovoAccessoryDeviceMode mode,
 				  GError **error)
 {
 	g_autoptr(FuStructLenovoAccessoryCmd) st_cmd = fu_struct_lenovo_accessory_cmd_new();
@@ -153,7 +155,7 @@ fu_lenovo_accessory_impl_set_mode(FuLenovoAccessoryImpl *self,
 	if (!fu_struct_lenovo_devicemode_req_set_cmd(st_req, st_cmd, error))
 		return FALSE;
 	fu_struct_lenovo_devicemode_req_set_mode(st_req, mode);
-	if (mode == FU_LENOVO_DEVICE_MODE_DFU_MODE)
+	if (mode == FU_LENOVO_ACCESSORY_DEVICE_MODE_DFU_MODE)
 		return fu_lenovo_accessory_impl_write(self, st_req->buf, error);
 	buf = fu_lenovo_accessory_impl_process(self, st_req->buf, error);
 	if (buf == NULL)
@@ -166,7 +168,7 @@ fu_lenovo_accessory_impl_set_mode(FuLenovoAccessoryImpl *self,
 /* @exit_code: the exit status code (e.g., 0x00 for success/reboot) */
 gboolean
 fu_lenovo_accessory_impl_dfu_exit(FuLenovoAccessoryImpl *self,
-				  FuLenovoDfuExitCode exit_code,
+				  FuLenovoAccessoryDfuExitCode exit_code,
 				  GError **error)
 {
 	g_autoptr(FuStructLenovoAccessoryCmd) st_cmd = fu_struct_lenovo_accessory_cmd_new();
@@ -243,7 +245,7 @@ fu_lenovo_accessory_impl_dfu_attribute(FuLenovoAccessoryImpl *self,
 
 gboolean
 fu_lenovo_accessory_impl_dfu_prepare(FuLenovoAccessoryImpl *self,
-				     FuLenovoDfuFileType file_type,
+				     FuLenovoAccessoryDfuFileType file_type,
 				     guint32 start_address,
 				     guint32 end_address,
 				     guint32 crc32,
@@ -276,7 +278,7 @@ fu_lenovo_accessory_impl_dfu_prepare(FuLenovoAccessoryImpl *self,
 
 gboolean
 fu_lenovo_accessory_impl_dfu_file(FuLenovoAccessoryImpl *self,
-				  FuLenovoDfuFileType file_type,
+				  FuLenovoAccessoryDfuFileType file_type,
 				  guint32 address,
 				  const guint8 *data,
 				  gsize datasz,

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-impl.h
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-impl.h
@@ -33,15 +33,15 @@ fu_lenovo_accessory_impl_get_fwversion(FuLenovoAccessoryImpl *self,
 				       GError **error) G_GNUC_NON_NULL(1);
 gboolean
 fu_lenovo_accessory_impl_get_mode(FuLenovoAccessoryImpl *self,
-				  FuLenovoDeviceMode *mode,
+				  FuLenovoAccessoryDeviceMode *mode,
 				  GError **error) G_GNUC_NON_NULL(1, 2);
 gboolean
 fu_lenovo_accessory_impl_set_mode(FuLenovoAccessoryImpl *self,
-				  FuLenovoDeviceMode mode,
+				  FuLenovoAccessoryDeviceMode mode,
 				  GError **error) G_GNUC_NON_NULL(1);
 gboolean
 fu_lenovo_accessory_impl_dfu_exit(FuLenovoAccessoryImpl *self,
-				  FuLenovoDfuExitCode exit_code,
+				  FuLenovoAccessoryDfuExitCode exit_code,
 				  GError **error) G_GNUC_NON_NULL(1);
 gboolean
 fu_lenovo_accessory_impl_dfu_attribute(FuLenovoAccessoryImpl *self,
@@ -54,14 +54,14 @@ fu_lenovo_accessory_impl_dfu_attribute(FuLenovoAccessoryImpl *self,
 				       GError **error) G_GNUC_NON_NULL(1);
 gboolean
 fu_lenovo_accessory_impl_dfu_prepare(FuLenovoAccessoryImpl *self,
-				     FuLenovoDfuFileType file_type,
+				     FuLenovoAccessoryDfuFileType file_type,
 				     guint32 start_address,
 				     guint32 end_address,
 				     guint32 crc32,
 				     GError **error) G_GNUC_NON_NULL(1);
 gboolean
 fu_lenovo_accessory_impl_dfu_file(FuLenovoAccessoryImpl *self,
-				  FuLenovoDfuFileType file_type,
+				  FuLenovoAccessoryDfuFileType file_type,
 				  guint32 address,
 				  const guint8 *data,
 				  gsize datasz,

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-plugin.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-plugin.c
@@ -30,7 +30,7 @@ fu_lenovo_accessory_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LENOVO_ACCESSORY_HID_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LENOVO_ACCESSORY_HID_BOOTLOADER);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LENOVO_ACCESSORY_BLE_DEVICE);
-	fu_plugin_add_udev_subsystem(plugin, "hidraw");
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 
 	/* chain up to parent */
 	G_OBJECT_CLASS(fu_lenovo_accessory_plugin_parent_class)->constructed(obj);

--- a/plugins/lenovo-accessory/fu-lenovo-accessory.rs
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory.rs
@@ -30,7 +30,7 @@ enum FuLenovoAccessoryCmdDir {
 }
 
 #[repr(u8)]
-enum FuLenovoStatus {
+enum FuLenovoAccessoryStatus {
     NewCommand = 0x00,
     CommandBusy = 0x01,
     CommandSuccessful = 0x02,
@@ -40,20 +40,20 @@ enum FuLenovoStatus {
 }
 
 #[repr(u8)]
-enum FuLenovoDeviceMode {
+enum FuLenovoAccessoryDeviceMode {
     NormalMode = 0x00,
     DriverMode = 0x01,
     DfuMode = 0x02,
 }
 
 #[repr(u8)]
-enum FuLenovoDfuFileType {
+enum FuLenovoAccessoryDfuFileType {
     HexFile = 0x00,
     BinFile = 0x01,
 }
 
 #[repr(u8)]
-enum FuLenovoDfuExitCode {
+enum FuLenovoAccessoryDfuExitCode {
     DfuSuccess = 0x00,
     Abort = 0x01,
 }
@@ -73,7 +73,7 @@ struct FuStructLenovoAccessoryCmd {
 #[repr(C, packed)]
 struct FuStructLenovoDfuFwReq {
     cmd: FuStructLenovoAccessoryCmd,
-    file_type: FuLenovoDfuFileType,
+    file_type: FuLenovoAccessoryDfuFileType,
     offset_address: u32be,
     data: [u8; 32],
 }
@@ -82,7 +82,7 @@ struct FuStructLenovoDfuFwReq {
 #[repr(C, packed)]
 struct FuStructLenovoDfuExitReq {
     cmd: FuStructLenovoAccessoryCmd,
-    exit_code: FuLenovoDfuExitCode,
+    exit_code: FuLenovoAccessoryDfuExitCode,
 }
 
 #[derive(Parse)]
@@ -106,7 +106,7 @@ struct FuStructLenovoDfuCrcRsp {
 #[repr(C, packed)]
 struct FuStructLenovoDfuPrepareReq {
     cmd: FuStructLenovoAccessoryCmd,
-    file_type: FuLenovoDfuFileType,
+    file_type: FuLenovoAccessoryDfuFileType,
     start_address: u32be,
     end_address: u32be,
     crc32: u32be,
@@ -116,13 +116,13 @@ struct FuStructLenovoDfuPrepareReq {
 #[repr(C, packed)]
 struct FuStructLenovoDevicemodeReq {
     cmd: FuStructLenovoAccessoryCmd,
-    mode: FuLenovoDeviceMode,
+    mode: FuLenovoAccessoryDeviceMode,
 }
 
-//#[derive(Parse)]
+#[derive(Parse)]
 #[repr(C, packed)]
 struct FuStructLenovoDevicemodeRsp {
-    mode: FuLenovoDeviceMode,
+    mode: FuLenovoAccessoryDeviceMode,
 }
 
 #[derive(Parse)]

--- a/plugins/lenovo-accessory/lenovo-accessory.quirk
+++ b/plugins/lenovo-accessory/lenovo-accessory.quirk
@@ -1,21 +1,21 @@
 # Lenovo HID Bootloader
-[HIDRAW\VEN_17EF&DEV_6194]
+[USB\VID_17EF&PID_6194]
 Plugin = lenovo_accessory
 GType = FuLenovoAccessoryHidBootloader
 
 # Lenovo Pro USB-A Unified Pairing Receiver
-[HIDRAW\VEN_17EF&DEV_629D]
+[USB\VID_17EF&PID_629D]
 Name = Pro USB-A Unified Pairing Receiver
 Plugin = lenovo_accessory
 GType = FuLenovoAccessoryHidDevice
-CounterpartGuid = HIDRAW\VEN_17EF&DEV_6194
+CounterpartGuid = USB\VID_17EF&PID_6194
 
 # Lenovo Pro USB-A Unified Pairing Receiver
-[HIDRAW\VEN_17EF&DEV_6201]
+[USB\VID_17EF&PID_6201]
 Name = Pro USB-A Unified Pairing Receiver
 Plugin = lenovo_accessory
 GType = FuLenovoAccessoryHidDevice
-CounterpartGuid = HIDRAW\VEN_17EF&DEV_6194
+CounterpartGuid = USB\VID_17EF&PID_6194
 
 # Lenovo 700 Multi-Device Wireless Mouse
 [BLUETOOTH\VID_17EF&PID_61FE]

--- a/plugins/lenovo-accessory/tests/lenovo-accessory-receiver.json
+++ b/plugins/lenovo-accessory/tests/lenovo-accessory-receiver.json
@@ -3,13 +3,13 @@
   "interactive": false,
   "steps": [
     {
-      "url": "49a8bf125d8ae8d43bcec977afa08e686d665c146424bea08b70d71d0e85bb04-Lenovo-hid_629d-vs1.1.3.cab",
-      "emulation-url": "c4bdf91f9ff41cfb6cff2c72a3196ae0a1965ab26e75d67175a92a9181eeca78-emulation.zip",
+      "url": "f73be118c45efc87b15935851ffc9de5250e37db6bda86484bd13be7f00a01ee-Lenovo-hid_629d-vs1.2.0.cab",
+      "emulation-url": "3e70166364fc32c4d3b86113280716b1e01bcf7e22736ebb0114d0ecb3cf780e-629d-1.1.3-to-1.2.0-emulation.zip",
       "components": [
         {
-          "version": "1.1.3",
+          "version": "1.2.0",
           "guids": [
-            "e31f39bb-f694-55da-9935-0cb19e922a5c"
+            "51ce2eac-38d4-5d12-aff0-c9493165dccc"
           ]
         }
       ]


### PR DESCRIPTION
Some firmware revisions do not expose an interrupt endpoint on the vendor command interface, so usbhid does not bind it and no hidraw node is created. On those receivers the existing hidraw path fails completely.

Switch the HID command transport from hidraw to USB control-transfer Feature reports on the vendor command interface, so these devices are supported too. Frames are now a flat 64-byte report with no report-id prefix.

- Use `fu_hid_device_{get,set}_report()` with `FU_HID_DEVICE_FLAG_IS_FEATURE` instead of hidraw ioctls, and reparent the device and bootloader classes onto `FuHidDevice`, pinning the command interface (0x03) and bootloader interface (0x00).
- Migrate the HID quirk entries and the bootloader counterpart instance-id from `HIDRAW\VEN&DEV` to `USB\VID&PID`; the BLE entries are left untouched.
- Refresh the BLE update flow to query the mode before entering DFU, read the DFU attributes once, and settle before reading back the CRC. This re-enables `fu_lenovo_accessory_impl_get_mode()` and fixes the command direction used to read the mode.
- Unify the enum prefixes on `FuLenovoAccessory*`.

Type of pull request:

- [ ] New plugin
- [ ] Code fix
- [x] Feature
- [ ] Documentation

Per your review, this is the first of the split PRs — the hidraw→HID transport conversion. The dual-bank dongle and paired-peripheral support (plus the child-device emulation) will follow in a second PR on top of this one.
