### PR TITLE
Increase the JCat parser item limit from 100 to 1000

### DIFF
--- a/libfwupd/fwupd-jcat-file.c
+++ b/libfwupd/fwupd-jcat-file.c
@@ -124,7 +124,7 @@ fwupd_jcat_file_json_parser_new(void)
 {
 	g_autoptr(FwupdJsonParser) json_parser = fwupd_json_parser_new();
 	fwupd_json_parser_set_max_depth(json_parser, 5);
-	fwupd_json_parser_set_max_items(json_parser, 100);
+	fwupd_json_parser_set_max_items(json_parser, 1000);
 	fwupd_json_parser_set_max_quoted(json_parser, 100 * 1024);
 	return g_steal_pointer(&json_parser);
 }


### PR DESCRIPTION
As requested in #10475, this raises the default max_items in fwupd_jcat_file_json_parser_new() from 100 to 1000. The Lenovo KEK update's JCat file contains 296 items. 

Fixes #10475

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
