### PR TITLE
libfwupd: replace GNetworkMonitor with direct /proc/net/route check (…

### DIFF
--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -30,6 +30,7 @@
 #include "fwupd-error.h"
 #include "fwupd-json-array.h"
 #include "fwupd-json-parser.h"
+#include "fwupd-network.h"
 #include "fwupd-plugin.h"
 #include "fwupd-release.h"
 #include "fwupd-remote-private.h"
@@ -5987,11 +5988,9 @@ fwupd_client_download_error_is_fatal(const GError *error)
 static gboolean
 fwupd_client_test_network(const gchar *url, GError **error)
 {
-#if GLIB_CHECK_VERSION(2, 66, 0)
-	GNetworkMonitor *monitor;
 	g_autoptr(GUri) uri = NULL;
-	g_autoptr(GError) error_monitor = NULL;
-	g_autoptr(GSocketConnectable) address = NULL;
+	const gchar *hostname;
+	gint port;
 
 	if (g_getenv("FWUPD_IGNORE_NETWORK_REACHABLE") != NULL)
 		return TRUE;
@@ -6000,22 +5999,20 @@ fwupd_client_test_network(const gchar *url, GError **error)
 	if (uri == NULL)
 		return FALSE;
 
-	address = g_network_address_parse(g_uri_get_host(uri), g_uri_get_port(uri), error);
-	if (address == NULL)
-		return FALSE;
-
-	monitor = g_network_monitor_get_default();
-	if (!g_network_monitor_can_reach(monitor, address, NULL, &error_monitor)) {
-		g_set_error(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_NOT_REACHABLE,
-			    "network is unreachable: %s",
-			    error_monitor->message);
+	hostname = g_uri_get_host(uri);
+	if (hostname == NULL || hostname[0] == '\0') {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "no hostname in URL");
 		return FALSE;
 	}
-#endif
-	/* success */
-	return TRUE;
+
+	port = g_uri_get_port(uri);
+	if (port == -1)
+		port = 80; /* default HTTP port */
+
+	return fwupd_network_is_reachable(hostname, port, error);
 }
 
 typedef struct {

--- a/libfwupd/fwupd-network-fallback.c
+++ b/libfwupd/fwupd-network-fallback.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Mario Limonciello <superm1@kernel.org>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include <gio/gio.h>
+
+#include "fwupd-error.h"
+#include "fwupd-network.h"
+
+/**
+ * fwupd_network_is_reachable:
+ * @hostname: the hostname to check reachability for
+ * @port: the port number
+ * @error: (nullable): optional return location for an error
+ *
+ * Fallback implementation for non-Linux platforms.
+ * Uses GNetworkMonitor which is fine on these platforms (the performance
+ * issue with netlink route table enumeration is Linux-specific).
+ *
+ * Returns: %TRUE if the network is reachable
+ *
+ * Since: 2.1.6
+ **/
+gboolean
+fwupd_network_is_reachable(const gchar *hostname, gint port, GError **error) /* nocheck:name */
+{
+	GNetworkMonitor *monitor;
+	g_autoptr(GSocketConnectable) address = NULL;
+
+	/* check connectivity to the target host */
+	address = g_network_address_new(hostname, port);
+	monitor = g_network_monitor_get_default();
+	if (!g_network_monitor_can_reach(monitor, address, NULL, error))
+		return FALSE;
+
+	return TRUE;
+}

--- a/libfwupd/fwupd-network-linux.c
+++ b/libfwupd/fwupd-network-linux.c
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2026 Mario Limonciello <superm1@kernel.org>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include <fcntl.h>
+#include <gio/gio.h>
+#include <glib/gstdio.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+
+#include "fwupd-error.h"
+#include "fwupd-network.h"
+
+/*
+ * Defined locally rather than including linux/route.h, which pulls in
+ * linux/if.h and redefines IFF_* in conflict with net/if.h.
+ */
+#ifndef RTF_UP
+#define RTF_UP 0x0001 /* route usable */
+#endif
+
+/*
+ * fwupd_network_ensure_interface_up:
+ * @iface: the interface name to check
+ * @error: (nullable): optional return location for an error
+ *
+ * Use ioctl(SIOCGIFFLAGS) to verify the given interface is up
+ * and running.
+ *
+ * Returns: %TRUE on success, %FALSE if the interface is down or on error
+ */
+static gboolean
+fwupd_network_ensure_interface_up(const gchar *iface, GError **error)
+{
+	g_autofd gint fd = -1;
+	struct ifreq ifr = {};
+
+	fd = socket(AF_INET, SOCK_DGRAM, 0);
+	if (fd < 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_REACHABLE,
+			    "failed to create socket for interface %s",
+			    iface);
+		return FALSE;
+	}
+
+	strncpy(ifr.ifr_name, iface, IFNAMSIZ - 1);
+	ifr.ifr_name[IFNAMSIZ - 1] = '\0';
+
+	/* nocheck:blocked */
+	if (ioctl(fd, SIOCGIFFLAGS, &ifr) < 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_REACHABLE,
+			    "failed to get flags for interface %s",
+			    iface);
+		return FALSE;
+	}
+
+	if ((ifr.ifr_flags & IFF_UP) == 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_REACHABLE,
+			    "interface %s is not up",
+			    iface);
+		return FALSE;
+	}
+	if ((ifr.ifr_flags & IFF_RUNNING) == 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_REACHABLE,
+			    "interface %s is not running",
+			    iface);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+/*
+ * fwupd_network_has_default_route_with_iface:
+ * Check for a default route in /proc/net/route and verify
+ * its interface is up via ioctl.
+ *
+ * Returns: %TRUE if a valid default route exists and its
+ *          interface is IFF_UP and IFF_RUNNING.
+ */
+static gboolean
+fwupd_network_has_default_route_with_iface(GError **error)
+{
+	g_autofree gchar *route_data = NULL;
+	g_auto(GStrv) lines = NULL;
+
+	if (!g_file_get_contents("/proc/net/route", &route_data, NULL, error))
+		return FALSE;
+
+	/* the first line is a header, so skip it */
+	lines = g_strsplit(route_data, "\n", -1);
+	for (guint i = 1; lines[i] != NULL; i++) {
+		guint64 dst = 0;
+		guint64 flags = 0;
+		g_auto(GStrv) fields = NULL;
+		g_auto(GStrv) fields_filtered = NULL;
+		guint field_count = 0;
+		g_autoptr(GError) error_local = NULL;
+
+		/*
+		 * fields (tab/space separated) are:
+		 * Iface Destination Gateway Flags RefCnt Use Metric Mask ...
+		 */
+		fields = g_strsplit_set(lines[i], "\t ", -1);
+
+		/* filter out empty strings from consecutive delimiters */
+		for (guint j = 0; fields[j] != NULL; j++) {
+			if (fields[j][0] != '\0')
+				field_count++;
+		}
+		if (field_count < 4)
+			continue;
+
+		fields_filtered = g_new0(gchar *, field_count + 1);
+		for (guint j = 0, k = 0; fields[j] != NULL; j++) {
+			if (fields[j][0] != '\0')
+				fields_filtered[k++] = g_strdup(fields[j]);
+		}
+
+		/* a default route has a destination of 0.0.0.0 */
+		dst = g_ascii_strtoull(fields_filtered[1], NULL, 16); /* nocheck:blocked */
+		if (dst != 0x0)
+			continue;
+
+		/* the route has to be usable */
+		flags = g_ascii_strtoull(fields_filtered[3], NULL, 16); /* nocheck:blocked */
+		if ((flags & RTF_UP) == 0)
+			continue;
+
+		if (!fwupd_network_ensure_interface_up(fields_filtered[0], &error_local)) {
+			g_debug("%s", error_local->message);
+			continue;
+		}
+
+		/* found a working route with a valid interface */
+		return TRUE;
+	}
+
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_REACHABLE,
+			    "network is unreachable");
+	return FALSE;
+}
+
+/**
+ * fwupd_network_is_reachable:
+ * @hostname: the hostname to check reachability for
+ * @port: the port number
+ * @error: (nullable): optional return location for an error
+ *
+ * Check if the network is reachable using a multi-layered approach
+ * that avoids spawning subprocesses or using GNetworkMonitor.
+ *
+ * The check works as follows:
+ *
+ * 1. Parse /proc/net/route for a default route (RTF_UP)
+ * 2. Use ioctl(SIOCGIFFLAGS) to verify the interface is IFF_UP | IFF_RUNNING
+ * 3. Resolve the hostname to verify DNS works
+ * 4. connect() a UDP socket to verify routing (does not generate traffic)
+ *
+ * This avoids the GNetworkMonitor path which on Linux uses
+ * NetworkManager and pulls the entire kernel route table into memory,
+ * causing CPU/RAM exhaustion on systems with very large route tables
+ * (see #10525).
+ *
+ * Returns: %TRUE if the network is reachable
+ *
+ * Since: 2.1.6
+ **/
+gboolean
+fwupd_network_is_reachable(const gchar *hostname, gint port, GError **error)
+{
+	g_autofd gint fd = -1;
+	g_autoptr(GResolver) resolver = NULL;
+	g_autolist(GInetAddress) addresses = NULL;
+	g_autoptr(GInetAddress) inet_addr = NULL;
+
+	if (!fwupd_network_has_default_route_with_iface(error))
+		return FALSE;
+
+	/* verify DNS resolution works for the target host */
+	resolver = g_resolver_get_default();
+	addresses = g_resolver_lookup_by_name(resolver, hostname, NULL, error);
+	if (addresses == NULL)
+		return FALSE;
+
+	/* prefer IPv4, fall back to IPv6 */
+	for (GList *l = addresses; l != NULL; l = l->next) {
+		GInetAddress *addr_tmp = G_INET_ADDRESS(l->data);
+		if (g_inet_address_get_family(addr_tmp) == G_SOCKET_FAMILY_IPV4) {
+			inet_addr = g_object_ref(addr_tmp);
+			break;
+		}
+	}
+	/* if no IPv4, use first IPv6 */
+	if (inet_addr == NULL)
+		inet_addr = g_object_ref(G_INET_ADDRESS(addresses->data));
+
+	/* verify routing to the resolved address works */
+	if (g_inet_address_get_family(inet_addr) == G_SOCKET_FAMILY_IPV4) {
+		struct sockaddr_in addr = {};
+
+		fd = socket(AF_INET, SOCK_DGRAM | SOCK_CLOEXEC, IPPROTO_UDP);
+		if (fd < 0) {
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_REACHABLE,
+					    "network is unreachable");
+			return FALSE;
+		}
+
+		addr.sin_family = AF_INET;
+		addr.sin_port = htons(port);
+		/* nocheck:blocked - safe since we just verified it's IPv4 */
+		memcpy(&addr.sin_addr, g_inet_address_to_bytes(inet_addr), sizeof(addr.sin_addr));
+		if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_REACHABLE,
+					    "network is unreachable");
+			return FALSE;
+		}
+	} else {
+		struct sockaddr_in6 addr6 = {};
+
+		fd = socket(AF_INET6, SOCK_DGRAM | SOCK_CLOEXEC, IPPROTO_UDP);
+		if (fd < 0) {
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_REACHABLE,
+					    "network is unreachable");
+			return FALSE;
+		}
+
+		addr6.sin6_family = AF_INET6;
+		addr6.sin6_port = htons(port);
+		/* nocheck:blocked - safe since we just verified it's IPv6 */
+		memcpy(&addr6.sin6_addr,
+		       g_inet_address_to_bytes(inet_addr),
+		       sizeof(addr6.sin6_addr));
+		if (connect(fd, (struct sockaddr *)&addr6, sizeof(addr6)) < 0) {
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_REACHABLE,
+					    "network is unreachable");
+			return FALSE;
+		}
+	}
+
+	return TRUE;
+}

