### PR TITLE
fix(redfish): log out of the session in the HPE update path

### DIFF
--- a/plugins/redfish/fu-redfish-backend.c
+++ b/plugins/redfish/fu-redfish-backend.c
@@ -24,6 +24,7 @@ struct _FuRedfishBackend {
 	gchar *password;
 	gchar *bearer_token;
 	gchar *session_key;
+	gchar *session_uri;
 	guint port;
 	gchar *vendor;
 	gchar *version;
@@ -42,6 +43,9 @@ struct _FuRedfishBackend {
 };
 
 G_DEFINE_TYPE(FuRedfishBackend, fu_redfish_backend, FU_TYPE_BACKEND)
+
+typedef struct curl_slist _curl_slist;
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(_curl_slist, curl_slist_free_all)
 
 const gchar *
 fu_redfish_backend_get_vendor(FuRedfishBackend *self)
@@ -256,6 +260,20 @@ fu_redfish_backend_set_session_key(FuRedfishBackend *self, const gchar *session_
 	self->session_key = g_strdup(session_key);
 }
 
+/**
+ * fu_redfish_backend_set_session_uri:
+ * @self: a #FuRedfishBackend
+ * @session_uri: (nullable): Redfish session URI
+ *
+ * Sets the Redfish session URI used when deleting the active session.
+ **/
+static void
+fu_redfish_backend_set_session_uri(FuRedfishBackend *self, const gchar *session_uri)
+{
+	g_free(self->session_uri);
+	self->session_uri = g_strdup(session_uri);
+}
+
 static size_t
 fu_redfish_backend_session_headers_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 {
@@ -272,8 +290,10 @@ fu_redfish_backend_session_headers_callback(char *ptr, size_t size, size_t nmemb
 gboolean
 fu_redfish_backend_create_session(FuRedfishBackend *self, GError **error)
 {
+	const gchar *session_uri;
 	g_autoptr(FuRedfishRequest) request = fu_redfish_backend_request_new(self);
 	g_autoptr(FwupdJsonObject) json_obj = fwupd_json_object_new();
+	g_autoptr(FwupdJsonObject) json_obj_resp = NULL;
 
 	fwupd_json_object_add_string(json_obj, "UserName", self->username);
 	fwupd_json_object_add_string(json_obj, "Password", self->password);
@@ -298,6 +318,71 @@ fu_redfish_backend_create_session(FuRedfishBackend *self, GError **error)
 				    "failed to get session key");
 		return FALSE;
 	}
+
+	/* save the session URI so we can log out later */
+	json_obj_resp = fu_redfish_request_get_json_object(request);
+	session_uri = fwupd_json_object_get_string(json_obj_resp, "@odata.id", error);
+	if (session_uri == NULL) {
+		g_prefix_error_literal(error, "failed to get session URI: ");
+		fu_redfish_backend_set_session_key(self, NULL);
+		return FALSE;
+	}
+	fu_redfish_backend_set_session_uri(self, session_uri);
+
+	/* success */
+	return TRUE;
+}
+
+/**
+ * fu_redfish_backend_delete_session:
+ * @self: a #FuRedfishBackend
+ * @error: (nullable): optional return location for an error
+ *
+ * Logs out of the Redfish session previously opened with
+ * fu_redfish_backend_create_session() by issuing a `DELETE` on the stored
+ * session URI. The session key and URI are cleared on success.
+ *
+ * If no session is currently active this is a no-op and returns successfully.
+ *
+ * Returns: %TRUE for success
+ **/
+gboolean
+fu_redfish_backend_delete_session(FuRedfishBackend *self, GError **error)
+{
+	g_autofree gchar *auth_header = NULL;
+	g_autoptr(FuRedfishRequest) request = NULL;
+	g_autoptr(_curl_slist) hs = NULL;
+	CURL *curl;
+
+	g_return_val_if_fail(FU_IS_REDFISH_BACKEND(self), FALSE);
+
+	/* nothing to do */
+	if (self->session_key == NULL && self->session_uri == NULL)
+		return TRUE;
+
+	/* we should never have one without the other */
+	if (self->session_key == NULL || self->session_uri == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "inconsistent session state, cannot delete session");
+		return FALSE;
+	}
+
+	request = fu_redfish_backend_request_new(self);
+	curl = fu_redfish_request_get_curl(request);
+	(void)curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE");
+	auth_header = g_strconcat("X-Auth-Token: ", self->session_key, NULL);
+	hs = curl_slist_append(hs, auth_header);
+	(void)curl_easy_setopt(curl, CURLOPT_HTTPHEADER, hs);
+	if (!fu_redfish_request_perform(request, self->session_uri, 0, error)) {
+		g_prefix_error_literal(error, "failed to delete session: ");
+		return FALSE;
+	}
+
+	/* the session is no longer valid */
+	fu_redfish_backend_set_session_key(self, NULL);
+	fu_redfish_backend_set_session_uri(self, NULL);
 
 	/* success */
 	return TRUE;
@@ -693,6 +778,7 @@ fu_redfish_backend_finalize(GObject *object)
 	g_free(self->password);
 	g_free(self->bearer_token);
 	g_free(self->session_key);
+	g_free(self->session_uri);
 	g_free(self->vendor);
 	g_free(self->version);
 	g_free(self->uuid);

--- a/plugins/redfish/fu-redfish-backend.h
+++ b/plugins/redfish/fu-redfish-backend.h
@@ -48,5 +48,7 @@ const gchar *
 fu_redfish_backend_get_session_key(FuRedfishBackend *self);
 gboolean
 fu_redfish_backend_create_session(FuRedfishBackend *self, GError **error);
+gboolean
+fu_redfish_backend_delete_session(FuRedfishBackend *self, GError **error);
 FuRedfishRequest *
 fu_redfish_backend_request_new(FuRedfishBackend *self);

--- a/plugins/redfish/fu-redfish-hpe-device.c
+++ b/plugins/redfish/fu-redfish-hpe-device.c
@@ -230,7 +230,7 @@ fu_redfish_hpe_device_write_firmware(FuDevice *device,
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 5, NULL);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 82, NULL);
 
