### PR TITLE
lenovo-accessory: Add dual-bank dongle and paired peripheral support

### DIFF
--- a/plugins/lenovo-accessory/README.md
+++ b/plugins/lenovo-accessory/README.md
@@ -1,50 +1,114 @@
-# Plugin: Lenovo Accessory
+---
+title: Plugin: Lenovo Accessory
+---
 
 ## Introduction
 
-The Lenovo Accessory plugin supports the standardized firmware update protocol for Lenovo peripherals.
-This protocol is MCU-agnostic and supports both HID and BLE transports.
+This plugin supports the standardized firmware update protocol used by Lenovo
+peripherals and their wireless pairing receivers. The protocol is MCU-agnostic
+and is carried over two transports:
 
-## Protocol Support
+* **USB HID**: command frames are exchanged as Get/Set Feature reports issued as
+  control transfers on the receiver's vendor HID interface (interface 3). This
+  does not rely on a `hidraw` kernel node, so it also works on receivers whose
+  command interface is not bound by `usbhid`.
+* **Bluetooth LE**: command frames are exchanged over a vendor-specific GATT
+  service with dedicated write and read characteristics.
 
-This plugin enables firmware management across different connection types:
+A single dongle may also expose the wireless peripherals paired to it as child
+devices, which are updated by relaying commands through the dongle. The dongle
+additionally pushes asynchronous notifications (e.g. a peripheral coming back
+online after a reboot) as interrupt-IN input reports on interface 2.
 
-* **USB HID**: Communicates via Get/Set Feature reports over the interface-3 control endpoint, using the `usb` subsystem.
-* **Bluetooth LE (BLE)**: Uses a custom service with dedicated Write/Read characteristics.
+## Firmware Format
 
-## Supported Devices
+The daemon will decompress the cabinet archive and extract a firmware blob in
+an unsigned, vendor-specific raw binary format. The blob is written to the
+device as-is (file type `BIN`) and its CRC-32 is computed by the host and sent
+to the device before the transfer begins.
 
-The plugin identifies devices using specific hardware IDs:
+This plugin supports the following protocol ID:
 
-### HID Devices (Single-bank)
+* `com.lenovo.accessory`
 
-* **Normal Mode**:
-  * `USB\VID_17EF&PID_629D`
-  * `USB\VID_17EF&PID_6201`
-* **Bootloader Mode**:
-  * `USB\VID_17EF&PID_6194` (Common bootloader PID)
+## GUID Generation
 
-### BLE Devices (Dual-bank)
+HID devices use the standard `USB` DeviceInstanceId values, e.g.
+
+* `USB\VID_17EF&PID_629D` (runtime receiver)
+* `USB\VID_17EF&PID_6194` (HID bootloader)
+
+BLE devices and paired peripherals use the standard `BLUETOOTH` values, e.g.
 
 * `BLUETOOTH\VID_17EF&PID_61FE`
-* `BLUETOOTH\VID_17EF&PID_629A`
+
+Paired peripherals enumerated behind a dongle additionally get a `logical_id`
+of `slot<slot>` (e.g. `slot1`) to disambiguate multiple peripherals on the same
+receiver.
+
+Single-bank receivers reboot into a dedicated bootloader mode that enumerates
+with a different USB PID. To keep these treated as one physical device, the
+runtime device declares its bootloader counterpart through the `CounterpartGuid`
+quirk key, and the bootloader dynamically re-creates the runtime GUID at setup.
+The `REPLUG_MATCH_GUID` internal flag lets fwupd match the two across the replug.
 
 ## Update Behavior
 
-The update strategy differs based on the device's memory architecture:
+The update strategy depends on the device's memory architecture.
 
-### HID (Single-bank Update)
+### Single-bank (HID receivers)
 
-HID devices utilize a **single-bank** design. For these devices:
+Single-bank devices cannot be written in place. The receiver is rebooted into a
+dedicated bootloader mode to receive the firmware, then rebooted again to run
+the new application:
 
-1. The device must reboot into a dedicated **bootloader mode** (`PID_6194`) to receive firmware.
-2. The plugin uses `CounterpartGuid` logic to map the runtime device to its bootloader interface.
-3. A final restart is performed to jump back to the new application code.
+1. The runtime device is detached by switching it into DFU mode; it
+   re-enumerates as the bootloader (`USB\VID_17EF&PID_6194`).
+2. The bootloader writes the whole image, then exits to jump back to the
+   application.
 
-### BLE (Dual-bank / In-place Update)
+Because the device is non-functional in bootloader mode (and so are any
+peripherals paired to the receiver), it is unusable for the duration of the
+update. The bootloader reports its version as `0.0.0` so that any firmware is
+considered an upgrade, ensuring a device stuck in bootloader mode is always
+recoverable.
 
-BLE devices utilize a **dual-bank** design. For these devices:
+### Dual-bank (BLE devices, HID dual receivers, paired peripherals)
 
