### PR TITLE
Add fu_backend_add_flag() and fu_backend_has_flag() for backend flags

### DIFF
--- a/libfwupdplugin/fu-backend-test.c
+++ b/libfwupdplugin/fu-backend-test.c
@@ -173,6 +173,18 @@ fu_backend_emulate_func(void)
 }
 
 static void
+fu_backend_flags_func(void)
+{
+	g_autoptr(FuBackend) backend = g_object_new(FU_TYPE_BACKEND, NULL);
+
+	g_assert_false(fu_backend_has_flag(backend, FU_BACKEND_FLAG_SORT_DEVICES));
+	fu_backend_add_flag(backend, FU_BACKEND_FLAG_SORT_DEVICES);
+	g_assert_true(fu_backend_has_flag(backend, FU_BACKEND_FLAG_SORT_DEVICES));
+	fu_backend_add_flag(backend, FU_BACKEND_FLAG_SORT_DEVICES);
+	g_assert_true(fu_backend_has_flag(backend, FU_BACKEND_FLAG_SORT_DEVICES));
+}
+
+static void
 fu_backend_func(void)
 {
 	FuDevice *dev;
@@ -226,6 +238,7 @@ main(int argc, char **argv)
 {
 	g_test_init(&argc, &argv, NULL);
 	g_test_add_func("/fwupd/backend", fu_backend_func);
+	g_test_add_func("/fwupd/backend/flags", fu_backend_flags_func);
 	g_test_add_func("/fwupd/backend/emulate", fu_backend_emulate_func);
 	return g_test_run();
 }

--- a/libfwupdplugin/fu-backend.c
+++ b/libfwupdplugin/fu-backend.c
@@ -22,6 +22,7 @@
 typedef struct {
 	FuContext *ctx;
 	gchar *name;
+	FuBackendFlags flags;
 	gboolean enabled;
 	gboolean done_setup;
 	gboolean can_invalidate;
@@ -559,6 +560,42 @@ fu_backend_coldplug(FuBackend *self, FuProgress *progress, GError **error)
 }
 
 /**
+ * fu_backend_add_flag:
+ * @self: a #FuBackend
+ * @flag: the backend flag
+ *
+ * Adds a specific flag to the backend.
+ *
+ * Since: 2.1.6
+ **/
+void
+fu_backend_add_flag(FuBackend *self, FuBackendFlags flag)
+{
+	FuBackendPrivate *priv = GET_PRIVATE(self);
+	g_return_if_fail(FU_IS_BACKEND(self));
+	priv->flags |= flag;
+}
+
+/**
+ * fu_backend_has_flag:
+ * @self: a #FuBackend
+ * @flag: the backend flag
+ *
+ * Finds if the backend has a specific flag.
+ *
+ * Returns: %TRUE if the flag is set
+ *
+ * Since: 2.1.6
+ **/
+gboolean
+fu_backend_has_flag(FuBackend *self, FuBackendFlags flag)
+{
+	FuBackendPrivate *priv = GET_PRIVATE(self);
+	g_return_val_if_fail(FU_IS_BACKEND(self), FALSE);
+	return (priv->flags & flag) > 0;
+}
+
+/**
  * fu_backend_get_name:
  * @self: a #FuBackend
  *
@@ -679,7 +716,8 @@ fu_backend_get_devices(FuBackend *self)
 	values = g_hash_table_get_values(priv->devices);
 	for (GList *l = values; l != NULL; l = l->next)
 		g_ptr_array_add(devices, g_object_ref(l->data));
-	g_ptr_array_sort(devices, fu_backend_get_devices_sort_cb);
+	if (priv->flags & FU_BACKEND_FLAG_SORT_DEVICES)
+		g_ptr_array_sort(devices, fu_backend_get_devices_sort_cb);
 	return g_steal_pointer(&devices);
 }
 

--- a/libfwupdplugin/fu-backend.h
+++ b/libfwupdplugin/fu-backend.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "fu-backend-struct.h"
 #include "fu-context.h"
 #include "fu-device.h"
 
@@ -56,6 +57,11 @@ struct _FuBackendClass {
 					     GError **error)G_GNUC_WARN_UNUSED_RESULT;
 };
 
+void
+fu_backend_add_flag(FuBackend *self, FuBackendFlags flag) G_GNUC_NON_NULL(1);
+gboolean
+fu_backend_has_flag(FuBackend *self, FuBackendFlags flag) G_GNUC_WARN_UNUSED_RESULT
+    G_GNUC_NON_NULL(1);
 const gchar *
 fu_backend_get_name(FuBackend *self) G_GNUC_NON_NULL(1);
 FuContext *

--- a/libfwupdplugin/fu-backend.rs
+++ b/libfwupdplugin/fu-backend.rs
@@ -1,0 +1,8 @@
+// Copyright 2025 Richard Hughes <richard@hughsie.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#[derive(Bitfield, FromString(enum))]
+enum FuBackendFlags {
+    None                    = 0,
+    SortDevices             = 1 << 0,
+}

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -1,4 +1,5 @@
 fwupdplugin_structs = [
+  'fu-backend.rs', # fuzzing
   'fu-cbor.rs', # fuzzing
   'fu-crc.rs', # fuzzing
   'fu-progress.rs', # fuzzing

--- a/plugins/devlink/fu-devlink-backend.c
+++ b/plugins/devlink/fu-devlink-backend.c
@@ -175,6 +175,7 @@ fu_devlink_backend_device_removed(FuDevlinkBackend *self, FuDevice *devlink_devi
 static void
 fu_devlink_backend_init(FuDevlinkBackend *self)
 {
+	fu_backend_add_flag(FU_BACKEND(self), FU_BACKEND_FLAG_SORT_DEVICES);
 }
 
 static void

--- a/plugins/modem-manager/fu-mm-backend.c
+++ b/plugins/modem-manager/fu-mm-backend.c
@@ -497,6 +497,7 @@ fu_mm_backend_coldplug(FuBackend *backend, FuProgress *progress, GError **error)
 static void
 fu_mm_backend_init(FuMmBackend *self)
 {
+	fu_backend_add_flag(FU_BACKEND(self), FU_BACKEND_FLAG_SORT_DEVICES);
 }
 
 static void

--- a/plugins/redfish/fu-redfish-backend.c
+++ b/plugins/redfish/fu-redfish-backend.c
@@ -725,6 +725,7 @@ fu_redfish_backend_init(FuRedfishBackend *self)
 	curl_share_setopt(self->curlsh, CURLSHOPT_SHARE, CURL_LOCK_DATA_COOKIE);
 	curl_share_setopt(self->curlsh, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
 	curl_share_setopt(self->curlsh, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);
+	fu_backend_add_flag(FU_BACKEND(self), FU_BACKEND_FLAG_SORT_DEVICES);
 }
 
 FuRedfishBackend *

--- a/plugins/uefi-capsule/fu-uefi-capsule-backend.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-backend.c
@@ -70,6 +70,7 @@ fu_uefi_capsule_backend_init(FuUefiCapsuleBackend *self)
 {
 	FuUefiCapsuleBackendPrivate *priv = GET_PRIVATE(self);
 	priv->device_gtype = FU_TYPE_UEFI_NVRAM_DEVICE;
+	fu_backend_add_flag(FU_BACKEND(self), FU_BACKEND_FLAG_SORT_DEVICES);
 }
 
 static void

--- a/src/fu-bluez-backend.c
+++ b/src/fu-bluez-backend.c
@@ -241,6 +241,7 @@ fu_bluez_backend_finalize(GObject *object)
 static void
 fu_bluez_backend_init(FuBluezBackend *self)
 {
+	fu_backend_add_flag(FU_BACKEND(self), FU_BACKEND_FLAG_SORT_DEVICES);
 }
 
 static void

--- a/src/fu-udev-backend.c
+++ b/src/fu-udev-backend.c
@@ -922,6 +922,7 @@ fu_udev_backend_finalize(GObject *object)
 static void
 fu_udev_backend_init(FuUdevBackend *self)
 {
+	fu_backend_add_flag(FU_BACKEND(self), FU_BACKEND_FLAG_SORT_DEVICES);
 	self->map_paths = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
 	self->coldplug_cache =
 	    g_hash_table_new_full(g_str_hash,

--- a/src/fu-usb-backend.c
+++ b/src/fu-usb-backend.c
@@ -494,6 +494,7 @@ fu_usb_backend_finalize(GObject *object)
 static void
 fu_usb_backend_init(FuUsbBackend *self)
 {
+	fu_backend_add_flag(FU_BACKEND(self), FU_BACKEND_FLAG_SORT_DEVICES);
 #ifndef HAVE_UDEV
 	/* to escape the thread into the mainloop */
 	g_mutex_init(&self->idle_events_mutex);


### PR DESCRIPTION
Only sort backend devices in fu_backend_get_devices() when the FU_BACKEND_FLAG_SORT_DEVICES flag is set, and add the flag to all backends that need sorted device ordering.

This fixes deploying the KEK update with fwupdtool, where we want to add the PK before the KEK so that all the requirements are in place.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