-	/* create session */
+	/* create session; it is torn down later in ->cleanup() */
 	backend = fu_redfish_device_get_backend(FU_REDFISH_DEVICE(self), error);
 	if (backend == NULL)
 		return FALSE;
@@ -301,6 +301,22 @@ fu_redfish_hpe_device_write_firmware(FuDevice *device,
 	return TRUE;
 }
 
+static gboolean
+fu_redfish_hpe_device_cleanup(FuDevice *device,
+			      FuProgress *progress,
+			      FwupdInstallFlags flags,
+			      GError **error)
+{
+	FuRedfishHpeDevice *self = FU_REDFISH_HPE_DEVICE(device);
+	FuRedfishBackend *backend;
+
+	/* log out of the session created in ->write_firmware() */
+	backend = fu_redfish_device_get_backend(FU_REDFISH_DEVICE(self), error);
+	if (backend == NULL)
+		return FALSE;
+	return fu_redfish_backend_delete_session(backend, error);
+}
+
 static void
 fu_redfish_hpe_device_set_progress(FuDevice *device, FuProgress *progress)
 {
@@ -323,5 +339,6 @@ fu_redfish_hpe_device_class_init(FuRedfishHpeDeviceClass *klass)
 	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	device_class->attach = fu_redfish_hpe_device_attach;
 	device_class->write_firmware = fu_redfish_hpe_device_write_firmware;
+	device_class->cleanup = fu_redfish_hpe_device_cleanup;
 	device_class->set_progress = fu_redfish_hpe_device_set_progress;
 }

--- a/plugins/redfish/tests/redfish.py
+++ b/plugins/redfish/tests/redfish.py
@@ -301,6 +301,13 @@ def session_service_sessions():
     )
 
 
+@app.route("/redfish/v1/SessionService/Sessions/<session_id>", methods=["DELETE"])
+def session_service_session_delete(session_id):
+    if request.headers.get("X-Auth-Token") != "1234eabcdeabcdeabcdeabcdeabc1234":
+        return _failure("unauthorised", status=401)
+    return Response(status=200)
+
+
 @app.route("/redfish/v1/TaskService/999")
 def task_manager():
     res = {


### PR DESCRIPTION
The HPE-specific firmware upgrade path created a Redfish session via fu_redfish_backend_create_session() but never deleted it, leaking a session on the BMC on every update.

Store the session URI from the creation response and add fu_redfish_backend_delete_session() to DELETE it. The HPE write_firmware now always tears the session down afterwards, on both success and failure, without masking the original install error.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
