### PR TITLE
clang-analyzer dead stores

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,7 +27,6 @@ Checks:
   - -cert-err33-c
   - -cert-err34-c
   - -clang-analyzer-core.NullDereference
-  - -clang-analyzer-deadcode.DeadStores
   - -clang-analyzer-optin.core.EnumCastOutOfRange
   - -clang-analyzer-optin.performance.Padding # not useful enough
   - -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling

--- a/libfwupdplugin/fu-bluez-device.c
+++ b/libfwupdplugin/fu-bluez-device.c
@@ -822,7 +822,7 @@ fu_bluez_device_write(FuBluezDevice *self, const gchar *uuid, GByteArray *buf, G
 
 	/* save */
 	if (event_id != NULL)
-		event = fu_device_save_event(FU_DEVICE(self), event_id);
+		fu_device_save_event(FU_DEVICE(self), event_id);
 
 	item = fu_bluez_device_get_uuid_item(self, uuid, error);
 	if (item == NULL)

--- a/libfwupdplugin/fu-edid.c
+++ b/libfwupdplugin/fu-edid.c
@@ -372,7 +372,6 @@ fu_edid_write(FuFirmware *firmware, GError **error)
 		memcpy(st->buf->data + offset_desc,
 		       st_desc->buf->data,
 		       st_desc->buf->len); /* nocheck:blocked */
-		offset_desc += st_desc->buf->len;
 	}
 
 	/* success */

--- a/libfwupdplugin/fu-efivars-test.c
+++ b/libfwupdplugin/fu-efivars-test.c
@@ -213,6 +213,7 @@ fu_efivars_boot_func(void)
 	g_assert_nonnull(loadopt2);
 	entries = fu_efivars_get_boot_entries(efivars, &error);
 	g_assert_no_error(error);
+	g_assert_nonnull(entries);
 	g_assert_nonnull(bootorder2);
 	g_assert_cmpint(bootorder2->len, ==, 2);
 

--- a/libfwupdplugin/fu-fdt-firmware-test.c
+++ b/libfwupdplugin/fu-fdt-firmware-test.c
@@ -16,7 +16,6 @@ fu_fdt_firmware_func(void)
 	gboolean ret;
 	g_autofree gchar *fn = NULL;
 	g_autofree gchar *compatible = NULL;
-	g_autofree gchar *testdatadir = NULL;
 	g_autoptr(FuContext) ctx = fu_context_new();
 	g_autoptr(FuFirmware) fdt = NULL;
 	g_autoptr(FuFirmware) fdt_root = NULL;
@@ -35,7 +34,6 @@ fu_fdt_firmware_func(void)
 	g_assert_nonnull(tmpdir);
 
 	/* set up test harness */
