### PR TITLE
trivial: check for updated metadata before running fwupdmgr update

### DIFF
--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -3220,6 +3220,10 @@ fu_util_update(FuUtil *self, gchar **values, GError **error)
 		return FALSE;
 	}
 
+	/* are the remotes very old */
+	if (!fu_util_perhaps_refresh_remotes(self, error))
+		return FALSE;
+
 	/* DEVICE-ID and GUID are acceptable args to update */
 	for (guint idx = 0; idx < g_strv_length(values); idx++) {
 		if (!fwupd_guid_is_valid(values[idx]) && !fwupd_device_id_is_valid(values[idx])) {


### PR DESCRIPTION
## Type of Change

- [x] 💡 Enhancement / Feature
- [ ] 🐛 Bug fix
- [ ] 🧹 Code cleanup

## Description

Add a check to prompt the user to refresh metadata before running the `update` command, similar to what `get-updates` already does (see [issue #10220](https://github.com/fwupd/fwupd/issues/10220)).

When firmware metadata has not been updated in 30 days, users will be prompted:

```
Firmware metadata has not been updated for 30 days and may not be up to date.
Update now? (y/n) [Requires internet connection]
```

## Changes

- Call `fu_util_perhaps_refresh_remotes()` at the beginning of `fu_util_update()`, matching the existing behavior in `fu_util_get_updates()`