### PR TITLE
redfish: Handle HPE reset-required updates 

### DIFF
--- a/plugins/redfish/fu-redfish-device.c
+++ b/plugins/redfish/fu-redfish-device.c
@@ -747,13 +747,67 @@ fu_redfish_device_parse_message_id(FuRedfishDevice *self,
 	return TRUE;
 }
 
+/**
+ * fu_redfish_device_parse_message:
+ * @self: a #FuRedfishDevice
+ * @json_message: a #FwupdJsonObject holding `MessageId` and `Message` members
+ * @progress: a #FuProgress
+ * @messages_seen: (nullable): a #GHashTable used to deduplicate already-handled
+ *     messages, or %NULL to handle every message
+ * @message: (nullable): a #GString updated in-place with the `Message` string
+ *     when one is present, or %NULL to ignore it
+ * @error: (nullable): optional return location for an error
+ *
+ * Reads the `MessageId` and `Message` members from a Redfish message object and
+ * dispatches them to fu_redfish_device_parse_message_id().
+ *
+ * When @messages_seen is set, a message that has already been handled is skipped
+ * so its side effects are not applied twice. When @message is set and the object
+ * carries a `Message` string, @message is assigned that value; otherwise it is
+ * left untouched so any default it was seeded with is preserved.
+ *
+ * Returns: %TRUE on success
+ **/
+gboolean
+fu_redfish_device_parse_message(FuRedfishDevice *self,
+				FwupdJsonObject *json_message,
+				FuProgress *progress,
+				GHashTable *messages_seen,
+				GString *message,
+				GError **error)
+{
+	const gchar *message_id;
+	const gchar *message_tmp;
+
+	message_id = fwupd_json_object_get_string(json_message, "MessageId", NULL);
+	message_tmp = fwupd_json_object_get_string(json_message, "Message", NULL);
+	if (message != NULL && message_tmp != NULL)
+		g_string_assign(message, message_tmp);
+
+	/* ignore messages we've seen before */
+	if (messages_seen != NULL) {
+		g_autofree gchar *message_key =
+		    message_tmp == NULL ? g_strdup(message_id)
+					: g_strdup_printf("%s;%s", message_id, message_tmp);
+		if (g_hash_table_contains(messages_seen, message_key)) {
+			g_debug("ignoring %s", message_key);
+			return TRUE;
+		}
+		g_hash_table_add(messages_seen, g_steal_pointer(&message_key));
+	}
+
+	/* use the message */
+	g_debug("message [%s]: %s", message_id, message_tmp);
+	return fu_redfish_device_parse_message_id(self, message_id, message_tmp, progress, error);
+}
+
 static gboolean
 fu_redfish_device_poll_task_once(FuRedfishDevice *self, FuRedfishDevicePollCtx *ctx, GError **error)
 {
 	FuRedfishDevicePrivate *priv = GET_PRIVATE(self);
-	const gchar *message = "Unknown failure";
 	const gchar *state_tmp;
 	gint64 pc = 0;
+	g_autoptr(GString) message = g_string_new("Unknown failure");
 	g_autoptr(FuRedfishRequest) request = fu_redfish_backend_request_new(priv->backend);
 	g_autoptr(FwupdJsonArray) json_msgs = NULL;
 	g_autoptr(FwupdJsonObject) json_obj = NULL;
@@ -780,32 +834,18 @@ fu_redfish_device_poll_task_once(FuRedfishDevice *self, FuRedfishDevicePollCtx *
 	json_msgs = fwupd_json_object_get_array(json_obj, "Messages", NULL);
 	if (json_msgs != NULL) {
 		for (guint i = 0; i < fwupd_json_array_get_size(json_msgs); i++) {
-			const gchar *message_id;
-			g_autofree gchar *message_key = NULL;
 			g_autoptr(FwupdJsonObject) json_message = NULL;
 
 			/* set additional device properties */
 			json_message = fwupd_json_array_get_object(json_msgs, i, error);
 			if (json_message == NULL)
 				return FALSE;
-			message_id = fwupd_json_object_get_string(json_message, "MessageId", NULL);
-			message = fwupd_json_object_get_string(json_message, "Message", NULL);
-
-			/* ignore messages we've seen before */
-			message_key = g_strdup_printf("%s;%s", message_id, message);
-			if (g_hash_table_contains(ctx->messages_seen, message_key)) {
-				g_debug("ignoring %s", message_key);
-				continue;
-			}
-			g_hash_table_add(ctx->messages_seen, g_steal_pointer(&message_key));
-
-			/* use the message */
-			g_debug("message #%u [%s]: %s", i, message_id, message);
-			if (!fu_redfish_device_parse_message_id(self,
-								message_id,
-								message,
-								ctx->progress,
-								error))
+			if (!fu_redfish_device_parse_message(self,
+							     json_message,
+							     ctx->progress,
+							     ctx->messages_seen,
+							     message,
+							     error))
 				return FALSE;
 		}
 	}
@@ -831,7 +871,7 @@ fu_redfish_device_poll_task_once(FuRedfishDevice *self, FuRedfishDevicePollCtx *
 	}
 	if (g_strcmp0(state_tmp, "Exception") == 0 ||
 	    g_strcmp0(state_tmp, "UserIntervention") == 0) {
-		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, message);
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, message->str);
 		return FALSE;
 	}
 