-	testdatadir = g_test_build_filename(G_TEST_DIST, "tests", NULL);
 	fu_context_set_tmpdir(ctx, FU_PATH_KIND_LOCALSTATEDIR_PKG, tmpdir);
 
 	/* write file */

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -2156,7 +2156,7 @@ fu_udev_device_write_sysfs(FuUdevDevice *self,
 
 	/* save */
 	if (event_id != NULL)
-		event = fu_device_save_event(FU_DEVICE(self), event_id);
+		fu_device_save_event(FU_DEVICE(self), event_id);
 	if (!fu_io_channel_write_raw(io_channel,
 				     (const guint8 *)val,
 				     strlen(val),
@@ -2235,7 +2235,7 @@ fu_udev_device_write_sysfs_byte_array(FuUdevDevice *self,
 
 	/* save */
 	if (event_id != NULL)
-		event = fu_device_save_event(FU_DEVICE(self), event_id);
+		fu_device_save_event(FU_DEVICE(self), event_id);
 	if (!fu_io_channel_write_byte_array(io_channel,
 					    buf,
 					    timeout_ms,
@@ -2314,7 +2314,7 @@ fu_udev_device_write_sysfs_bytes(FuUdevDevice *self,
 
 	/* save */
 	if (event_id != NULL)
-		event = fu_device_save_event(FU_DEVICE(self), event_id);
+		fu_device_save_event(FU_DEVICE(self), event_id);
 	if (!fu_io_channel_write_bytes(io_channel,
 				       blob,
 				       timeout_ms,

--- a/plugins/devlink/fu-devlink-netlink.c
+++ b/plugins/devlink/fu-devlink-netlink.c
@@ -408,6 +408,7 @@ fu_devlink_netlink_fu_devlink_netlink_genl_ensure_family_cb(const struct nlmsghd
 	struct nlattr *mcgrp;
 
 	g_return_val_if_fail(nlh != NULL, -1);
+	g_return_val_if_fail(genl != NULL, -1);
 
 	mnl_attr_parse(nlh, sizeof(*genl), fu_devlink_netlink_genl_ctrl_attr_cb, tb);
 	if (tb[CTRL_ATTR_FAMILY_ID] == NULL)

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
@@ -362,7 +362,6 @@ fu_synaptics_rmi_device_setup(FuDevice *device, GError **error)
 	FuSynapticsRmiDevicePrivate *priv = GET_PRIVATE(self);
 	guint16 addr;
 	guint16 prod_info_addr;
-	guint8 ds4_query_length = 0;
 	guint8 product_sub_id = 0;
 	gboolean has_build_id_query = FALSE;
 	gboolean has_dds4_queries = FALSE;
@@ -462,7 +461,6 @@ fu_synaptics_rmi_device_setup(FuDevice *device, GError **error)
 			g_prefix_error_literal(error, "failed to read DS4 query length: ");
 			return FALSE;
 		}
-		ds4_query_length = f01_tmp->data[0];
 	}
 	f01_ds4 = fu_synaptics_rmi_device_read(self, addr, 0x1, error);
 	if (f01_ds4 == NULL) {
@@ -471,7 +469,6 @@ fu_synaptics_rmi_device_setup(FuDevice *device, GError **error)
 	}
 	has_package_id_query = (f01_ds4->data[0] & RMI_DEVICE_F01_QRY43_01_PACKAGE_ID) > 0;
 	has_build_id_query = (f01_ds4->data[0] & RMI_DEVICE_F01_QRY43_01_BUILD_ID) > 0;
-	addr += ds4_query_length;
 	if (has_package_id_query)
 		prod_info_addr++;
 	if (has_build_id_query) {

--- a/plugins/uefi-capsule/fu-uefi-bgrt.c
+++ b/plugins/uefi-capsule/fu-uefi-bgrt.c
@@ -27,7 +27,6 @@ fu_uefi_bgrt_setup(FuUefiBgrt *self, GError **error)
 	guint64 type;
 	guint64 version;
 	g_autofree gchar *bgrtdir = NULL;
-	g_autofree gchar *imagefn = NULL;
 	g_autoptr(FuBitmapImage) bmp_image = fu_bitmap_image_new();
 	g_autoptr(GFile) file = NULL;
 
@@ -70,7 +69,6 @@ fu_uefi_bgrt_setup(FuUefiBgrt *self, GError **error)
 	/* load image */
 	self->xoffset = fu_uefi_read_file_as_uint64(bgrtdir, "xoffset");
 	self->yoffset = fu_uefi_read_file_as_uint64(bgrtdir, "yoffset");
-	imagefn = g_build_filename(bgrtdir, "image", NULL);
 	file = g_file_new_build_filename(bgrtdir, "image", NULL);
 	if (!fu_firmware_parse_file(FU_FIRMWARE(bmp_image),
 				    file,

--- a/src/fu-dbus-daemon.c
+++ b/src/fu-dbus-daemon.c
@@ -1361,12 +1361,10 @@ fu_dbus_daemon_method_set_approved_firmware(FuDbusDaemon *self,
 					    FuEngineRequest *request,
 					    GDBusMethodInvocation *invocation)
 {
-	g_autofree gchar *checksums_str = NULL;
 	g_auto(GStrv) checksums = NULL;
 	g_autoptr(FuMainAuthHelper) helper = NULL;
 
 	g_variant_get(parameters, "(^as)", &checksums);
-	checksums_str = g_strjoinv(",", checksums);
 
 	/* authenticate */
 	fu_dbus_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);

--- a/src/fu-udev-backend.c
+++ b/src/fu-udev-backend.c
@@ -203,7 +203,7 @@ fu_udev_backend_create_device_for_donor(FuBackend *backend, FuDevice *donor, GEr
 	FuUdevBackend *self = FU_UDEV_BACKEND(backend);
 	FuContext *ctx = fu_backend_get_context(FU_BACKEND(self));
 	g_autoptr(FuDevice) device = NULL;
-	GType gtype = FU_TYPE_UDEV_DEVICE;
+	GType gtype;
 
 	/* ignore zram and loop block devices -- of which there are dozens on systems with snap */
 	if (g_strcmp0(fu_udev_device_get_subsystem(FU_UDEV_DEVICE(donor)), "block") == 0) {


### PR DESCRIPTION
To me this check does appear very useful to enable.

Not completely certain if all of these fixes are adequate or if instead some of these variables actually were meant to be used in some way.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