-1. **No Bootloader required**: Firmware is written to the secondary bank while the device is in runtime mode.
-2. The device remains functional during the transfer, minimizing user downtime.
-3. A reboot is only triggered at the end to swap the active banks and apply the update.
+Dual-bank devices are updated in place: firmware is written to the inactive bank
+while the device keeps running (`USABLE_DURING_UPDATE`), and the host verifies
+the written image by reading back the device CRC before the device reboots to
+swap the active bank (`DUAL_IMAGE`).
+
+## Vendor ID Security
+
+The vendor ID is set from the transport vendor, in this instance set to
+`USB:0x17EF` for HID devices and `BLUETOOTH:0x17EF` for BLE devices.
+
+## Quirk Use
+
+This plugin uses the following standard quirk keys:
+
+### `CounterpartGuid`
+
+Set on single-bank runtime receivers to declare the GUID of their bootloader
+mode, so the runtime and bootloader enumerations are treated as one device.
+
+### `Flags=no-generic-version`
+
+Set on BLE peripherals to suppress the generic version, as the version is read
+from the device over the vendor protocol.
+
+The authoritative and complete device list is `lenovo-accessory.quirk`.
+
+## External Interface Access
+
+For HID devices this plugin requires read and write access to the receiver's USB
+interfaces: the vendor HID command interface (interface 3) for control-transfer
+Feature reports, and the notification interface (interface 2) for interrupt-IN
+input reports. For BLE devices it requires read and write access to the vendor
+GATT characteristics through BlueZ.
+
+## Version Considerations
+
+This plugin has been available since fwupd version `2.1.5`.

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-hid-child-device.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-hid-child-device.c
@@ -1,0 +1,605 @@
+/*
+ * Copyright 2026 Yuchao Li <liyc44@lenovo.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-lenovo-accessory-hid-child-device.h"
+#include "fu-lenovo-accessory-hid-common.h"
+
+/* peripheral commands go through BT relay and need more time */
+#define FU_LENOVO_ACCESSORY_CHILD_RETRY_COUNT	 500
+#define FU_LENOVO_ACCESSORY_CHILD_RETRY_DELAY_MS 10
+
+/* maximum number of times a stale response frame is flushed by re-issuing the
+ * request before giving up */
+#define FU_LENOVO_ACCESSORY_CHILD_STALE_REWRITE_MAX 2
+
+/* the dongle pushes asynchronous notifications (e.g. a peripheral coming back
+ * online after a reboot) on this interrupt-IN interface */
+#define FU_LENOVO_ACCESSORY_IFACE_NOTIFY 0x02
+
+/* how long to wait for a rebooted peripheral to re-announce itself; treated as
+ * a hard failure if no online notification arrives within the window */
+#define FU_LENOVO_ACCESSORY_CHILD_REBOOT_TIMEOUT_MS 5000
+
+/* after the peripheral re-announces itself it still needs a moment to finish
+ * its own init before it can answer commands, so settle before setup */
+#define FU_LENOVO_ACCESSORY_CHILD_REBOOT_SETTLE_MS 1000
+
+struct _FuLenovoAccessoryHidChildDevice {
+	FuDevice parent_instance;
+	guint target_slot;
+	guint16 pid;
+};
+
+static void
+fu_lenovo_accessory_hid_child_device_impl_iface_init(FuLenovoAccessoryImplInterface *iface);
+
+G_DEFINE_TYPE_WITH_CODE(FuLenovoAccessoryHidChildDevice,
+			fu_lenovo_accessory_hid_child_device,
+			FU_TYPE_DEVICE,
+			G_IMPLEMENT_INTERFACE(FU_TYPE_LENOVO_ACCESSORY_IMPL,
+					      fu_lenovo_accessory_hid_child_device_impl_iface_init))
+
+guint16
+fu_lenovo_accessory_hid_child_device_get_pid(FuLenovoAccessoryHidChildDevice *self)
+{
+	g_return_val_if_fail(FU_IS_LENOVO_ACCESSORY_HID_CHILD_DEVICE(self), 0);
+	return self->pid;
+}
+
+void
+fu_lenovo_accessory_hid_child_device_set_pid(FuLenovoAccessoryHidChildDevice *self, guint16 pid)
+{
+	g_return_if_fail(FU_IS_LENOVO_ACCESSORY_HID_CHILD_DEVICE(self));
+	self->pid = pid;
+}
+
+void
+fu_lenovo_accessory_hid_child_device_set_target_slot(FuLenovoAccessoryHidChildDevice *self,
+						     guint8 target_slot)
+{
+	g_return_if_fail(FU_IS_LENOVO_ACCESSORY_HID_CHILD_DEVICE(self));
+	self->target_slot = target_slot;
+}
+
+static void
+fu_lenovo_accessory_hid_child_device_set_target(FuLenovoAccessoryHidChildDevice *self,
+						GByteArray *buf)
+{
+	g_return_if_fail(FU_IS_LENOVO_ACCESSORY_HID_CHILD_DEVICE(self));
+	g_return_if_fail(buf != NULL);
+	/*
+	 * Commands to a paired peripheral are relayed through the dongle. The
+	 * high nibble of the first command byte selects the target pairing slot
+	 * for the relay; the low nibble (status) is unused in the request.
+	 */
+	if (buf->len > 0)
+		buf->data[0] = self->target_slot << 4;
+}
+
+static GByteArray *
+fu_lenovo_accessory_hid_child_device_read(FuLenovoAccessoryImpl *impl, GError **error)
+{
+	FuDevice *proxy;
+
+	proxy = fu_device_get_proxy(FU_DEVICE(impl), error);
+	if (proxy == NULL)
+		return NULL;
+	return fu_lenovo_accessory_hid_read(FU_LENOVO_ACCESSORY_IMPL(proxy), error);
+}
+
+static gboolean
+fu_lenovo_accessory_hid_child_device_write(FuLenovoAccessoryImpl *impl,
+					   GByteArray *buf,
+					   GError **error)
+{
+	FuDevice *proxy;
+
+	fu_lenovo_accessory_hid_child_device_set_target(FU_LENOVO_ACCESSORY_HID_CHILD_DEVICE(impl),
+							buf);
+	proxy = fu_device_get_proxy(FU_DEVICE(impl), error);
+	if (proxy == NULL)
+		return FALSE;
+	return fu_lenovo_accessory_hid_write(FU_LENOVO_ACCESSORY_IMPL(proxy), buf, error);
+}
+
+typedef struct {
+	guint8 req_cmd_class;
+	guint8 req_cmd_id;
+	guint stale_rewrites;
+	GByteArray *buf_req;
+	GByteArray *buf_rsp;
+} FuLenovoAccessoryChildPollHelper;
+
+static gboolean
+fu_lenovo_accessory_hid_child_device_poll_cb(FuDevice *device, gpointer user_data, GError **error)
+{
+	FuLenovoAccessoryHidChildDevice *self = FU_LENOVO_ACCESSORY_HID_CHILD_DEVICE(device);
+	FuLenovoAccessoryChildPollHelper *helper = (FuLenovoAccessoryChildPollHelper *)user_data;
+	GByteArray *buf_rsp = helper->buf_rsp;
+	FuDevice *proxy;
+	guint8 target_status;
+	guint8 rsp_cmd_class;
+	guint8 rsp_cmd_id;
+	FuLenovoAccessoryStatus status;
+	guint8 rsp_slot;
+	gsize offset = 0x0;
+	g_autoptr(GByteArray) buf = NULL;
+	g_autoptr(FuStructLenovoAccessoryCmd) st_cmd = NULL;
+
+	proxy = fu_device_get_proxy(device, error);
+	if (proxy == NULL)
+		return FALSE;
+	buf = fu_lenovo_accessory_hid_read(FU_LENOVO_ACCESSORY_IMPL(proxy), error);
+	if (buf == NULL) {
+		g_prefix_error_literal(error, "failed to read cmd: ");
+		return FALSE;
+	}
+
+	/* control-transfer frame has no report-id prefix */
+	st_cmd = fu_struct_lenovo_accessory_cmd_parse(buf->data, buf->len, offset, error);
+	if (st_cmd == NULL)
+		return FALSE;
+	target_status = fu_struct_lenovo_accessory_cmd_get_target_status(st_cmd);
+
+	/* the relayed response must come from the slot we addressed,
+	 * otherwise a frame for a different peripheral leaked onto the channel;
+	 * retry the read */
+	rsp_slot = target_status >> 4;
+	if (rsp_slot != self->target_slot) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_BUSY,
+			    "slot mismatch: requested 0x%x, got 0x%x",
+			    self->target_slot,
+			    rsp_slot);
+		return FALSE;
+	}
+
+	/* the relay can leave a frame from a previous command in the report
+	 * buffer; the command_id carries the direction bit (e.g. GET 0x03 -> 0x83)
+	 * so the answer must echo our class/id exactly. Detect this before the
+	 * status check, as a stale frame may carry an unrelated status (e.g. a
+	 * timeout from the previous command) that would otherwise be misread as a
+	 * failure of the current command. Re-issue the write to flush it */
+	rsp_cmd_class = fu_struct_lenovo_accessory_cmd_get_command_class(st_cmd);
+	rsp_cmd_id = fu_struct_lenovo_accessory_cmd_get_command_id(st_cmd);
+	if (rsp_cmd_class != helper->req_cmd_class || rsp_cmd_id != helper->req_cmd_id) {
+		if (helper->stale_rewrites >= FU_LENOVO_ACCESSORY_CHILD_STALE_REWRITE_MAX) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_READ,
+				    "stale frame after %u rewrites: requested class 0x%02x "
+				    "id 0x%02x, got class 0x%02x id 0x%02x",
+				    helper->stale_rewrites,
+				    helper->req_cmd_class,
+				    helper->req_cmd_id,
+				    rsp_cmd_class,
+				    rsp_cmd_id);
+			return FALSE;
+		}
+		helper->stale_rewrites++;
+		g_debug("stale frame (rewrite %u): requested class 0x%02x id 0x%02x, "
+			"got class 0x%02x id 0x%02x",
+			helper->stale_rewrites,
+			helper->req_cmd_class,
+			helper->req_cmd_id,
+			rsp_cmd_class,
+			rsp_cmd_id);
+		if (!fu_lenovo_accessory_hid_child_device_write(FU_LENOVO_ACCESSORY_IMPL(device),
+								helper->buf_req,
+								error))
+			return FALSE;
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_BUSY, "stale frame, rewrote");
+		return FALSE;
+	}
+
+	status = target_status & 0x0F;
+	if (status == FU_LENOVO_ACCESSORY_STATUS_COMMAND_BUSY) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_BUSY, "command busy");
+		return FALSE;
+	}
+	if (status != FU_LENOVO_ACCESSORY_STATUS_COMMAND_SUCCESSFUL) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_WRITE,
+			    "command failed with status 0x%02x",
+			    status);
+		return FALSE;
+	}
+	offset += FU_STRUCT_LENOVO_ACCESSORY_CMD_SIZE;
+
+	/* success */
+	return fu_byte_array_append_safe(buf_rsp,
+					 buf->data,
+					 buf->len,
+					 offset,
+					 buf->len - offset,
+					 error);
+}
+
+static GByteArray *
+fu_lenovo_accessory_hid_child_device_process(FuLenovoAccessoryImpl *impl,
+					     GByteArray *buf,
+					     GError **error)
+{
+	g_autoptr(GByteArray) buf_rsp = g_byte_array_new();
+	g_autoptr(FuStructLenovoAccessoryCmd) st_req = NULL;
+	FuLenovoAccessoryChildPollHelper helper = {0};
+
+	/* the command_class/command_id that the response must echo back; the
+	 * command_id already carries the direction bit (e.g. GET 0x03 -> 0x83) */
+	st_req = fu_struct_lenovo_accessory_cmd_parse(buf->data, buf->len, 0x0, error);
+	if (st_req == NULL)
+		return NULL;
+	helper.req_cmd_class = fu_struct_lenovo_accessory_cmd_get_command_class(st_req);
+	helper.req_cmd_id = fu_struct_lenovo_accessory_cmd_get_command_id(st_req);
+	helper.buf_req = buf;
+	helper.buf_rsp = buf_rsp;
+
+	if (!fu_lenovo_accessory_hid_child_device_write(impl, buf, error)) {
+		g_prefix_error_literal(error, "failed to write cmd: ");
+		return NULL;
+	}
+	if (!fu_device_retry_full(FU_DEVICE(impl),
+				  fu_lenovo_accessory_hid_child_device_poll_cb,
+				  FU_LENOVO_ACCESSORY_CHILD_RETRY_COUNT,
+				  FU_LENOVO_ACCESSORY_CHILD_RETRY_DELAY_MS,
+				  &helper,
+				  error))
+		return NULL;
+	return g_steal_pointer(&buf_rsp);
+}
+
+static gboolean
+fu_lenovo_accessory_hid_child_device_setup(FuDevice *device, GError **error)
+{
+	guint8 major = 0;
+	guint8 minor = 0;
+	guint8 micro = 0;
+	g_autofree gchar *version = NULL;
+	if (!fu_lenovo_accessory_impl_get_fwversion(FU_LENOVO_ACCESSORY_IMPL(device),
+						    &major,
+						    &minor,
+						    &micro,
+						    error))
+		return FALSE;
+	version = g_strdup_printf("%u.%u.%u", major, minor, micro);
+	fu_device_set_version(device, version);
+	return TRUE;
+}
+
+static gboolean
+fu_lenovo_accessory_hid_child_device_write_files(FuLenovoAccessoryHidChildDevice *self,
+						 FuLenovoAccessoryDfuFileType file_type,
+						 GInputStream *stream,
+						 FuProgress *progress,
+						 GError **error)
+{
+	g_autoptr(FuChunkArray) chunks = NULL;
+
+	chunks = fu_chunk_array_new_from_stream(stream, 0, 0, 32, error);
+	if (chunks == NULL)
+		return FALSE;
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
+	for (guint32 i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = NULL;
+
+		chk = fu_chunk_array_index(chunks, i, error);
+		if (chk == NULL)
+			return FALSE;
+		if (!fu_lenovo_accessory_impl_dfu_file(FU_LENOVO_ACCESSORY_IMPL(self),
+						       file_type,
+						       fu_chunk_get_address(chk),
+						       fu_chunk_get_data(chk),
+						       fu_chunk_get_data_sz(chk),
+						       error))
+			return FALSE;
+		fu_progress_step_done(progress);
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_lenovo_accessory_hid_child_device_write_firmware(FuDevice *device,
+						    FuFirmware *firmware,
+						    FuProgress *progress,
+						    FwupdInstallFlags flags,
+						    GError **error)
+{
+	FuLenovoAccessoryHidChildDevice *self = FU_LENOVO_ACCESSORY_HID_CHILD_DEVICE(device);
+	gsize fw_size = 0;
+	guint32 file_crc = 0xFFFFFFFF;
+	guint32 device_crc = 0;
+	FuLenovoAccessoryDeviceMode mode;
+	g_autoptr(GInputStream) stream = NULL;
+
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 5, "prepare");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 95, "write");
+
+	stream = fu_firmware_get_stream(firmware, error);
+	if (stream == NULL)
+		return FALSE;
+	if (!fu_input_stream_size(stream, &fw_size, error))
+		return FALSE;
+	if (!fu_input_stream_compute_crc32(stream, FU_CRC_KIND_B32_STANDARD, &file_crc, error))
+		return FALSE;
+
+	/* only enter DFU mode if not already there */
+	if (!fu_lenovo_accessory_impl_get_mode(FU_LENOVO_ACCESSORY_IMPL(device), &mode, error))
+		return FALSE;
+	if (mode != FU_LENOVO_ACCESSORY_DEVICE_MODE_DFU_MODE) {
+		if (!fu_lenovo_accessory_impl_dfu_entry(FU_LENOVO_ACCESSORY_IMPL(device), error))
+			return FALSE;
+	}
+	if (!fu_lenovo_accessory_impl_dfu_attribute(FU_LENOVO_ACCESSORY_IMPL(device),
+						    NULL,
+						    NULL,
+						    NULL,
+						    NULL,
+						    NULL,
+						    NULL,
+						    error))
+		return FALSE;
+	if (!fu_lenovo_accessory_impl_dfu_prepare(FU_LENOVO_ACCESSORY_IMPL(device),
+						  FU_LENOVO_ACCESSORY_DFU_FILE_TYPE_BIN_FILE,
+						  0x0,
+						  (guint32)fw_size,
+						  file_crc,
+						  error))
+		return FALSE;
+	fu_progress_step_done(progress);
+	if (!fu_lenovo_accessory_hid_child_device_write_files(
+		self,
+		FU_LENOVO_ACCESSORY_DFU_FILE_TYPE_BIN_FILE,
+		stream,
+		fu_progress_get_child(progress),
+		error))
+		return FALSE;
+
+	/* give the device time to finalize the flash before reading back CRC */
+	fu_device_sleep(FU_DEVICE(self), 2000);
+	if (!fu_lenovo_accessory_impl_dfu_crc(FU_LENOVO_ACCESSORY_IMPL(device),
+					      &device_crc,
+					      error)) {
+		g_prefix_error_literal(error, "failed to read device CRC: ");
+		return FALSE;
+	}
+	if (device_crc != file_crc) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_WRITE,
+			    "CRC mismatch: device 0x%08x != file 0x%08x",
+			    device_crc,
+			    file_crc);
+		return FALSE;
+	}
+	fu_progress_step_done(progress);
+
+	/* success */
+	return TRUE;
+}
+
+static guint8
+fu_lenovo_accessory_hid_child_device_find_notify_ep(FuUsbDevice *device, GError **error)
+{
+	g_autoptr(GPtrArray) ifaces = NULL;
+
+	/* find the notify interface by number: it is a standard HID collection
+	 * that cannot be told apart from the mouse interface by descriptor
+	 * (both advertise the same vendor usage-page), so match the number */
+	ifaces = fu_usb_device_get_interfaces(device, error);
+	if (ifaces == NULL)
+		return 0x0;
+	for (guint i = 0; i < ifaces->len; i++) {
+		FuUsbInterface *iface = g_ptr_array_index(ifaces, i);
+		g_autoptr(GPtrArray) endpoints = NULL;
+		if (fu_usb_interface_get_number(iface) != FU_LENOVO_ACCESSORY_IFACE_NOTIFY)
+			continue;
+		endpoints = fu_usb_interface_get_endpoints(iface);
+		for (guint j = 0; endpoints != NULL && j < endpoints->len; j++) {
+			FuUsbEndpoint *ep = g_ptr_array_index(endpoints, j);
+			if (fu_usb_endpoint_get_direction(ep) == FU_USB_DIRECTION_DEVICE_TO_HOST)
+				return fu_usb_endpoint_get_address(ep);
+		}
+	}
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
+			    "no interrupt-IN endpoint on the notify interface");
+	return 0x0;
+}
+
+static gboolean
+fu_lenovo_accessory_hid_child_device_notify_open(FuUsbDevice *device, GError **error)
+{
+	/* claim the notify interface, detaching the kernel HID driver that
+	 * normally owns it; best-effort callers may ignore failure on a
+	 * receiver that does not expose this interface */
+	return fu_usb_device_claim_interface(device,
+					     FU_LENOVO_ACCESSORY_IFACE_NOTIFY,
+					     FU_USB_DEVICE_CLAIM_FLAG_KERNEL_DRIVER,
+					     error);
+}
+
+static void
+fu_lenovo_accessory_hid_child_device_notify_close(FuUsbDevice *device)
+{
+	g_autoptr(GError) error_local = NULL;
+	if (!fu_usb_device_release_interface(device,
+					     FU_LENOVO_ACCESSORY_IFACE_NOTIFY,
+					     FU_USB_DEVICE_CLAIM_FLAG_KERNEL_DRIVER,
+					     &error_local))
+		g_debug("failed to release notify interface: %s", error_local->message);
+}
+
+typedef struct {
+	guint8 ep;
+} FuLenovoAccessoryNotifyHelper;
+
+static gboolean
+fu_lenovo_accessory_hid_child_device_notify_poll_cb(FuDevice *device,
+						    gpointer user_data,
+						    GError **error)
+{
+	FuLenovoAccessoryNotifyHelper *helper = (FuLenovoAccessoryNotifyHelper *)user_data;
+	guint8 buf[FU_LENOVO_ACCESSORY_HID_BUFSZ] = {0x0};
+	gsize actual_len = 0;
+	g_autoptr(FuStructLenovoAccessoryNotify) st = NULL;
+
+	/* a rebooted peripheral re-announces itself over the notify endpoint; a
+	 * read timeout or an unrelated input report (e.g. a keypress, rejected by
+	 * the struct validation) is reported as an error so the retry loop keeps
+	 * polling until the connect event arrives or the window elapses */
+	if (!fu_usb_device_interrupt_transfer(FU_USB_DEVICE(device),
+					      helper->ep,
+					      buf,
+					      sizeof(buf),
+					      &actual_len,
+					      500, /* ms */
+					      NULL,
+					      error))
+		return FALSE;
+	st = fu_struct_lenovo_accessory_notify_parse(buf, actual_len, 0x0, error);
+	if (st == NULL)
+		return FALSE;
+	if (fu_struct_lenovo_accessory_notify_get_event(st) !=
+		FU_LENOVO_ACCESSORY_NOTIFY_EVENT_WIRELESS_CONNECT_STATUS_CHANGE ||
+	    fu_struct_lenovo_accessory_notify_get_connect_status(st) !=
+		FU_LENOVO_ACCESSORY_NOTIFY_CONNECT_STATUS_CONNECTED) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_BUSY,
+				    "no online notification yet");
+		return FALSE;
+	}
+	return TRUE;
+}
+
+static gboolean
+fu_lenovo_accessory_hid_child_device_notify_wait_online(FuUsbDevice *self, GError **error)
+{
+	FuLenovoAccessoryNotifyHelper helper = {0};
+
+	helper.ep = fu_lenovo_accessory_hid_child_device_find_notify_ep(self, error);
+	if (helper.ep == 0x0)
+		return FALSE;
+
+	/* poll the notify endpoint until the connect event arrives; using
+	 * fu_device_retry means the wait aborts if the proxy is unplugged rather
+	 * than blocking for the whole window */
+	return fu_device_retry_full(FU_DEVICE(self),
+				    fu_lenovo_accessory_hid_child_device_notify_poll_cb,
+				    FU_LENOVO_ACCESSORY_CHILD_REBOOT_TIMEOUT_MS / 500,
+				    0, /* ms */
+				    &helper,
+				    error);
+}
+
+static gboolean
+fu_lenovo_accessory_hid_child_device_attach(FuDevice *device, FuProgress *progress, GError **error)
+{
+	FuDevice *proxy;
+	gboolean notify_open = FALSE;
+	g_autoptr(GError) error_notify = NULL;
+
+	/* the reboot announcement arrives on the dongle's notify interface, so
+	 * start listening before triggering the reboot; best-effort, as a
+	 * receiver without the notify interface falls back to a fixed wait */
+	proxy = fu_device_get_proxy(device, error);
+	if (proxy == NULL)
+		return FALSE;
+	if (fu_lenovo_accessory_hid_child_device_notify_open(FU_USB_DEVICE(proxy), &error_notify)) {
+		notify_open = TRUE;
+	} else {
+		g_debug("notify channel unavailable, using fixed wait: %s", error_notify->message);
+	}
+
+	if (!fu_lenovo_accessory_impl_dfu_exit(FU_LENOVO_ACCESSORY_IMPL(device),
+					       FU_LENOVO_ACCESSORY_DFU_EXIT_CODE_DFU_SUCCESS,
+					       error)) {
+		g_prefix_error_literal(error, "failed to exit: ");
+		if (notify_open)
+			fu_lenovo_accessory_hid_child_device_notify_close(FU_USB_DEVICE(proxy));
+		return FALSE;
+	}
+
+	if (notify_open) {
+		/* the reboot must be observed within the window or it failed */
+		gboolean online =
+		    fu_lenovo_accessory_hid_child_device_notify_wait_online(FU_USB_DEVICE(proxy),
+									    error);
+		fu_lenovo_accessory_hid_child_device_notify_close(FU_USB_DEVICE(proxy));
+		if (!online) {
+			g_prefix_error_literal(error, "peripheral did not come back online: ");
+			return FALSE;
+		}
+		/* let the peripheral finish initializing before talking to it */
+		fu_device_sleep(device, FU_LENOVO_ACCESSORY_CHILD_REBOOT_SETTLE_MS);
+	} else {
+		fu_device_sleep(device, FU_LENOVO_ACCESSORY_CHILD_REBOOT_TIMEOUT_MS);
+	}
+
+	if (!fu_lenovo_accessory_hid_child_device_setup(device, error))
+		return FALSE;
+	return TRUE;
+}
+
+static void
+fu_lenovo_accessory_hid_child_device_set_progress(FuDevice *device, FuProgress *progress)
+{
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0, "detach");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 99, "write");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 1, "attach");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 0, "reload");
+}
+
+static void
+fu_lenovo_accessory_hid_child_device_impl_iface_init(FuLenovoAccessoryImplInterface *iface)
+{
+	iface->read = fu_lenovo_accessory_hid_child_device_read;
+	iface->write = fu_lenovo_accessory_hid_child_device_write;
+	iface->process = fu_lenovo_accessory_hid_child_device_process;
+}
+
+static void
+fu_lenovo_accessory_hid_child_device_class_init(FuLenovoAccessoryHidChildDeviceClass *klass)
+{
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->setup = fu_lenovo_accessory_hid_child_device_setup;
+	device_class->write_firmware = fu_lenovo_accessory_hid_child_device_write_firmware;
+	device_class->set_progress = fu_lenovo_accessory_hid_child_device_set_progress;
+	device_class->attach = fu_lenovo_accessory_hid_child_device_attach;
+}
+
+static void
+fu_lenovo_accessory_hid_child_device_init(FuLenovoAccessoryHidChildDevice *self)
+{
+	fu_device_set_remove_delay(FU_DEVICE(self), 10000); /* ms */
+	fu_device_add_protocol(FU_DEVICE(self), "com.lenovo.accessory");
+	fu_device_set_install_duration(FU_DEVICE(self), 60);
+	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_DUAL_IMAGE);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE);
+	fu_device_set_proxy_gtype(FU_DEVICE(self), FU_TYPE_HID_DEVICE);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_USE_PROXY_FOR_OPEN);
+}
+
+FuLenovoAccessoryHidChildDevice *
+fu_lenovo_accessory_hid_child_device_new(FuDevice *proxy)
+{
+	return g_object_new(FU_TYPE_LENOVO_ACCESSORY_HID_CHILD_DEVICE, "proxy", proxy, NULL);
+}

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-hid-child-device.h
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-hid-child-device.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Yuchao Li <liyc44@lenovo.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_LENOVO_ACCESSORY_HID_CHILD_DEVICE (fu_lenovo_accessory_hid_child_device_get_type())
+G_DECLARE_FINAL_TYPE(FuLenovoAccessoryHidChildDevice,
+		     fu_lenovo_accessory_hid_child_device,
+		     FU,
+		     LENOVO_ACCESSORY_HID_CHILD_DEVICE,
+		     FuDevice)
+
+FuLenovoAccessoryHidChildDevice *
+fu_lenovo_accessory_hid_child_device_new(FuDevice *proxy);
+
+guint16
+fu_lenovo_accessory_hid_child_device_get_pid(FuLenovoAccessoryHidChildDevice *self);
+
+void
+fu_lenovo_accessory_hid_child_device_set_pid(FuLenovoAccessoryHidChildDevice *self, guint16 pid);
+
+void
+fu_lenovo_accessory_hid_child_device_set_target_slot(FuLenovoAccessoryHidChildDevice *self,
+						     guint8 target_slot);

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-hid-common.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-hid-common.c
@@ -7,7 +7,94 @@
 
 #include "config.h"
 