--- a/plugins/redfish/fu-redfish-device.c
+++ b/plugins/redfish/fu-redfish-device.c
@@ -659,6 +659,7 @@ fu_redfish_device_parse_message_id(FuRedfishDevice *self,
 
 	/* set flags */
 	if (g_pattern_match_simple("Base.*.ResetRequired", message_id) ||
+	    g_pattern_match_simple("iLO.*.SystemResetRequired", message_id) ||
 	    g_pattern_match_simple("IDRAC.*.JCP001", message_id) ||
 	    g_pattern_match_simple("IDRAC.*.RED014", message_id)) {
 		fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_NEEDS_REBOOT);

--- a/plugins/redfish/fu-redfish-device.h
+++ b/plugins/redfish/fu-redfish-device.h
@@ -32,6 +32,13 @@ fu_redfish_device_parse_message_id(FuRedfishDevice *self,
 				   FuProgress *progress,
 				   GError **error);
 gboolean
+fu_redfish_device_parse_message(FuRedfishDevice *self,
+				FwupdJsonObject *json_message,
+				FuProgress *progress,
+				GHashTable *messages_seen,
+				GString *message,
+				GError **error);
+gboolean
 fu_redfish_device_poll_task(FuRedfishDevice *self,
 			    const gchar *location,
 			    FuProgress *progress,

--- a/plugins/redfish/fu-redfish-hpe-device.c
+++ b/plugins/redfish/fu-redfish-hpe-device.c
@@ -227,7 +227,6 @@ fu_redfish_hpe_device_write_firmware(FuDevice *device,
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_WAITING_FOR_AUTH, 3, NULL);
 	fu_progress_add_step(progress, FWUPD_STATUS_DOWNLOADING, 10, NULL);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 5, NULL);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 82, NULL);
 
 	/* create session; it is torn down later in ->cleanup() */

