### PR TITLE
Add fu_ptr_array_copy() to replace g_ptr_array_copy()

### DIFF
--- a/contrib/ci/check-source.py
+++ b/contrib/ci/check-source.py
@@ -849,6 +849,7 @@ class Checker:
             "g_variant_get_strv": "Use fwupd_variant_get_strv() instead",
             "g_variant_get_double": "Use fwupd_variant_get_double() instead",
             "g_variant_get_int32": "Use fwupd_variant_get_int32() instead",
+            "g_ptr_array_copy": "Use fu_ptr_array_copy() instead",
             "g_random_int_range": "Use fu_common_get_random() or a predictable token instead",
             "g_assert": "Use g_set_error() or g_return_val_if_fail() instead",
             "HIDIOCSFEATURE": "Use fu_hidraw_device_set_feature() instead",

--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -17,6 +17,7 @@
 #include "fu-input-stream.h"
 #include "fu-mem.h"
 #include "fu-partial-input-stream.h"
+#include "fu-ptr-array.h"
 #include "fu-string.h"
 
 /**
@@ -2459,7 +2460,8 @@ static GPtrArray *
 fu_firmware_get_images_sorted(FuFirmware *self)
 {
 	FuFirmwarePrivate *priv = GET_PRIVATE(self);
-	g_autoptr(GPtrArray) images = g_ptr_array_copy(priv->images, (GCopyFunc)g_object_ref, NULL);
+	g_autoptr(GPtrArray) images =
+	    fu_ptr_array_copy(priv->images, (GCopyFunc)g_object_ref, g_object_unref);
 	if (priv->flags & FU_FIRMWARE_FLAG_DEDUPE_IDX)
 		g_ptr_array_sort(images, fu_firmware_sort_by_idx_cb);
 	if (priv->flags & FU_FIRMWARE_FLAG_DEDUPE_ID)

--- a/libfwupdplugin/fu-ptr-array-test.c
+++ b/libfwupdplugin/fu-ptr-array-test.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include <fwupdplugin.h>
+
+#include "fu-test.h"
+
+static void
+fu_ptr_array_copy_func(void)
+{
+	g_autoptr(GPtrArray) array = g_ptr_array_new_with_free_func(g_free);
+	g_autoptr(GPtrArray) array_copy = NULL;
+
+	g_ptr_array_add(array, g_strdup("hello"));
+	g_ptr_array_add(array, g_strdup("world"));
+	g_assert_cmpint(array->len, ==, 2);
+
+	array_copy = fu_ptr_array_copy(array, (GCopyFunc)g_strdup, g_free);
+	g_assert_nonnull(array_copy);
+	g_assert_cmpint(array_copy->len, ==, 2);
+	g_assert_cmpstr(g_ptr_array_index(array_copy, 0), ==, "hello");
+	g_assert_cmpstr(g_ptr_array_index(array_copy, 1), ==, "world");
+
+	/* check it is a deep copy */
+	g_assert_true(g_ptr_array_index(array, 0) != g_ptr_array_index(array_copy, 0));
+	g_assert_true(g_ptr_array_index(array, 1) != g_ptr_array_index(array_copy, 1));
+}
+
+static void
+fu_ptr_array_copy_empty_func(void)
+{
+	g_autoptr(GPtrArray) array = g_ptr_array_new_with_free_func(g_free);
+	g_autoptr(GPtrArray) array_copy = NULL;
+
+	array_copy = fu_ptr_array_copy(array, (GCopyFunc)g_strdup, g_free);
+	g_assert_nonnull(array_copy);
+	g_assert_cmpint(array_copy->len, ==, 0);
+}
+
+int
+main(int argc, char **argv)
+{
+	g_test_init(&argc, &argv, NULL);
+	g_test_add_func("/fwupd/ptr-array/copy", fu_ptr_array_copy_func);
+	g_test_add_func("/fwupd/ptr-array/copy-empty", fu_ptr_array_copy_empty_func);
+	return g_test_run();
+}

--- a/libfwupdplugin/fu-ptr-array.c
+++ b/libfwupdplugin/fu-ptr-array.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#define G_LOG_DOMAIN "FuCommon"
+
+#include "config.h"
+
+#include "fu-ptr-array.h"
+
+/**
+ * fu_ptr_array_copy:
+ * @array: a #GPtrArray
+ * @func: a copy function
+ * @free_func: (nullable): a free function for the new array
+ *
+ * Deep copies a #GPtrArray using @func to copy each element. The new array uses @free_func
+ * as the element free function.
+ *
+ * Returns: (transfer full): a new #GPtrArray
+ *
+ * Since: 2.0.8
+ **/
+GPtrArray *
+fu_ptr_array_copy(GPtrArray *array, GCopyFunc func, GDestroyNotify free_func)
+{
+	GPtrArray *array_new;
+
+	g_return_val_if_fail(array != NULL, NULL);
+	g_return_val_if_fail(func != NULL, NULL);
+
+	array_new = g_ptr_array_new_with_free_func(free_func);
+	for (guint i = 0; i < array->len; i++)
+		g_ptr_array_add(array_new, func(g_ptr_array_index(array, i), NULL));
+	return array_new;
+}

