### PR TITLE
Prevent clients using FwupdClient to download the same file again and again

### DIFF
--- a/libfwupd/fwupd-client-test.c
+++ b/libfwupd/fwupd-client-test.c
@@ -11,6 +11,36 @@
 #include "fwupd-test.h"
 
 static void
+fwupd_client_download_func(void)
+{
+	const gchar *fn = "/etc/os-release";
+	g_autofree gchar *uri = NULL;
+	g_autoptr(FwupdClient) client = fwupd_client_new();
+	g_autoptr(GBytes) blob1 = NULL;
+	g_autoptr(GBytes) blob2 = NULL;
+	g_autoptr(GError) error = NULL;
+
+	/* sanity check */
+	if (!g_file_test(fn, G_FILE_TEST_EXISTS)) {
+		g_test_skip("no installed os-release");
+		return;
+	}
+
+	fwupd_client_set_user_agent_for_package(client, PACKAGE_NAME, PACKAGE_VERSION);
+	uri = g_strdup_printf("file://%s", fn);
+	blob1 =
+	    fwupd_client_download_bytes(client, uri, FWUPD_CLIENT_DOWNLOAD_FLAG_NONE, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(blob1);
+
+	/* will be stopped by the download rate limiting */
+	blob2 =
+	    fwupd_client_download_bytes(client, uri, FWUPD_CLIENT_DOWNLOAD_FLAG_NONE, NULL, &error);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_REACHABLE);
+	g_assert_null(blob2);
+}
+
+static void
 fwupd_client_api_undefined_setter(void)
 {
 #if GLIB_CHECK_VERSION(2, 74, 0)
@@ -357,5 +387,6 @@ main(int argc, char **argv)
 		g_test_add_func("/fwupd/client/remotes", fwupd_client_remotes_func);
 		g_test_add_func("/fwupd/client/devices", fwupd_client_devices_func);
 	}
+	g_test_add_func("/fwupd/client/download", fwupd_client_download_func);
 	return g_test_run();
 }

--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -44,6 +44,9 @@ typedef GObject *(*FwupdClientObjectNewFunc)(void);
 
 #define FWUPD_CLIENT_DBUS_PROXY_TIMEOUT 180000 /* ms */
 
+/* the smallest amount of time between requests of the same URI from the same FwupdClient */
+#define FWUPD_CLIENT_DOWNLOAD_URI_DELTA 1500 /* ms */
+
 /**
  * FwupdClient:
  *
@@ -85,6 +88,8 @@ typedef struct {
 	GHashTable *immediate_requests; /* str:FwupdRequest */
 	GStrv hwid_keys;
 	GStrv hwid_values;