--- a/plugins/redfish/fu-redfish-hpe-device.c
+++ b/plugins/redfish/fu-redfish-hpe-device.c
@@ -97,10 +97,12 @@ fu_redfish_hpe_device_poll_task_once(FuRedfishDevice *self,
 	FuRedfishBackend *backend;
 	const gchar *status;
 	gint64 pc = 0;
+	g_autoptr(GString) message = g_string_new("Unknown failure");
 	g_autoptr(FwupdJsonObject) json_obj = NULL;
 	g_autoptr(FuRedfishRequest) request = NULL;
 	g_autoptr(FwupdJsonObject) json_oem = NULL;
 	g_autoptr(FwupdJsonObject) json_oem_hpe = NULL;
+	g_autoptr(FwupdJsonObject) json_result = NULL;
 
 	/* create URI and poll */
 	backend = fu_redfish_device_get_backend(FU_REDFISH_DEVICE(self), error);
@@ -123,30 +125,28 @@ fu_redfish_hpe_device_poll_task_once(FuRedfishDevice *self,
 	if (json_oem_hpe == NULL)
 		return TRUE;
 
+	/* parse the OEM Hpe Result if present: it may flag the device (e.g.
+	 * NEEDS_REBOOT) or raise a specific error, and captures the message
+	 * reused for the generic State=Error fallback below */
+	json_result = fwupd_json_object_get_object(json_oem_hpe, "Result", NULL);
+	if (json_result != NULL) {
+		if (!fu_redfish_device_parse_message(self,
+						     json_result,
+						     ctx->progress,
+						     NULL,
+						     message,
+						     error))
+			return FALSE;
+	}
+	if (fu_device_has_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_NEEDS_REBOOT)) {
+		ctx->completed = TRUE;
+		fu_progress_set_status(ctx->progress, FWUPD_STATUS_IDLE);
+		return TRUE;
+	}
+
 	status = fwupd_json_object_get_string(json_oem_hpe, "State", NULL);
 	if (g_strcmp0(status, "Error") == 0) {
-		const gchar *message = NULL;
-		g_autoptr(FwupdJsonObject) json_result = NULL;
-		/* default error, will be replaced by something more fitting
-		 * in fu_redfish_device_parse_message_id if we can
-		 */
-		json_result = fwupd_json_object_get_object(json_oem_hpe, "Result", NULL);
-		if (json_result != NULL) {
-			const gchar *message_id;
-			message_id = fwupd_json_object_get_string(json_result, "MessageId", NULL);
-			message = fwupd_json_object_get_string(json_result, "Message", NULL);
-			g_debug("message [%s]: %s", message_id, message);
-			if (!fu_redfish_device_parse_message_id(self,
-								message_id,
-								message,
-								ctx->progress,
-								error))
-				return FALSE;
-		}
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_INTERNAL,
-				    message != NULL ? message : "Unknown failure");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, message->str);
 		return FALSE;
 	}
 	if (!fwupd_json_object_get_integer_with_default(json_oem_hpe,

--- a/plugins/redfish/fu-self-test.c
+++ b/plugins/redfish/fu-self-test.c
@@ -471,9 +471,11 @@ fu_redfish_hpe_update_func(gconstpointer user_data)
 	FuTest *self = (FuTest *)user_data;
 	GPtrArray *devices;
 	gboolean ret;
-	g_autoptr(GError) error = NULL;
 	g_autoptr(GBytes) blob_fw = NULL;
+	g_autoptr(GBytes) blob_fw_reboot = NULL;
+	g_autoptr(GError) error = NULL;
 	g_autoptr(FuFirmware) stream_fw = NULL;
+	g_autoptr(FuFirmware) stream_fw_reboot = NULL;
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 
 	/* progress */
@@ -502,6 +504,23 @@ fu_redfish_hpe_update_func(gconstpointer user_data)
 					      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
+	g_assert_false(fu_device_has_flag(dev, FWUPD_DEVICE_FLAG_NEEDS_REBOOT));
+	fu_progress_step_done(progress);
+
+	/* BIOS */
+	dev = g_ptr_array_index(devices, 1);
+	blob_fw_reboot = g_bytes_new_static("reboot", 6);
+	stream_fw_reboot = fu_firmware_new_from_bytes(blob_fw_reboot);
+	fu_firmware_set_filename(stream_fw_reboot, "test.fwpkg");
+	ret = fu_plugin_runner_write_firmware(self->hpe_plugin,
+					      dev,
+					      stream_fw_reboot,
+					      fu_progress_get_child(progress),
+					      FWUPD_INSTALL_FLAG_NONE,
+					      &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_true(fu_device_has_flag(dev, FWUPD_DEVICE_FLAG_NEEDS_REBOOT));
 }
 
 static void

--- a/plugins/redfish/tests/redfish.py
+++ b/plugins/redfish/tests/redfish.py
@@ -27,6 +27,7 @@ HARDCODED_PASSWORD = "password2"
 app._percentage545: int = 0
 app._percentage546: int = 0
 app._hpeupdatestate: str = "Idle"
+app._hpeupdateresult = None
 
 
 def _failure(msg: str, status=400):
@@ -44,6 +45,7 @@ def index():
     app._percentage545 = 0
     app._percentage546 = 0
     app._hpeupdatestate = "Idle"
+    app._hpeupdateresult = None
 
     # check password from the config file
     try:
@@ -144,6 +146,8 @@ def update_service():
         }
     elif request.authorization["username"] == HARDCODED_HPE_USERNAME:
         res["Oem"] = {"Hpe": {"State": app._hpeupdatestate}}
+        if app._hpeupdateresult is not None:
+            res["Oem"]["Hpe"]["Result"] = app._hpeupdateresult
         res["HttpPushUri"] = "/FWUpdate-hpe"
     else:
         res["MultipartHttpPushUri"] = "/FWUpdate"
@@ -505,8 +509,19 @@ def fwupdate_hpe():
     fileitem = request.files["files[]"]
     if not fileitem:
         return _failure("no file supplied")
+    filecontents = fileitem.read().decode()
 
-    app._hpeupdatestate = "Complete"
+    if filecontents == "hello":
+        app._hpeupdatestate = "Complete"
+        app._hpeupdateresult = None
+    elif filecontents == "reboot":
+        app._hpeupdatestate = "Error"
+        app._hpeupdateresult = {
+            "Message": "A reset is required",
+            "MessageId": "iLO.2.25.SystemResetRequired",
+        }
+    else:
+        return _failure("data invalid")
     return Response(status=200)
 
 


### PR DESCRIPTION
When a firmware update requires a reset on an HPE server, we currently would report an error.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