--- a/libfwupdplugin/fu-ptr-array.h
+++ b/libfwupdplugin/fu-ptr-array.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2026 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupd.h>
+
+GPtrArray *
+fu_ptr_array_copy(GPtrArray *array, GCopyFunc func, GDestroyNotify free_func) G_GNUC_NON_NULL(1, 2);

--- a/libfwupdplugin/fwupdplugin.h
+++ b/libfwupdplugin/fwupdplugin.h
@@ -116,6 +116,7 @@
 #include <libfwupdplugin/fu-processor-device.h>
 #include <libfwupdplugin/fu-progress.h>
 #include <libfwupdplugin/fu-protobuf.h>
+#include <libfwupdplugin/fu-ptr-array.h>
 #include <libfwupdplugin/fu-sbatlevel-section.h>
 #include <libfwupdplugin/fu-security-attr.h>
 #include <libfwupdplugin/fu-security-attrs.h>

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -187,6 +187,7 @@ fwupdplugin_src = [
   'fu-pkcs7.c',
   'fu-processor-device.c',
   'fu-protobuf.c', # fuzzing
+  'fu-ptr-array.c', # fuzzing
   'fu-oprom-device.c',
   'fu-output-stream.c', # fuzzing
   'fu-plugin.c',
@@ -353,6 +354,7 @@ fwupdplugin_headers = [
   'fu-plugin-private.h',
   'fu-processor-device.h',
   'fu-progress.h',
+  'fu-ptr-array.h',
   'fu-quirks.h',
   'fu-sbatlevel-section.h',
   'fu-security-attr.h',
@@ -533,6 +535,7 @@ if get_option('tests')
     'plugin',
     'progress',
     'protobuf',
+    'ptr-array',
     'quirks',
     'security-attrs',
     'smbios',

--- a/plugins/gpio/fu-gpio-plugin.c
+++ b/plugins/gpio/fu-gpio-plugin.c
@@ -122,7 +122,7 @@ fu_gpio_plugin_cleanup(FuPlugin *plugin,
 
 	/* deep copy to local to clear transaction array */
 	current_logical_ids =
-	    g_ptr_array_copy(self->current_logical_ids, (GCopyFunc)g_strdup, NULL);
+	    fu_ptr_array_copy(self->current_logical_ids, (GCopyFunc)g_strdup, g_free);
 	g_ptr_array_set_size(self->current_logical_ids, 0);
 
 	/* close the fds we opened during ->prepare */

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -5692,7 +5692,7 @@ fu_engine_get_remotes(FuEngine *self, GError **error)
 	}
 
 	/* deep copy so the remote list can be kept up to date */
-	return g_ptr_array_copy(remotes, (GCopyFunc)g_object_ref, NULL);
+	return fu_ptr_array_copy(remotes, (GCopyFunc)g_object_ref, g_object_unref);
 }
 
 /**

--- a/src/fu-usb-backend.c
+++ b/src/fu-usb-backend.c
@@ -241,6 +241,14 @@ typedef struct {
 	libusb_hotplug_event event;
 } FuUsbBackendIdleHelper;
 
+static void
+fu_usb_backend_idle_helper_free(FuUsbBackendIdleHelper *helper)
+{
+	g_object_unref(helper->self);
+	libusb_unref_device(helper->dev);
+	g_free(helper);
+}
+
 static gpointer
 fu_usb_backend_idle_helper_copy(gconstpointer src, gpointer user_data)
 {
@@ -261,7 +269,9 @@ fu_usb_backend_idle_hotplug_cb(gpointer user_data)
 
 	/* drain the idle events with the lock held */
 	g_mutex_lock(&self->idle_events_mutex);
-	idle_events = g_ptr_array_copy(self->idle_events, fu_usb_backend_idle_helper_copy, NULL);
+	idle_events = fu_ptr_array_copy(self->idle_events,
+					fu_usb_backend_idle_helper_copy,
+					(GDestroyNotify)fu_usb_backend_idle_helper_free);
 	g_ptr_array_set_size(self->idle_events, 0);
 	self->idle_events_id = 0;
 	g_mutex_unlock(&self->idle_events_mutex);
@@ -480,16 +490,6 @@ fu_usb_backend_finalize(GObject *object)
 
 	G_OBJECT_CLASS(fu_usb_backend_parent_class)->finalize(object);
 }
-
-#ifndef HAVE_UDEV
-static void
-fu_usb_backend_idle_helper_free(FuUsbBackendIdleHelper *helper)
-{
-	g_object_unref(helper->self);
-	libusb_unref_device(helper->dev);
-	g_free(helper);
-}
-#endif
 
 static void
 fu_usb_backend_init(FuUsbBackend *self)


### PR DESCRIPTION
This takes a GCopyFunc and GDestroyNotify rather than a GCopyFunc and user_data, which makes the ownership semantics explicit.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