+#include "fu-lenovo-accessory-hid-child-device.h"
 #include "fu-lenovo-accessory-hid-common.h"
+
+#define FU_LENOVO_ACCESSORY_MAX_PAIR_SLOTS 6
+
+static gboolean
+fu_lenovo_accessory_hid_add_child(FuLenovoAccessoryImpl *self, guint8 target_slot, GError **error)
+{
+	guint16 pid = 0;
+	guint8 bt_addr[FU_STRUCT_LENOVO_ACCESSORY_PAIR_SLOT_INFO_V2_RSP_SIZE_MAC_ADDR] = {0};
+	g_autofree gchar *bt_name = NULL;
+	g_autofree gchar *logical_id = NULL;
+	g_autoptr(FuLenovoAccessoryHidChildDevice) child = NULL;
+
+	child = fu_lenovo_accessory_hid_child_device_new(FU_DEVICE(self));
+	if (child == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "failed to create child device");
+		return FALSE;
+	}
+
+	if (!fu_lenovo_accessory_impl_get_pair_slot_info_v2(self,
+							    target_slot,
+							    &pid,
+							    bt_addr,
+							    sizeof(bt_addr),
+							    &bt_name,
+							    error))
+		return FALSE;
+	fu_lenovo_accessory_hid_child_device_set_target_slot(child, target_slot);
+	fu_lenovo_accessory_hid_child_device_set_pid(child, pid);
+
+	logical_id = g_strdup_printf("slot%u", (guint)target_slot);
+	fu_device_set_logical_id(FU_DEVICE(child), logical_id);
+
+	fu_device_add_instance_u16(FU_DEVICE(child), "VID", fu_device_get_vid(FU_DEVICE(self)));
+	fu_device_add_instance_u16(FU_DEVICE(child), "PID", pid);
+	if (!fu_device_build_instance_id(FU_DEVICE(child), error, "BLUETOOTH", "VID", "PID", NULL))
+		return FALSE;
+	if (bt_name != NULL && bt_name[0] != '\0')
+		fu_device_set_name(FU_DEVICE(child), bt_name);
+
+	/* best-effort: a paired peripheral that fails to set up (e.g. it went to
+	 * sleep) must not prevent the dongle itself from being updatable, so the
+	 * caller skips the slot rather than failing setup */
+	if (!fu_device_setup(FU_DEVICE(child), error))
+		return FALSE;
+	fu_device_add_child(FU_DEVICE(self), FU_DEVICE(child));
+	return TRUE;
+}
+
+gboolean
+fu_lenovo_accessory_hid_add_children(FuLenovoAccessoryImpl *self, GError **error)
+{
+	guint8 max_slot_num = 0;
+	guint8 slot_status[FU_LENOVO_ACCESSORY_MAX_PAIR_SLOTS] = {0};
+	g_autoptr(GError) error_local = NULL;
+	g_return_val_if_fail(FU_IS_LENOVO_ACCESSORY_IMPL(self), FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	/* best-effort: a dongle that cannot report its pairing list is still
+	 * updatable itself, so skip child enumeration rather than failing setup */
+	if (!fu_lenovo_accessory_impl_get_pair_support_info(self,
+							    &max_slot_num,
+							    slot_status,
+							    G_N_ELEMENTS(slot_status),
+							    &error_local)) {
+		g_debug("skipping child enumeration: %s", error_local->message);
+		return TRUE;
+	}
+
+	if (max_slot_num == 0)
+		return TRUE;
+
+	max_slot_num = MIN(max_slot_num, (guint8)G_N_ELEMENTS(slot_status));
+
+	for (guint8 i = 0; i < max_slot_num; i++) {
+		g_autoptr(GError) error_slot = NULL;
+
+		if (slot_status[i] != FU_LENOVO_ACCESSORY_PAIR_SLOT_STATUS_CONNECTED)
+			continue;
+		if (!fu_lenovo_accessory_hid_add_child(self, i + 1, &error_slot))
+			g_debug("skipping slot %u: %s", (guint)(i + 1), error_slot->message);
+	}
+	return TRUE;
+}
 
 GByteArray *
 fu_lenovo_accessory_hid_read(FuLenovoAccessoryImpl *impl, GError **error)
@@ -49,11 +136,27 @@ fu_lenovo_accessory_hid_write(FuLenovoAccessoryImpl *impl, GByteArray *buf, GErr
 					error);
 }
 
