### PR TITLE
mtd: Fall back to a generic firmware when no specific gtype is set

### DIFF
--- a/plugins/mtd/fu-mtd-device.c
+++ b/plugins/mtd/fu-mtd-device.c
@@ -123,8 +123,13 @@ fu_mtd_device_read_firmware(FuDevice *device, FuProgress *progress, GError **err
 {
 	FuMtdDevice *self = FU_MTD_DEVICE(device);
 	GType firmware_gtype = fu_device_get_firmware_gtype(device);
-	g_autoptr(FuFirmware) firmware = g_object_new(firmware_gtype, NULL);
+	g_autoptr(FuFirmware) firmware = NULL;
 	g_autoptr(GInputStream) stream = NULL;
+
+	/* fall back to a generic firmware when no specific type was detected */
+	if (firmware_gtype == G_TYPE_INVALID)
+		firmware_gtype = FU_TYPE_FIRMWARE;
+	firmware = g_object_new(firmware_gtype, NULL);
 
 	/* parse as firmware image */
 	stream = fu_mtd_device_read_stream(self, progress, error);

--- a/plugins/mtd/fu-self-test.c
+++ b/plugins/mtd/fu-self-test.c
@@ -379,6 +379,33 @@ fu_test_mtd_device_raw_func(gconstpointer user_data)
 }
 
 static void
+fu_test_mtd_device_read_firmware_invalid_gtype_func(gconstpointer user_data)
+{
+	FuTest *self = (FuTest *)user_data;
+	g_autoptr(FuMtdDevice) device = NULL;
+	g_autoptr(FuFirmware) firmware = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(NULL);
+	g_autoptr(GError) error = NULL;
+
+	/* find correct device; this leaves the firmware gtype as G_TYPE_INVALID */
+	device = fu_test_mtd_find_mtdram(self->ctx, &error);
+	if (device == NULL) {
+		g_test_skip(error->message);
+		return;
+	}
+	g_assert_cmpint(fu_device_get_firmware_gtype(FU_DEVICE(device)), ==, G_TYPE_INVALID);
+
+	/* with no specific firmware type set we should fall back to a generic
+	 * FuFirmware rather than crashing on g_object_new(G_TYPE_INVALID) */
+	firmware = fu_device_read_firmware(FU_DEVICE(device),
+					  progress,
+					  FU_FIRMWARE_PARSE_FLAG_NONE,
+					  &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(firmware);
+}
+
+static void
 fu_test_mtd_device_ifd_func(gconstpointer user_data)
 {
 	FuTest *self = (FuTest *)user_data;
@@ -592,6 +619,9 @@ main(int argc, char **argv)
 			     self,
 			     fu_test_mtd_device_quirk_unknown_func);
 	g_test_add_data_func("/mtd/device/raw", self, fu_test_mtd_device_raw_func);
+	g_test_add_data_func("/mtd/device/read-firmware/invalid-gtype",
+			     self,
+			     fu_test_mtd_device_read_firmware_invalid_gtype_func);
 	g_test_add_data_func("/mtd/device/uswid", self, fu_test_mtd_device_uswid_func);
 	g_test_add_data_func("/mtd/device/ifd", self, fu_test_mtd_device_ifd_func);
 	g_test_add_data_func("/mtd/device/fmap", self, fu_test_mtd_device_fmap_func);


### PR DESCRIPTION
The MTD device unconditionally advertises CAN_VERIFY_IMAGE, but the firmware gtype is only set for FMAP/IFD/uSWID devices. A plain MTD device left the gtype as G_TYPE_INVALID, so verify-update called g_object_new(G_TYPE_INVALID, NULL) which returned NULL and then crashed in fu_firmware_parse_stream() dereferencing a NULL firmware.

Match the generic fu_device_read_firmware() behavior by falling back to FU_TYPE_FIRMWARE when no specific type was detected.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
