### PR TITLE
trivial: Fix reboot-cleanup using a GUID

### DIFF
--- a/data/tests/fwupdtool.sh
+++ b/data/tests/fwupdtool.sh
@@ -12,6 +12,7 @@ INPUT="@installedtestsdir@/fakedevice124.bin \
        @installedtestsdir@/fakedevice124.jcat \
        @installedtestsdir@/fakedevice124.metainfo.xml"
 DEVICE=08d460be0f1f9f128413f816022a6439e0078018
+GUID=b585990a-003e-5270-89d5-3705a17f9a43
 
 error() {
     cat fwupdtool.txt
@@ -286,6 +287,11 @@ if [ $? != 0 ]; then
     echo " ● Skipping tests due to no test device enabled"
     exit 0
 fi
+
+# ---
+echo " ● Reboot cleanup by GUID…"
+run reboot-cleanup ${GUID}
+expect_rc 0
 
 # ---
 echo " ● Get devices (including not-known protocol)…"

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -4996,7 +4996,7 @@ fu_util_reboot_cleanup(FuUtil *self, gchar **values, GError **error)
 
 	/* both arguments are optional */
 	if (g_strv_length(values) >= 1) {
-		device = fu_engine_get_device(self->engine, values[0], error);
+		device = fu_util_get_device(self, values[0], error);
 		if (device == NULL)
 			return FALSE;
 	} else {


### PR DESCRIPTION
fwupdtool documents the reboot-cleanup argument as DEVICE-ID|GUID, but the explicit argument path used the raw engine device lookup and only handled device IDs.

Use the normal fwupdtool device resolver for an explicit argument.

Checked with the test plugin fake device by running reboot-cleanup with its GUID.