+#define FU_LENOVO_ACCESSORY_STALE_REWRITE_MAX 2
+
+typedef struct {
+	guint8 req_slot;
+	guint8 req_cmd_class;
+	guint8 req_cmd_id;
+	guint stale_rewrites; /* number of times the request was re-issued */
+	GByteArray *buf_req;  /* request to re-issue when a stale frame is read */
+	GByteArray *buf_rsp;
+} FuLenovoAccessoryPollHelper;
+
 static gboolean
 fu_lenovo_accessory_hid_poll_cb(FuDevice *device, gpointer user_data, GError **error)
 {
-	GByteArray *buf_rsp = (GByteArray *)user_data;
+	FuLenovoAccessoryPollHelper *helper = (FuLenovoAccessoryPollHelper *)user_data;
+	GByteArray *buf_rsp = helper->buf_rsp;
+	guint8 target_status;
+	guint8 rsp_cmd_class;
+	guint8 rsp_cmd_id;
 	FuLenovoAccessoryStatus status;
+	guint8 rsp_slot;
 	gsize offset = 0x0;
 	g_autoptr(GByteArray) buf = NULL;
 	g_autoptr(FuStructLenovoAccessoryCmd) st_cmd = NULL;
@@ -64,7 +167,63 @@ fu_lenovo_accessory_hid_poll_cb(FuDevice *device, gpointer user_data, GError **e
 	st_cmd = fu_struct_lenovo_accessory_cmd_parse(buf->data, buf->len, offset, error);
 	if (st_cmd == NULL)
 		return FALSE;
-	status = fu_struct_lenovo_accessory_cmd_get_target_status(st_cmd) & 0x0F;
+	target_status = fu_struct_lenovo_accessory_cmd_get_target_status(st_cmd);
+
+	/* the response slot must match the request slot, otherwise a frame
+	 * for a different target leaked onto the CMD channel; retry the read */
+	rsp_slot = target_status >> 4;
+	if (rsp_slot != helper->req_slot) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_BUSY,
+			    "slot mismatch: requested 0x%x, got 0x%x",
+			    helper->req_slot,
+			    rsp_slot);
+		return FALSE;
+	}
+
+	/* the firmware can leave a frame from a previous command in the report
+	 * buffer; the command_id carries the direction bit (e.g. GET 0x03 -> 0x83)
+	 * so the answer must echo our class/id exactly. Detect this before the
+	 * status check, as a stale frame may carry an unrelated status (e.g. a
+	 * timeout from the previous command) that would otherwise be misread as a
+	 * failure of the current command. Flag it so the caller re-issues the
+	 * write rather than spinning on the same stale frame */
+	rsp_cmd_class = fu_struct_lenovo_accessory_cmd_get_command_class(st_cmd);
+	rsp_cmd_id = fu_struct_lenovo_accessory_cmd_get_command_id(st_cmd);
+	if (rsp_cmd_class != helper->req_cmd_class || rsp_cmd_id != helper->req_cmd_id) {
+		if (helper->stale_rewrites >= FU_LENOVO_ACCESSORY_STALE_REWRITE_MAX) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_READ,
+				    "stale frame after %u rewrites: requested class 0x%02x "
+				    "id 0x%02x, got class 0x%02x id 0x%02x",
+				    helper->stale_rewrites,
+				    helper->req_cmd_class,
+				    helper->req_cmd_id,
+				    rsp_cmd_class,
+				    rsp_cmd_id);
+			return FALSE;
+		}
+		/* the buffer still holds the answer to a previous command; re-issue
+		 * the request to flush it, then keep polling for the fresh answer */
+		helper->stale_rewrites++;
+		g_debug("stale frame (rewrite %u): requested class 0x%02x id 0x%02x, "
+			"got class 0x%02x id 0x%02x",
+			helper->stale_rewrites,
+			helper->req_cmd_class,
+			helper->req_cmd_id,
+			rsp_cmd_class,
+			rsp_cmd_id);
+		if (!fu_lenovo_accessory_hid_write(FU_LENOVO_ACCESSORY_IMPL(device),
+						   helper->buf_req,
+						   error))
+			return FALSE;
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_BUSY, "stale frame, rewrote");
+		return FALSE;
+	}
+
+	status = target_status & 0x0F;
 	if (status == FU_LENOVO_ACCESSORY_STATUS_COMMAND_BUSY) {
 		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_BUSY, "command busy");
 		return FALSE;