+	GMutex download_items_mutex; /* for @download_items */
+	GPtrArray *download_items; /* element-type FwupdClientDownloadItem */
 } FwupdClientPrivate;
 
 typedef struct {
@@ -928,10 +933,12 @@ fwupd_client_curl_new(FwupdClient *self, GError **error)
 	(void)curl_easy_setopt(helper->curl, CURLOPT_FOLLOWLOCATION, 1L);
 	(void)curl_easy_setopt(helper->curl, CURLOPT_MAXREDIRS, 5L);
 #if CURL_AT_LEAST_VERSION(7, 85, 0)
-	(void)curl_easy_setopt(helper->curl, CURLOPT_PROTOCOLS_STR, "http,https");
+	(void)curl_easy_setopt(helper->curl, CURLOPT_PROTOCOLS_STR, "http,https,file");
 	(void)curl_easy_setopt(helper->curl, CURLOPT_REDIR_PROTOCOLS_STR, "http,https");
 #else
-	(void)curl_easy_setopt(helper->curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+	(void)curl_easy_setopt(helper->curl,
+			       CURLOPT_PROTOCOLS,
+			       CURLPROTO_HTTP | CURLPROTO_HTTPS | CURLPROTO_FILE);
 	(void)curl_easy_setopt(helper->curl,
 			       CURLOPT_REDIR_PROTOCOLS,
 			       CURLPROTO_HTTP | CURLPROTO_HTTPS);
@@ -6011,6 +6018,92 @@ fwupd_client_test_network(const gchar *url, GError **error)
 	return TRUE;
 }
 
+typedef struct {
+	gchar *uri;
+	gint64 time;
+} FwupdClientDownloadItem;
+
+static void
+fwupd_client_download_item_prune(FwupdClient *self)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE(self);
+	gint64 now = g_get_monotonic_time();
+	g_autoptr(GMutexLocker) download_items_locker = NULL;
+	g_autoptr(GPtrArray) download_remove = g_ptr_array_new();
+
+	download_items_locker = g_mutex_locker_new(&priv->download_items_mutex);
+	if (download_items_locker == NULL)
+		return;
+	for (guint i = 0; i < priv->download_items->len; i++) {
+		FwupdClientDownloadItem *item = g_ptr_array_index(priv->download_items, i);
+		gint64 delta = (now - item->time) / 1000;
+		if (delta > FWUPD_CLIENT_DOWNLOAD_URI_DELTA)
+			g_ptr_array_add(download_remove, item);
+	}
+	for (guint i = 0; i < download_remove->len; i++) {
+		FwupdClientDownloadItem *item = g_ptr_array_index(download_remove, i);
+		g_ptr_array_remove(priv->download_items, item);
+	}
+}
+
+static FwupdClientDownloadItem *
+fwupd_client_download_item_find_by_uri(FwupdClient *self, const gchar *uri)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE(self);
+	for (guint i = 0; i < priv->download_items->len; i++) {
+		FwupdClientDownloadItem *item = g_ptr_array_index(priv->download_items, i);
+		if (g_strcmp0(item->uri, uri) == 0)
+			return item;
+	}
+	return NULL;
+}
+
+static gboolean
+fwupd_client_download_item_add(FwupdClient *self, const gchar *uri, GError **error)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE(self);
+	FwupdClientDownloadItem *item;
+	gint64 now = g_get_monotonic_time();
+	g_autoptr(GMutexLocker) download_items_locker = NULL;
+
+	/* already exists */
+	download_items_locker = g_mutex_locker_new(&priv->download_items_mutex);
+	if (download_items_locker == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "failed to lock download items");
+		return FALSE;
+	}
+	item = fwupd_client_download_item_find_by_uri(self, uri);
+	if (item != NULL) {
+		gint64 delta = (now - item->time) / 1000;
+		if (delta < FWUPD_CLIENT_DOWNLOAD_URI_DELTA) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_REACHABLE,
+				    "attempted previous download of %s from just %ums ago",
+				    uri,
+				    (guint)delta);
+			return FALSE;
+		}
+	}
+
+	/* add new */
+	item = g_new0(FwupdClientDownloadItem, 1);
+	item->time = now;
+	item->uri = g_strdup(uri);
+	g_ptr_array_add(priv->download_items, item);
+	return TRUE;
+}
+
+static void
+fwupd_client_download_item_free(FwupdClientDownloadItem *item)
+{
+	g_free(item->uri);
+	g_free(item);
+}
+
 static GBytes *
 fwupd_client_download_http_retry(FwupdClient *self, CURL *curl, const gchar *url, GError **error)
 {
@@ -6018,7 +6111,13 @@ fwupd_client_download_http_retry(FwupdClient *self, CURL *curl, const gchar *url
 	gulong delay_ms = 2500;
 
 	/* test if we can reach this network */
-	if (!fwupd_client_test_network(url, error))
+	if (!g_str_has_prefix(url, "file://")) {
+		if (!fwupd_client_test_network(url, error))
+			return NULL;
+	}
+
+	/* add this to a cooldown list */
+	if (!fwupd_client_download_item_add(self, url, error))
 		return NULL;
 
 	for (guint i = 0;; i++, delay_ms *= 2) {
@@ -6093,6 +6192,7 @@ fwupd_client_download_bytes2_async(FwupdClient *self,
 {
 	g_autoptr(GTask) task = NULL;
 	g_autoptr(GError) error = NULL;
+	g_autoptr(GMutexLocker) download_items_locker = NULL;
 	g_autoptr(FwupdCurlHelper) helper = NULL;
 
 	g_return_if_fail(FWUPD_IS_CLIENT(self));
@@ -6115,6 +6215,9 @@ fwupd_client_download_bytes2_async(FwupdClient *self,
 	g_task_set_task_data(task,
 			     g_steal_pointer(&helper),
 			     (GDestroyNotify)fwupd_client_curl_helper_free);
+
+	/* keep list sane */
+	fwupd_client_download_item_prune(self);
 
 	/* download data */
 	g_task_run_in_thread(task, fwupd_client_download_bytes_thread_cb);
@@ -7888,8 +7991,11 @@ fwupd_client_init(FwupdClient *self)
 	priv->percentage = FWUPD_PERCENTAGE_UNKNOWN;
 	g_mutex_init(&priv->proxy_mutex);
 	g_mutex_init(&priv->idle_mutex);
+	g_mutex_init(&priv->download_items_mutex);
 	priv->idle_sources =
 	    g_ptr_array_new_with_free_func((GDestroyNotify)fwupd_client_context_helper_free);
+	priv->download_items =
+	    g_ptr_array_new_with_free_func((GDestroyNotify)fwupd_client_download_item_free);
 	priv->proxy_resolver = g_proxy_resolver_get_default();
 	priv->hints = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 	priv->battery_level = FWUPD_BATTERY_LEVEL_INVALID;
@@ -7923,9 +8029,11 @@ fwupd_client_finalize(GObject *object)
 	g_hash_table_unref(priv->hints);
 	g_hash_table_unref(priv->immediate_requests);
 	g_mutex_clear(&priv->idle_mutex);
+	g_mutex_clear(&priv->download_items_mutex);
 	if (priv->idle_id != 0)
 		g_source_remove(priv->idle_id);
 	g_ptr_array_unref(priv->idle_sources);
+	g_ptr_array_unref(priv->download_items);
 	g_mutex_clear(&priv->proxy_mutex);
 	if (priv->proxy != NULL)
 		g_object_unref(priv->proxy);


### PR DESCRIPTION
There appears to be some kind of thread issue in some versions of gnome-software that cause the client to re-request the firmware archive in a tight loop -- many times per second.

This could be a cosmic particle, a bug in pthread or a kernel issue -- or something else entirely. Either way it's increasing the db load on the LVFS.

To prevent hitting the LVFS 200 times (when the abuse ban-hammer comes into force) just refuse to download the same file if already requested within the last 1500ms.

This may surface an error to the front-end, but that's entirely what I want to happen as that's the only place it can be investigated and fixed.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
