### PR TITLE
trivial: make rustgen write depfiles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,6 +24,8 @@ indent_size = 2
 
 [*.py]
 indent_size = 4
+# default for python black
+max_line_length = 88
 
 [*.{sh,{pre,post}{inst,rm}}]
 indent_size = 4

--- a/libfwupdplugin/rustgen.py
+++ b/libfwupdplugin/rustgen.py
@@ -7,13 +7,19 @@
 
 import os
 import sys
+import textwrap
 import uuid
 import argparse
 
 from enum import Enum
+from pathlib import Path
 from typing import Optional, List, Tuple, Dict
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+
+def file_next_to_module(file: str) -> str:
+    return str(Path(os.path.relpath(__file__)).parent / file)
 
 
 class Endian(Enum):
@@ -681,6 +687,7 @@ class Generator:
         self.prefix: Optional[str] = prefix
         self.import_headers: List[str] = []
         self.modules_map: Dict[str, str] = modules_map
+        self.input_files: List[str] = []
         self.includes: List[str] = includes
         self.struct_objs: Dict[str, StructObj] = {}
         self.enum_objs: Dict[str, EnumObj] = {}
@@ -697,8 +704,11 @@ class Generator:
             "Export": Export,
             "obj": enum_obj,
         }
-        template_h = self._env.get_template(os.path.basename("fu-rustgen-enum.h.in"))
-        template_c = self._env.get_template(os.path.basename("fu-rustgen-enum.c.in"))
+        h = "fu-rustgen-enum.h.in"
+        c = "fu-rustgen-enum.c.in"
+        template_h = self._env.get_template(os.path.basename(h))
+        template_c = self._env.get_template(os.path.basename(c))
+        self.input_files.extend([file_next_to_module(i) for i in [h, c]])
         return template_c.render(subst), template_h.render(subst)
 
     def _process_structs(self, struct_obj: StructObj) -> Tuple[str, str]:
@@ -708,8 +718,11 @@ class Generator:
             "Export": Export,
             "obj": struct_obj,
         }
-        template_h = self._env.get_template(os.path.basename("fu-rustgen-struct.h.in"))
-        template_c = self._env.get_template(os.path.basename("fu-rustgen-struct.c.in"))
+        h = "fu-rustgen-struct.h.in"
+        c = "fu-rustgen-struct.c.in"
+        template_h = self._env.get_template(os.path.basename(h))
+        template_c = self._env.get_template(os.path.basename(c))
+        self.input_files.extend([file_next_to_module(i) for i in [h, c]])
         return template_c.render(subst), template_h.render(subst)
 
     def _use_import(self, where: str, module: str, what: str) -> None:
@@ -719,9 +732,12 @@ class Generator:
             fn = os.path.join(self.modules_map[where], f"fu-{module_basename}.rs")
         except KeyError:
             raise ValueError(f"invalid module name: {where}")
+        self.input_files.append(os.path.relpath(fn))
         child = Generator(self.basename, self.modules_map, prefix=self.prefix)
         with open(fn, "rb") as f:
             child._parse_input(f.read().decode())
+
+        self.input_files.extend(child.input_files)
 
         # header includes
         header_basename: str = f"fu-{module_basename}-struct.h"
@@ -920,8 +936,9 @@ class Generator:
             "import_headers": self.import_headers,
             "includes": self.includes,
         }
-        template_h = self._env.get_template(os.path.basename("fu-rustgen.h.in"))
-        template_c = self._env.get_template(os.path.basename("fu-rustgen.c.in"))
+        template_h = self._env.get_template(os.path.basename(h := "fu-rustgen.h.in"))
+        template_c = self._env.get_template(os.path.basename(c := "fu-rustgen.c.in"))
+        self.input_files.extend([file_next_to_module(i) for i in [h, c]])
         dst_h = template_h.render(subst)
         dst_c = template_c.render(subst)
         for enum_obj in self.enum_objs.values():
@@ -946,6 +963,9 @@ if __name__ == "__main__":
     parser.add_argument("src", action="store", type=str, help="source")
     parser.add_argument("--outc", action="store", type=str, help="destination .c")
     parser.add_argument("--outh", action="store", type=str, help="destination .h")
+    parser.add_argument(
+        "--depfile", action="store", type=str, help="build system depfile"
+    )
     parser.add_argument("--prefix", action="store", type=str, default="", help="prefix")
     parser.add_argument("--use", action="append", default=[], help="module:path")
     parser.add_argument(
@@ -981,3 +1001,19 @@ if __name__ == "__main__":
     if args.outh:
         with open(args.outh, "wb") as f:  # type: ignore
             f.write(dst_h.encode())
+
+    # depfiles are sort of like makefile target lines `output: inputs...`
+    if args.depfile:
+        rsgenpath = os.path.relpath(__file__)
+        inputs = set(g.input_files)
+        inputs_c = [i for i in inputs if not i.endswith((".h", ".h.in"))]
+        inputs_h = [i for i in inputs if not i.endswith((".c", ".c.in"))]
+        with open(args.depfile, "w") as f:
+            f.write(
+                textwrap.dedent(
+                    f"""\
+                    {args.outc}: {rsgenpath} {args.src} {" ".join(inputs_c)}
+                    {args.outh}: {rsgenpath} {args.src} {" ".join(inputs_h)}
+            """
+                )
+            )

--- a/meson.build
+++ b/meson.build
@@ -820,27 +820,14 @@ endif
 rustgen = generator(
   python3,
   output: ['@BASENAME@-struct.c', '@BASENAME@-struct.h'],
-  # fake custom target to ensure the generator reruns if these input files change
-  depends: custom_target(
-    'rustgen-files-timestamp',
-    input: files(
-      'libfwupdplugin/fu-rustgen-enum.c.in',
-      'libfwupdplugin/fu-rustgen-enum.h.in',
-      'libfwupdplugin/fu-rustgen-struct.c.in',
-      'libfwupdplugin/fu-rustgen-struct.h.in',
-      'libfwupdplugin/fu-rustgen.c.in',
-      'libfwupdplugin/fu-rustgen.h.in',
-      'libfwupdplugin/rustgen.py',
-    ),
-    output: 'rustgen-files-timestamp',
-    command: [python3, '-c', 'from pathlib import Path\nPath("@OUTPUT@").touch()'],
-  ),
+  depfile: '@BASENAME@.deps',
   arguments: [
     join_paths(meson.project_source_root(), 'libfwupdplugin', 'rustgen.py'),
     '--use', 'fwupd:@0@'.format(join_paths(meson.project_source_root(), 'libfwupdplugin')),
     '@INPUT@',
     '--outc', '@OUTPUT0@',
     '--outh', '@OUTPUT1@',
+    '--depfile', '@DEPFILE@',
     '--include',
     'fwupdplugin.h',
     '--prefix',


### PR DESCRIPTION
I don't think this makes too much of a difference effectively, but this is a more proper way to actually inform the build system of what goes into an output.

I feel like I had an issue with the previous hack at some point but maybe that was a fluke.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