@@ -80,22 +239,48 @@ fu_lenovo_accessory_hid_poll_cb(FuDevice *device, gpointer user_data, GError **e
 	offset += FU_STRUCT_LENOVO_ACCESSORY_CMD_SIZE;
 
 	/* success */
-	g_byte_array_append(buf_rsp, buf->data + offset, buf->len - offset);
-	return TRUE;
+	return fu_byte_array_append_safe(buf_rsp,
+					 buf->data,
+					 buf->len,
+					 offset,
+					 buf->len - offset,
+					 error);
 }
 
 GByteArray *
 fu_lenovo_accessory_hid_process(FuLenovoAccessoryImpl *impl, GByteArray *buf, GError **error)
 {
+	guint8 req_slot = 0;
 	g_autoptr(GByteArray) buf_rsp = g_byte_array_new();
+	g_autoptr(FuStructLenovoAccessoryCmd) st_req = NULL;
+	FuLenovoAccessoryPollHelper helper = {0};
+
+	/* the high nibble of the first request byte selects the target slot */
+	if (buf->len > 0) {
+		if (!fu_memread_uint8_safe(buf->data, buf->len, 0x0, &req_slot, error))
+			return NULL;
+		req_slot >>= 4;
+	}
+
+	/* the command_class/command_id that the response must echo back; the
+	 * command_id already carries the direction bit (e.g. GET 0x03 -> 0x83) so
+	 * an exact match is expected */
+	st_req = fu_struct_lenovo_accessory_cmd_parse(buf->data, buf->len, 0x0, error);
+	if (st_req == NULL)
+		return NULL;
+	helper.req_slot = req_slot;
+	helper.req_cmd_class = fu_struct_lenovo_accessory_cmd_get_command_class(st_req);
+	helper.req_cmd_id = fu_struct_lenovo_accessory_cmd_get_command_id(st_req);
+	helper.buf_req = buf;
+	helper.buf_rsp = buf_rsp;
 
 	if (!fu_lenovo_accessory_hid_write(impl, buf, error))
 		return NULL;
 	if (!fu_device_retry_full(FU_DEVICE(impl),
 				  fu_lenovo_accessory_hid_poll_cb,
-				  5,  /* count */
-				  10, /* ms */
-				  buf_rsp,
+				  500, /* count */
+				  10,  /* ms */
+				  &helper,
 				  error))
 		return NULL;
 	return g_steal_pointer(&buf_rsp);

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-hid-common.h
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-hid-common.h
@@ -33,3 +33,7 @@ fu_lenovo_accessory_hid_write(FuLenovoAccessoryImpl *impl, GByteArray *buf, GErr
 GByteArray *
 fu_lenovo_accessory_hid_process(FuLenovoAccessoryImpl *impl, GByteArray *buf, GError **error)
     G_GNUC_NON_NULL(1, 2);
+
+gboolean
+fu_lenovo_accessory_hid_add_children(FuLenovoAccessoryImpl *self, GError **error)
+    G_GNUC_NON_NULL(1);

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-hid-device.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-hid-device.c
@@ -74,7 +74,7 @@ fu_lenovo_accessory_hid_device_setup(FuDevice *device, GError **error)
 		return FALSE;
 	version = g_strdup_printf("%u.%u.%u", major, minor, micro);
 	fu_device_set_version(device, version);
-	return TRUE;
+	return fu_lenovo_accessory_hid_add_children(FU_LENOVO_ACCESSORY_IMPL(device), error);
 }
 
 static gboolean

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-hid-dual-device.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-hid-dual-device.c
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2026 Yuchao Li <liyc44@lenovo.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-lenovo-accessory-hid-common.h"
+#include "fu-lenovo-accessory-hid-dual-device.h"
+
+struct _FuLenovoAccessoryHidDualDevice {
+	FuHidDevice parent_instance;
+};
+
+static void
+fu_lenovo_accessory_hid_dual_device_impl_iface_init(FuLenovoAccessoryImplInterface *iface);
+
+G_DEFINE_TYPE_WITH_CODE(FuLenovoAccessoryHidDualDevice,
+			fu_lenovo_accessory_hid_dual_device,
+			FU_TYPE_HID_DEVICE,
+			G_IMPLEMENT_INTERFACE(FU_TYPE_LENOVO_ACCESSORY_IMPL,
+					      fu_lenovo_accessory_hid_dual_device_impl_iface_init))
+
+static gboolean
+fu_lenovo_accessory_hid_dual_device_write_files(FuLenovoAccessoryHidDualDevice *self,
+						FuLenovoAccessoryDfuFileType file_type,
+						GInputStream *stream,
+						FuProgress *progress,
+						GError **error)
+{
+	g_autoptr(FuChunkArray) chunks = NULL;
+
+	chunks = fu_chunk_array_new_from_stream(stream, 0, 0, 32, error);
+	if (chunks == NULL)
+		return FALSE;
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
+	for (guint32 i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = NULL;
+
+		chk = fu_chunk_array_index(chunks, i, error);
+		if (chk == NULL)
+			return FALSE;
+		if (!fu_lenovo_accessory_impl_dfu_file(FU_LENOVO_ACCESSORY_IMPL(self),
+						       file_type,
+						       fu_chunk_get_address(chk),
+						       fu_chunk_get_data(chk),
+						       fu_chunk_get_data_sz(chk),
+						       error))
+			return FALSE;
+		fu_progress_step_done(progress);
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_lenovo_accessory_hid_dual_device_write_firmware(FuDevice *device,
+						   FuFirmware *firmware,
+						   FuProgress *progress,
+						   FwupdInstallFlags flags,
+						   GError **error)
+{
+	FuLenovoAccessoryHidDualDevice *self = FU_LENOVO_ACCESSORY_HID_DUAL_DEVICE(device);
+	gsize fw_size = 0;
+	guint32 file_crc = 0xFFFFFFFF;
+	guint32 device_crc = 0;
+	FuLenovoAccessoryDeviceMode mode;
+	g_autoptr(GInputStream) stream = NULL;
+
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 5, "prepare");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 95, "write");
+
+	stream = fu_firmware_get_stream(firmware, error);
+	if (stream == NULL)
+		return FALSE;
+	if (!fu_input_stream_size(stream, &fw_size, error))
+		return FALSE;
+	if (!fu_input_stream_compute_crc32(stream, FU_CRC_KIND_B32_STANDARD, &file_crc, error))
+		return FALSE;
+
+	/* only enter DFU mode if not already there */
+	if (!fu_lenovo_accessory_impl_get_mode(FU_LENOVO_ACCESSORY_IMPL(device), &mode, error))
+		return FALSE;
+	if (mode != FU_LENOVO_ACCESSORY_DEVICE_MODE_DFU_MODE) {
+		if (!fu_lenovo_accessory_impl_dfu_entry(FU_LENOVO_ACCESSORY_IMPL(device), error))
+			return FALSE;
+	}
+	if (!fu_lenovo_accessory_impl_dfu_attribute(FU_LENOVO_ACCESSORY_IMPL(device),
+						    NULL,
+						    NULL,
+						    NULL,
+						    NULL,
+						    NULL,
+						    NULL,
+						    error))
+		return FALSE;
+	if (!fu_lenovo_accessory_impl_dfu_prepare(FU_LENOVO_ACCESSORY_IMPL(device),
+						  FU_LENOVO_ACCESSORY_DFU_FILE_TYPE_BIN_FILE,
+						  0x0,
+						  (guint32)fw_size,
+						  file_crc,
+						  error))
+		return FALSE;
+	fu_progress_step_done(progress);
+	if (!fu_lenovo_accessory_hid_dual_device_write_files(
+		self,
+		FU_LENOVO_ACCESSORY_DFU_FILE_TYPE_BIN_FILE,
+		stream,
+		fu_progress_get_child(progress),
+		error))
+		return FALSE;
+
+	/* give the device time to finalize the flash before reading back CRC */
+	fu_device_sleep(FU_DEVICE(self), 2000);
+	if (!fu_lenovo_accessory_impl_dfu_crc(FU_LENOVO_ACCESSORY_IMPL(device),
+					      &device_crc,
+					      error)) {
+		g_prefix_error_literal(error, "failed to read device CRC: ");
+		return FALSE;
+	}
+	if (device_crc != file_crc) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_WRITE,
+			    "CRC mismatch: device 0x%08x != file 0x%08x",
+			    device_crc,
+			    file_crc);
+		return FALSE;
+	}
+	fu_progress_step_done(progress);
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_lenovo_accessory_hid_dual_device_attach(FuDevice *device, FuProgress *progress, GError **error)
+{
+	if (!fu_lenovo_accessory_impl_dfu_exit(FU_LENOVO_ACCESSORY_IMPL(device),
+					       FU_LENOVO_ACCESSORY_DFU_EXIT_CODE_DFU_SUCCESS,
+					       error)) {
+		g_prefix_error_literal(error, "failed to exit: ");
+		return FALSE;
+	}
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
+	return TRUE;
+}
+
+static gboolean
+fu_lenovo_accessory_hid_dual_device_setup(FuDevice *device, GError **error)
+{
+	FuLenovoAccessoryHidDualDevice *self = FU_LENOVO_ACCESSORY_HID_DUAL_DEVICE(device);
+	guint8 major = 0;
+	guint8 minor = 0;
+	guint8 micro = 0;
+	g_autofree gchar *version = NULL;
+	g_autoptr(GPtrArray) descriptors = NULL;
+	gboolean found_report = FALSE;
+
+	/* the command interface is a vendor HID collection (UsagePage 0xFF00,
+	 * Usage 0x02) carrying a 64-byte report; confirm it is present so we
+	 * fail early on a device that does not speak this protocol */
+	descriptors = fu_hid_device_parse_descriptors(FU_HID_DEVICE(self), error);
+	if (descriptors == NULL)
+		return FALSE;
+	for (guint i = 0; i < descriptors->len; i++) {
+		FuHidDescriptor *desc = g_ptr_array_index(descriptors, i);
+		g_autoptr(FuHidReport) report = NULL;
+		report = fu_hid_descriptor_find_report(desc,
+						       NULL,
+						       "usage-page",
+						       0xFF00,
+						       "usage",
+						       0x02,
+						       "report-size",
+						       8,
+						       "report-count",
+						       0x40,
+						       NULL);
+		if (report != NULL) {
+			found_report = TRUE;
+			break;
+		}
+	}
+	if (!found_report) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no vendor command report (0xFF00/0x02) found");
+		return FALSE;
+	}
+	if (!fu_lenovo_accessory_impl_get_fwversion(FU_LENOVO_ACCESSORY_IMPL(device),
+						    &major,
+						    &minor,
+						    &micro,
+						    error))
+		return FALSE;
+	version = g_strdup_printf("%u.%u.%u", major, minor, micro);
+	fu_device_set_version(device, version);
+	return fu_lenovo_accessory_hid_add_children(FU_LENOVO_ACCESSORY_IMPL(device), error);
+}
+
+static void
+fu_lenovo_accessory_hid_dual_device_set_progress(FuDevice *device, FuProgress *progress)
+{
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0, "detach");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 99, "write");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 1, "attach");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 0, "reload");
+}
+
+static void
+fu_lenovo_accessory_hid_dual_device_impl_iface_init(FuLenovoAccessoryImplInterface *iface)
+{
+	iface->read = fu_lenovo_accessory_hid_read;
+	iface->write = fu_lenovo_accessory_hid_write;
+	iface->process = fu_lenovo_accessory_hid_process;
+}
+
+static void
+fu_lenovo_accessory_hid_dual_device_class_init(FuLenovoAccessoryHidDualDeviceClass *klass)
+{
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->write_firmware = fu_lenovo_accessory_hid_dual_device_write_firmware;
+	device_class->set_progress = fu_lenovo_accessory_hid_dual_device_set_progress;
+	device_class->setup = fu_lenovo_accessory_hid_dual_device_setup;
+	device_class->attach = fu_lenovo_accessory_hid_dual_device_attach;
+}
+
+static void
+fu_lenovo_accessory_hid_dual_device_init(FuLenovoAccessoryHidDualDevice *self)
+{
+	fu_device_set_remove_delay(FU_DEVICE(self), 10000); /* ms */
+	fu_device_add_protocol(FU_DEVICE(self), "com.lenovo.accessory");
+	fu_device_set_install_duration(FU_DEVICE(self), 60);
+	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_CAN_EMULATION_TAG);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_DUAL_IMAGE);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE);
+	fu_hid_device_set_interface(FU_HID_DEVICE(self), FU_LENOVO_ACCESSORY_IFACE_CMD);
+}

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-hid-dual-device.h
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-hid-dual-device.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2026 Yuchao Li <liyc44@lenovo.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_LENOVO_ACCESSORY_HID_DUAL_DEVICE (fu_lenovo_accessory_hid_dual_device_get_type())
+G_DECLARE_FINAL_TYPE(FuLenovoAccessoryHidDualDevice,
+		     fu_lenovo_accessory_hid_dual_device,
+		     FU,
+		     LENOVO_ACCESSORY_HID_DUAL_DEVICE,
+		     FuHidDevice)

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-impl.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-impl.c
@@ -165,6 +165,129 @@ fu_lenovo_accessory_impl_set_mode(FuLenovoAccessoryImpl *self,
 	return TRUE;
 }
 
