### PR TITLE
fix(debian): add fonts-noto-cjk to build dependencies for CJK splash support

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -80,6 +80,16 @@
     <distro id="arch">
       <package variant="x86_64" />
     </distro>
+    <distro id="debian">
+      <control />
+      <package variant="x86_64">fonts-noto-cjk</package>
+      <package variant="aarch64">fonts-noto-cjk</package>
+    </distro>
+    <distro id="ubuntu">
+      <control />
+      <package variant="x86_64">fonts-noto-cjk</package>
+      <package variant="aarch64">fonts-noto-cjk</package>
+    </distro>
   </dependency>
   <dependency id="ca-certificates">
     <distro id="centos">


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

---

The UEFI capsule splash images for CJK locales (zh_TW, zh_CN, ja, ko)
render as tofu because fonts-noto-cjk is missing from the Debian/Ubuntu
build dependencies. Unlike Fedora (google-noto-sans-cjk-ttc-fonts) and
Arch (noto-fonts-cjk), the Debian/Ubuntu build dependencies
auto-generated from dependencies.xml only pulled fonts-noto (core
Noto fonts, no CJK coverage).

An example: Ubuntu 26.04 ships fwupd 2.1.1-1ubuntu3, and extracting
/usr/share/fwupd/uefi-capsule-ux.zip confirms that every CJK BMP
(zh_TW, zh_CN, ja, ko) contains tofu instead of the intended glyphs.

Adding Debian and Ubuntu distro entries to the existing noto-fonts-cjk
dependency ensures fonts-noto-cjk gets installed in the build chroot,
so make-images.py can render CJK glyphs correctly.

Signed-off-by: Dustin Lee <ifg1229@gmail.com>