--- a/libfwupd/fwupd-network.h
+++ b/libfwupd/fwupd-network.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2026 Mario Limonciello <superm1@kernel.org>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <glib.h>
+
+gboolean
+fwupd_network_is_reachable(const gchar *hostname, gint port, GError **error);

--- a/libfwupd/meson.build
+++ b/libfwupd/meson.build
@@ -136,6 +136,12 @@ libfwupd_src = [
   'fwupd-version.c',
 ]
 
+if host_machine.system() == 'linux'
+  libfwupd_src += 'fwupd-network-linux.c'
+else
+  libfwupd_src += 'fwupd-network-fallback.c'
+endif
+
 fwupd_mapfile = 'fwupd.map'
 vflag = '-Wl,--version-script,@0@/@1@'.format(meson.current_source_dir(), fwupd_mapfile)
 fwupd = library(


### PR DESCRIPTION
…#10525)

GNetworkMonitor.get_default() on Linux uses NetworkManager which pulls the entire kernel route table into memory via netlink. On systems with very large route tables this causes CPU/RAM exhaustion during fwupdmgr refresh (#10525).

Fix by replacing the GNetworkMonitor path with a 3-layer approach using no subprocesses and no GNetworkMonitor:

  1. Parse /proc/net/route for a default route (RTF_UP)
  2. ioctl(SIOCGIFFLAGS) to verify the interface is IFF_UP | IFF_RUNNING
  3. UDP connect() to 8.8.8.8:53 with SO_SNDTIMEO as final sanity check

This runs in ~microseconds regardless of route table size.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