+gboolean
+fu_lenovo_accessory_impl_get_pair_support_info(FuLenovoAccessoryImpl *self,
+					       guint8 *max_slot_num,
+					       guint8 *slot_status,
+					       gsize slot_status_sz,
+					       GError **error)
+{
+	g_autoptr(FuStructLenovoAccessoryCmd) st_cmd = fu_struct_lenovo_accessory_cmd_new();
+	g_autoptr(FuStructLenovoAccessoryPairListReq) st_req =
+	    fu_struct_lenovo_accessory_pair_list_req_new();
+	g_autoptr(FuStructLenovoAccessoryPairSupportInfoRsp) st_rsp = NULL;
+	g_autoptr(GByteArray) buf = NULL;
+
+	fu_struct_lenovo_accessory_cmd_set_data_size(st_cmd, 0x02);
+	fu_struct_lenovo_accessory_cmd_set_command_class(
+	    st_cmd,
+	    FU_LENOVO_ACCESSORY_COMMAND_CLASS_DEVICE_INFORMATION);
+	fu_struct_lenovo_accessory_cmd_set_command_id(
+	    st_cmd,
+	    FU_LENOVO_ACCESSORY_INFO_ID_WIRELESS_PAIR_LIST |
+		(FU_LENOVO_ACCESSORY_CMD_DIR_CMD_GET << 7));
+	if (!fu_struct_lenovo_accessory_pair_list_req_set_cmd(st_req, st_cmd, error))
+		return FALSE;
+	fu_struct_lenovo_accessory_pair_list_req_set_op_code(
+	    st_req,
+	    FU_LENOVO_ACCESSORY_PAIR_LIST_OP_CODE_GET_SUPPORT_INFO);
+	buf = fu_lenovo_accessory_impl_process(self, st_req->buf, error);
+	if (buf == NULL) {
+		g_prefix_error_literal(error, "get pair support info: ");
+		return FALSE;
+	}
+	st_rsp =
+	    fu_struct_lenovo_accessory_pair_support_info_rsp_parse(buf->data, buf->len, 0x0, error);
+	if (st_rsp == NULL)
+		return FALSE;
+	if (max_slot_num != NULL)
+		*max_slot_num =
+		    fu_struct_lenovo_accessory_pair_support_info_rsp_get_max_slot_num(st_rsp);
+	if (slot_status != NULL) {
+		gsize rsp_status_sz = 0;
+		const guint8 *rsp_status =
+		    fu_struct_lenovo_accessory_pair_support_info_rsp_get_slot_status(
+			st_rsp,
+			&rsp_status_sz);
+		gsize copy_sz = MIN(slot_status_sz, rsp_status_sz);
+		if (!fu_memcpy_safe(slot_status,
+				    slot_status_sz,
+				    0,
+				    rsp_status,
+				    rsp_status_sz,
+				    0,
+				    copy_sz,
+				    error))
+			return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+gboolean
+fu_lenovo_accessory_impl_get_pair_slot_info_v2(FuLenovoAccessoryImpl *self,
+					       guint8 target_slot,
+					       guint16 *pid,
+					       guint8 *mac_addr,
+					       guint8 mac_addr_sz,
+					       gchar **bt_name,
+					       GError **error)
+{
+	g_autoptr(FuStructLenovoAccessoryCmd) st_cmd = fu_struct_lenovo_accessory_cmd_new();
+	g_autoptr(FuStructLenovoAccessoryPairListReq) st_req =
+	    fu_struct_lenovo_accessory_pair_list_req_new();
+	g_autoptr(FuStructLenovoAccessoryPairSlotInfoV2Rsp) st_rsp = NULL;
+	g_autoptr(GByteArray) buf = NULL;
+
+	fu_struct_lenovo_accessory_cmd_set_data_size(st_cmd, 0x02);
+	fu_struct_lenovo_accessory_cmd_set_command_class(
+	    st_cmd,
+	    FU_LENOVO_ACCESSORY_COMMAND_CLASS_DEVICE_INFORMATION);
+	fu_struct_lenovo_accessory_cmd_set_command_id(
+	    st_cmd,
+	    FU_LENOVO_ACCESSORY_INFO_ID_WIRELESS_PAIR_LIST |
+		(FU_LENOVO_ACCESSORY_CMD_DIR_CMD_GET << 7));
+	if (!fu_struct_lenovo_accessory_pair_list_req_set_cmd(st_req, st_cmd, error))
+		return FALSE;
+	fu_struct_lenovo_accessory_pair_list_req_set_op_code(
+	    st_req,
+	    FU_LENOVO_ACCESSORY_PAIR_LIST_OP_CODE_GET_SLOT_INFO_V2);
+	fu_struct_lenovo_accessory_pair_list_req_set_target_slot(st_req, target_slot);
+	buf = fu_lenovo_accessory_impl_process(self, st_req->buf, error);
+	if (buf == NULL) {
+		g_prefix_error_literal(error, "get pair slot info v2: ");
+		return FALSE;
+	}
+	st_rsp =
+	    fu_struct_lenovo_accessory_pair_slot_info_v2_rsp_parse(buf->data, buf->len, 0x0, error);
+	if (st_rsp == NULL)
+		return FALSE;
+	if (pid != NULL)
+		*pid = fu_struct_lenovo_accessory_pair_slot_info_v2_rsp_get_pid(st_rsp);
+	if (mac_addr != NULL) {
+		gsize rsp_mac_sz = 0;
+		const guint8 *rsp_mac =
+		    fu_struct_lenovo_accessory_pair_slot_info_v2_rsp_get_mac_addr(st_rsp,
+										  &rsp_mac_sz);
+		gsize copy_sz = MIN(mac_addr_sz, rsp_mac_sz);
+		if (!fu_memcpy_safe(mac_addr,
+				    mac_addr_sz,
+				    0,
+				    rsp_mac,
+				    rsp_mac_sz,
+				    0,
+				    copy_sz,
+				    error))
+			return FALSE;
+	}
+	if (bt_name != NULL)
+		*bt_name = fu_struct_lenovo_accessory_pair_slot_info_v2_rsp_get_bt_name(st_rsp);
+
+	/* success */
+	return TRUE;
+}
+
 /* @exit_code: the exit status code (e.g., 0x00 for success/reboot) */
 gboolean
 fu_lenovo_accessory_impl_dfu_exit(FuLenovoAccessoryImpl *self,

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-impl.h
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-impl.h
@@ -39,6 +39,22 @@ gboolean
 fu_lenovo_accessory_impl_set_mode(FuLenovoAccessoryImpl *self,
 				  FuLenovoAccessoryDeviceMode mode,
 				  GError **error) G_GNUC_NON_NULL(1);
+
+gboolean
+fu_lenovo_accessory_impl_get_pair_support_info(FuLenovoAccessoryImpl *self,
+					       guint8 *max_slot_num,
+					       guint8 *slot_status,
+					       gsize slot_status_sz,
+					       GError **error) G_GNUC_NON_NULL(1);
+gboolean
+fu_lenovo_accessory_impl_get_pair_slot_info_v2(FuLenovoAccessoryImpl *self,
+					       guint8 target_slot,
+					       guint16 *pid,
+					       guint8 *mac_addr,
+					       guint8 mac_addr_sz,
+					       gchar **bt_name,
+					       GError **error) G_GNUC_NON_NULL(1);
+
 gboolean
 fu_lenovo_accessory_impl_dfu_exit(FuLenovoAccessoryImpl *self,
 				  FuLenovoAccessoryDfuExitCode exit_code,

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-plugin.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-plugin.c
@@ -9,6 +9,7 @@
 #include "fu-lenovo-accessory-ble-device.h"
 #include "fu-lenovo-accessory-hid-bootloader.h"
 #include "fu-lenovo-accessory-hid-device.h"
+#include "fu-lenovo-accessory-hid-dual-device.h"
 #include "fu-lenovo-accessory-plugin.h"
 
 struct _FuLenovoAccessoryPlugin {
@@ -28,6 +29,7 @@ fu_lenovo_accessory_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LENOVO_ACCESSORY_HID_DEVICE);
+	fu_plugin_add_device_gtype(plugin, FU_TYPE_LENOVO_ACCESSORY_HID_DUAL_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LENOVO_ACCESSORY_HID_BOOTLOADER);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LENOVO_ACCESSORY_BLE_DEVICE);
 	fu_plugin_add_udev_subsystem(plugin, "usb");

--- a/plugins/lenovo-accessory/fu-lenovo-accessory.rs
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory.rs
@@ -11,6 +11,7 @@ enum FuLenovoAccessoryCommandClass {
 enum FuLenovoAccessoryInfoId {
     FirmwareVersion = 0x01,
     DeviceMode = 0x04,
+    WirelessPairList = 0x13,
 }
 
 #[repr(u8)]
@@ -27,6 +28,21 @@ enum FuLenovoAccessoryDfuId {
 enum FuLenovoAccessoryCmdDir {
     CmdSet = 0x00,
     CmdGet = 0x01,
+}
+
+#[repr(u8)]
+enum FuLenovoAccessoryPairSlotStatus {
+    NeverPaired = 0x00,
+    Disconnected = 0x01,
+    Connected = 0x02,
+}
+
+#[repr(u8)]
+enum FuLenovoAccessoryPairListOpCode {
+    GetSupportInfo = 0x00,
+    GetSlotInfo = 0x01,
+    DeleteSlot = 0x02,
+    GetSlotInfoV2 = 0x03,
 }
 
 #[repr(u8)]
@@ -56,6 +72,33 @@ enum FuLenovoAccessoryDfuFileType {
 enum FuLenovoAccessoryDfuExitCode {
     DfuSuccess = 0x00,
     Abort = 0x01,
+}
+
+// asynchronous notifications pushed by the dongle over the interface-2
+// interrupt-IN endpoint (input reports, no command/response handshake)
+#[repr(u8)]
+enum FuLenovoAccessoryNotifyEvent {
+    WirelessConnectStatusChange = 0x0B,
+    BtHostMsg = 0x0D,
+}
+
+#[repr(u8)]
+enum FuLenovoAccessoryNotifyConnectStatus {
+    Disconnected = 0x00,
+    Connected = 0x01,
+}
+
+#[derive(Parse, Default)]
+#[repr(C, packed)]
+struct FuStructLenovoAccessoryNotify {
+    report_id: u8 == 0x04,
+    ntf_type: u8 == 0x02,
+    event: FuLenovoAccessoryNotifyEvent,
+    // payload interpretation depends on `event`; for
+    // WirelessConnectStatusChange this is the connect status followed by the
+    // wireless slot number
+    connect_status: FuLenovoAccessoryNotifyConnectStatus,
+    slot: u8,
 }
 
 #[derive(New, Parse, Default)]
@@ -131,4 +174,30 @@ struct FuStructLenovoFwVersionRsp {
     major: u8,
     minor: u8,
     internal: u8,
+}
+
+#[derive(New)]
+#[repr(C, packed)]
+struct FuStructLenovoAccessoryPairListReq {
+    cmd: FuStructLenovoAccessoryCmd,
+    op_code: FuLenovoAccessoryPairListOpCode,
+    target_slot: u8,
+}
+
+#[derive(Parse)]
+#[repr(C, packed)]
+struct FuStructLenovoAccessoryPairSupportInfoRsp {
+    op_code: FuLenovoAccessoryPairListOpCode,
+    max_slot_num: u8,
+    slot_status: [u8; 8],
+}
+
+#[derive(Parse)]
+#[repr(C, packed)]
+struct FuStructLenovoAccessoryPairSlotInfoV2Rsp {
+    op_code: FuLenovoAccessoryPairListOpCode,
+    target_slot: u8,
+    pid: u16be,
+    mac_addr: [u8; 6],
+    bt_name: [char; 48],
 }

--- a/plugins/lenovo-accessory/lenovo-accessory.quirk
+++ b/plugins/lenovo-accessory/lenovo-accessory.quirk
@@ -3,37 +3,166 @@
 Plugin = lenovo_accessory
 GType = FuLenovoAccessoryHidBootloader
 
-# Lenovo Pro USB-A Unified Pairing Receiver
-[USB\VID_17EF&PID_629D]
-Name = Pro USB-A Unified Pairing Receiver
-Plugin = lenovo_accessory
-GType = FuLenovoAccessoryHidDevice
-CounterpartGuid = USB\VID_17EF&PID_6194
+# === GTECH ODM (0x61FA-0x6202) ===
 
-# Lenovo Pro USB-A Unified Pairing Receiver
-[USB\VID_17EF&PID_6201]
-Name = Pro USB-A Unified Pairing Receiver
+# Lenovo Professional Wireless Keyboard 2
+[BLUETOOTH\VID_17EF&PID_61FA]
+Name = Lenovo Professional Wireless Keyboard 2
 Plugin = lenovo_accessory
-GType = FuLenovoAccessoryHidDevice
-CounterpartGuid = USB\VID_17EF&PID_6194
+Flags = no-generic-version
+GType = FuLenovoAccessoryBleDevice
 
-# Lenovo 700 Multi-Device Wireless Mouse
-[BLUETOOTH\VID_17EF&PID_61FE]
-Name = 700 Multi-Device Wireless Mouse
+# Lenovo 700 Wireless Modern Keyboard
+[BLUETOOTH\VID_17EF&PID_61FB]
+Name = Lenovo 700 Wireless Modern Keyboard
+Plugin = lenovo_accessory
+Flags = no-generic-version
+GType = FuLenovoAccessoryBleDevice
+
+# Lenovo Pro Mouse
+[BLUETOOTH\VID_17EF&PID_61FC]
+Name = Lenovo Pro Mouse
+Plugin = lenovo_accessory
+Flags = no-generic-version
+GType = FuLenovoAccessoryBleDevice
+
+# Lenovo Pro Plus Mouse
+[BLUETOOTH\VID_17EF&PID_61FD]
+Name = Lenovo Pro Plus Mouse
 Plugin = lenovo_accessory
 Flags = no-generic-version
 GType = FuLenovoAccessoryBleDevice
 
 # Lenovo 700 Multi-Device Wireless Mouse
-[BLUETOOTH\VID_17EF&PID_629A]
-Name = 700 Multi-Device Wireless Mouse
+[BLUETOOTH\VID_17EF&PID_61FE]
+Name = Lenovo 700 Multi-Device Wireless Mouse
+Plugin = lenovo_accessory
+Flags = no-generic-version
+GType = FuLenovoAccessoryBleDevice
+
+# Lenovo 350 Bluetooth Mouse
+[BLUETOOTH\VID_17EF&PID_61FF]
+Name = Lenovo 350 Bluetooth Mouse
+Plugin = lenovo_accessory
+Flags = no-generic-version
+GType = FuLenovoAccessoryBleDevice
+
+# Lenovo Yoga AI Mouse
+[BLUETOOTH\VID_17EF&PID_6200]
+Name = Lenovo Yoga AI Mouse
+Plugin = lenovo_accessory
+Flags = no-generic-version
+GType = FuLenovoAccessoryBleDevice
+
+# Lenovo Pro USB-A Unified Pairing Receiver
+[USB\VID_17EF&PID_6201]
+Name = Lenovo Pro USB-A Unified Pairing Receiver
+Plugin = lenovo_accessory
+GType = FuLenovoAccessoryHidDevice
+CounterpartGuid = USB\VID_17EF&PID_6194
+
+# Lenovo Pro USB-C Unified Pairing Receiver
+[USB\VID_17EF&PID_6202]
+Name = Lenovo Pro USB-C Unified Pairing Receiver
+Plugin = lenovo_accessory
+GType = FuLenovoAccessoryHidDualDevice
+
+# === Liteon ODM (0x6296-0x629E) ===
+
+# Lenovo Professional Wireless Keyboard 2
+[BLUETOOTH\VID_17EF&PID_6296]
+Name = Lenovo Professional Wireless Keyboard 2
 Plugin = lenovo_accessory
 Flags = no-generic-version
 GType = FuLenovoAccessoryBleDevice
 
 # Lenovo 700 Wireless Modern Keyboard
 [BLUETOOTH\VID_17EF&PID_6297]
-Name = 700 Wireless Modern Keyboard
+Name = Lenovo 700 Wireless Modern Keyboard
+Plugin = lenovo_accessory
+Flags = no-generic-version
+GType = FuLenovoAccessoryBleDevice
+
+# Lenovo Pro Mouse
+[BLUETOOTH\VID_17EF&PID_6298]
+Name = Lenovo Pro Mouse
+Plugin = lenovo_accessory
+Flags = no-generic-version
+GType = FuLenovoAccessoryBleDevice
+
+# Lenovo Pro Plus Mouse
+[BLUETOOTH\VID_17EF&PID_6299]
+Name = Lenovo Pro Plus Mouse
+Plugin = lenovo_accessory
+Flags = no-generic-version
+GType = FuLenovoAccessoryBleDevice
+
+# Lenovo 700 Multi-Device Wireless Mouse
+[BLUETOOTH\VID_17EF&PID_629A]
+Name = Lenovo 700 Multi-Device Wireless Mouse
+Plugin = lenovo_accessory
+Flags = no-generic-version
+GType = FuLenovoAccessoryBleDevice
+
+# Lenovo 350 Bluetooth Mouse
+[BLUETOOTH\VID_17EF&PID_629B]
+Name = Lenovo 350 Bluetooth Mouse
+Plugin = lenovo_accessory
+Flags = no-generic-version
+GType = FuLenovoAccessoryBleDevice
+
+# Lenovo Yoga AI Mouse
+[BLUETOOTH\VID_17EF&PID_629C]
+Name = Lenovo Yoga AI Mouse
+Plugin = lenovo_accessory
+Flags = no-generic-version
+GType = FuLenovoAccessoryBleDevice
+
+# Lenovo Pro USB-A Unified Pairing Receiver
+[USB\VID_17EF&PID_629D]
+Name = Lenovo Pro USB-A Unified Pairing Receiver
+Plugin = lenovo_accessory
+GType = FuLenovoAccessoryHidDevice
+CounterpartGuid = USB\VID_17EF&PID_6194
+
+# Lenovo Pro USB-C Unified Pairing Receiver
+[USB\VID_17EF&PID_629E]
+Name = Lenovo Pro USB-C Unified Pairing Receiver
+Plugin = lenovo_accessory
+GType = FuLenovoAccessoryHidDualDevice
+
+# === Others ===
+
+# Lenovo Pro USB-A Unified Pairing Receiver
+[USB\VID_17EF&PID_62E7]
+Name = Pro USB-A Unified Pairing Receiver
+Plugin = lenovo_accessory
+GType = FuLenovoAccessoryHidDualDevice
+
+# FUJI 2.0 Mouse (BT)
+[BLUETOOTH\VID_17EF&PID_6282]
+Name = FUJI 2.0 Mouse
+Plugin = lenovo_accessory
+Flags = no-generic-version
+GType = FuLenovoAccessoryBleDevice
+
+# Lenovo Solar Keyboard (BT)
+[BLUETOOTH\VID_17EF&PID_61B3]
+Name = Lenovo Solar Keyboard
+Plugin = lenovo_accessory
+Flags = no-generic-version
+GType = FuLenovoAccessoryBleDevice
+
+# Helios Gen II Mouse (BT Mode)
+[BLUETOOTH\VID_17EF&PID_62A7]
+Name = Helios Gen II Mouse
+Plugin = lenovo_accessory
+Flags = no-generic-version
+GType = FuLenovoAccessoryBleDevice
+
+# Helios Gen II Keyboard (BT Mode)
+[BLUETOOTH\VID_17EF&PID_62A8]
+Name = Helios Gen II Keyboard
 Plugin = lenovo_accessory
 Flags = no-generic-version
 GType = FuLenovoAccessoryBleDevice

--- a/plugins/lenovo-accessory/meson.build
+++ b/plugins/lenovo-accessory/meson.build
@@ -7,8 +7,10 @@ plugin_builtins += static_library('fu_plugin_lenovo_accessory',
   sources: [
     'fu-lenovo-accessory-ble-device.c',
     'fu-lenovo-accessory-hid-bootloader.c',
+    'fu-lenovo-accessory-hid-child-device.c',
     'fu-lenovo-accessory-hid-common.c',
     'fu-lenovo-accessory-hid-device.c',
+    'fu-lenovo-accessory-hid-dual-device.c',
     'fu-lenovo-accessory-impl.c',
     'fu-lenovo-accessory-plugin.c',
   ],
@@ -19,7 +21,9 @@ plugin_builtins += static_library('fu_plugin_lenovo_accessory',
 )
 
 device_tests += files(
+  'tests/lenovo-accessory-6202-receiver.json',
   'tests/lenovo-accessory-700-keyboard.json',
   'tests/lenovo-accessory-700-mouse.json',
+  'tests/lenovo-accessory-700-mouse-receiver.json',
   'tests/lenovo-accessory-receiver.json',
 )

--- a/plugins/lenovo-accessory/tests/lenovo-accessory-6202-receiver.json
+++ b/plugins/lenovo-accessory/tests/lenovo-accessory-6202-receiver.json
@@ -1,0 +1,18 @@
+{
+  "name": "Lenovo Pro USB-C Unified Pairing Receiver",
+  "interactive": false,
+  "steps": [
+    {
+      "url": "95876f99dd95368c342b5277b9e5637c864d773fc1b7cd57b6e06d2254b505be-Lenovo-hid_6202-vs1.0.4.cab",
+      "emulation-url": "6da26ca0cc05f9ce237bba04059f02ae72457d394564a524634f98de54f411a7-6202-1.0.3-to-1.0.4-emulation.zip",
+      "components": [
+        {
+          "version": "1.0.4",
+          "guids": [
+            "c7c221bf-1f3b-5b5a-baa2-cef86a6f2a1a"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/lenovo-accessory/tests/lenovo-accessory-700-mouse-receiver.json
+++ b/plugins/lenovo-accessory/tests/lenovo-accessory-700-mouse-receiver.json
@@ -1,0 +1,18 @@
+{
+  "name": "Lenovo 700 Wireless Silent Mouse (via receiver)",
+  "interactive": false,
+  "steps": [
+    {
+      "url": "627e5b178920f483f1e7109d08a4dd987905d8f3e84f763d9a3913899d4485a5-Lenovo-mouse_629a-vs1.0.00.cab",
+      "emulation-url": "22db66be3db948b6cdf0f3b4ccee4871dc51d6844c63722645cc98e464afeac5-700-mouse-child-emulation.zip",
+      "components": [
+        {
+          "version": "1.0.00",
+          "guids": [
+            "325f7de4-94a6-531a-8a76-d9ec93df5575"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Build on the USB HID transport to support the Unified Pairing receivers that update in place and to enumerate and update the
  peripherals paired to a dongle.

   * Add FuLenovoAccessoryHidDualDevice for the dual-bank receivers that write to the alternate image bank and reboot in place,
  rather than detaching into a separate bootloader device.
   * Add FuLenovoAccessoryHidChildDevice for mice and keyboards paired to a dongle. The dongle enumerates its paired slots and
  exposes each as a child device that is updated over the dongle's USB proxy.
   * Query the paired peripheral list and per-slot info, and listen on the notify interface for a child coming back online
  after it reboots into the new firmware, instead of sleeping for a fixed delay.
   * Validate the slot in the command response so a queued reply for a different slot on the shared control channel is not
  mistaken for the result, retrying the read until the expected slot is seen.
   * Add device-test emulations for the dual-bank receiver and the paired mouse update paths.

  This is the second of the split PRs requested in #10474; it builds on the HID transport conversion that already merged.

  Type of pull request:

  - [ ] New plugin
  - [ ] Code fix
  - [x] Feature
  - [ ] Documentation