### PR TITLE
ifwi-cpd: avoid guint32 overflow in the manifest length check

### DIFF
--- a/libfwupdplugin/fu-firmware-test.c
+++ b/libfwupdplugin/fu-firmware-test.c
@@ -11,6 +11,7 @@
 #include "fwupd-test.h"
 
 #include "fu-context-private.h"
+#include "fu-ifwi-struct.h"
 
 static void
 fu_firmware_raw_aligned_func(void)
@@ -579,6 +580,45 @@ fu_firmware_ifwi_cpd_func(void)
 }
 
 static void
+fu_firmware_ifwi_cpd_manifest_overflow_func(void)
+{
+	gboolean ret;
+	g_autoptr(FuFirmware) firmware = fu_ifwi_cpd_firmware_new();
+	g_autoptr(GByteArray) buf = g_byte_array_new();
+	g_autoptr(FuStructIfwiCpd) st_hdr = fu_struct_ifwi_cpd_new();
+	g_autoptr(FuStructIfwiCpdEntry) st_entry = fu_struct_ifwi_cpd_entry_new();
+	g_autoptr(FuStructIfwiCpdManifest) st_mhd = fu_struct_ifwi_cpd_manifest_new();
+	g_autoptr(GBytes) blob = NULL;
+	g_autoptr(GError) error = NULL;
+
+	/* CPD header with a single entry */
+	fu_struct_ifwi_cpd_set_num_of_entries(st_hdr, 0x1);
+	fu_struct_ifwi_cpd_set_header_version(st_hdr, 0x1);
+	fu_struct_ifwi_cpd_set_entry_version(st_hdr, 0x2);
+	fu_struct_ifwi_cpd_set_partition_name(st_hdr, 0x1234);
+	fu_byte_array_append_array(buf, st_hdr->buf);
+
+	/* entry[0] is the manifest, data follows the header and entry, length 0x100 */
+	fu_struct_ifwi_cpd_entry_set_offset(st_entry, st_hdr->buf->len + st_entry->buf->len);
+	fu_struct_ifwi_cpd_entry_set_length(st_entry, 0x100);
+	fu_byte_array_append_array(buf, st_entry->buf);
+
+	/* size is in dwords, 0x40000040 * 4 wraps a guint32 back to the 0x100 stream
+	 * size, so an unchecked multiply lets the length test pass */
+	fu_struct_ifwi_cpd_manifest_set_header_length(st_mhd, 0x40);
+	fu_struct_ifwi_cpd_manifest_set_size(st_mhd, 0x40000040);
+	fu_byte_array_append_array(buf, st_mhd->buf);
+
+	/* pad so the manifest entry stream is the full declared 0x100 bytes */
+	fu_byte_array_set_size(buf, st_hdr->buf->len + st_entry->buf->len + 0x100, 0x0);
+
+	blob = g_bytes_new(buf->data, buf->len);
+	ret = fu_firmware_parse_bytes(firmware, blob, 0x0, FU_FIRMWARE_PARSE_FLAG_NONE, &error);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
+	g_assert_false(ret);
+}
+
+static void
 fu_firmware_ifwi_fpt_func(void)
 {
 	g_autofree gchar *filename = NULL;
@@ -1143,6 +1183,8 @@ main(int argc, char **argv)
 	g_test_add_func("/fwupd/firmware/fdt", fu_firmware_fdt_func);
 	g_test_add_func("/fwupd/firmware/fit", fu_firmware_fit_func);
 	g_test_add_func("/fwupd/firmware/ifwi-cpd", fu_firmware_ifwi_cpd_func);
+	g_test_add_func("/fwupd/firmware/ifwi-cpd-manifest-overflow",
+			fu_firmware_ifwi_cpd_manifest_overflow_func);
 	g_test_add_func("/fwupd/firmware/ifwi-fpt", fu_firmware_ifwi_fpt_func);
 	g_test_add_func("/fwupd/firmware/oprom", fu_firmware_oprom_func);
 	g_test_add_func("/fwupd/firmware/dfu", fu_firmware_dfu_func);

--- a/libfwupdplugin/fu-ifwi-cpd-firmware.c
+++ b/libfwupdplugin/fu-ifwi-cpd-firmware.c
@@ -79,11 +79,19 @@ fu_ifwi_cpd_firmware_parse_manifest(FuIfwiCpdFirmware *self,
 	if (!fu_input_stream_size(stream, &streamsz, error))
 		return FALSE;
 	size = fu_struct_ifwi_cpd_manifest_get_size(st_mhd);
+	if ((guint64)size * 4 > G_MAXUINT32) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "manifest size 0x%x dwords would overflow",
+			    size);
+		return FALSE;
+	}
 	if (size * 4 != streamsz) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INVALID_DATA,
-			    "invalid manifest invalid length, got 0x%x, expected 0x%x",
+			    "invalid manifest length, got 0x%x, expected 0x%x",
 			    size * 4,
 			    (guint)streamsz);
 		return FALSE;


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

**Unchecked dword multiply in the CPD manifest length test**

The manifest `size` is a u32le taken straight from the header, but `size * 4` is evaluated as a guint32, so a manifest declaring 0x40000040 dwords wraps the product back to the 0x100-byte entry length and slips past the `size * 4 != streamsz` check. The `header_length` conversion just below already goes through `fu_size_checked_inc_product`, so I widened this one to match; a regression test covers the wrapping manifest.
