### PR TITLE
plugins/elan-ts: Enable plugin on Android systems

### DIFF
--- a/plugins/elan-ts/meson.build
+++ b/plugins/elan-ts/meson.build
@@ -1,4 +1,4 @@
-host_machine.system() == 'linux' or subdir_done()
+host_machine.system() in ['linux', 'android'] or subdir_done()
 
 cargs = ['-DG_LOG_DOMAIN="FuPluginElanTs"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

This change  enables Elan-ts plugin for Android.