### PR TITLE
elan-ts: add 5 new HP Gaston device quirks and remove unused one

### DIFF
--- a/plugins/elan-ts/elan-ts.quirk
+++ b/plugins/elan-ts/elan-ts.quirk
@@ -19,6 +19,10 @@ Plugin = elan_ts
 [HIDRAW\VEN_04F3&DEV_4833]
 Plugin = elan_ts
 
+# HP Gaston (FWID: 0x48EC)
+[HIDRAW\VEN_04F3&DEV_4834]
+Plugin = elan_ts
+
 # HP Gaston (FWID: 0x48ED)
 [HIDRAW\VEN_04F3&DEV_4835]
 Plugin = elan_ts
@@ -27,6 +31,18 @@ Plugin = elan_ts
 [HIDRAW\VEN_04F3&DEV_4836]
 Plugin = elan_ts
 
-# HP Gaston (FWID: 0x498F)
-[HIDRAW\VEN_04F3&DEV_489D]
+# HP Gaston (FWID: 0x48EF)
+[HIDRAW\VEN_04F3&DEV_4837]
+Plugin = elan_ts
+
+# HP Gaston (FWID: 0x503F)
+[HIDRAW\VEN_04F3&DEV_48D0]
+Plugin = elan_ts
+
+# HP Gaston (FWID: 0x5070)
+[HIDRAW\VEN_04F3&DEV_48D1]
+Plugin = elan_ts
+
+# HP Gaston (FWID: 0x5071)
+[HIDRAW\VEN_04F3&DEV_48D2]
 Plugin = elan_ts


### PR DESCRIPTION
Add five new HP Gaston touchscreen devices to the quirk file to enable firmware updates via the elan_ts plugin:
- HP Gaston (FWID: 0x48EC, DEV_4834)
- HP Gaston (FWID: 0x48EF, DEV_4837)
- HP Gaston (FWID: 0x503F, DEV_48D0)
- HP Gaston (FWID: 0x5070, DEV_48D1)
- HP Gaston (FWID: 0x5071, DEV_48D2)

Also, remove the unused device quirk for HP Gaston (FWID: 0x498F, DEV_489D) as it is no longer required.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
