### PR TITLE
trivial: Allow fastboot mode modem when using the modem-manager plugin

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -125,6 +125,7 @@ if build_daemon
     if get_option('plugin_modem_manager').allowed()
       device_allows += ['char-wwan_port']
       device_allows += ['char-ttyUSB']
+      device_allows += ['/dev/bus/usb/']
     endif
     foreach device_allow : device_allows
       dynamic_options += ['DeviceAllow=' + device_allow + ' rw']


### PR DESCRIPTION
trivial: Allow fastboot mode modem when using the modem-manager plugin
