### PR TITLE
trivial: Add urgency field to json from "fwupdmgr --json get-updates"…

### DIFF
--- a/libfwupd/fwupd-release.c
+++ b/libfwupd/fwupd-release.c
@@ -2160,6 +2160,11 @@ fwupd_release_add_json(FwupdCodec *codec, FwupdJsonObject *json_obj, FwupdCodecF
 	}
 	if (priv->sbom_url != NULL)
 		fwupd_json_object_add_string(json_obj, FWUPD_RESULT_KEY_SBOM_URL, priv->sbom_url);
+	if (priv->urgency != FWUPD_RELEASE_URGENCY_UNKNOWN) {
+		fwupd_json_object_add_string(json_obj,
+					     FWUPD_RESULT_KEY_URGENCY,
+					     fwupd_release_urgency_to_string(priv->urgency));
+	}
 	if (priv->vendor != NULL)
 		fwupd_json_object_add_string(json_obj, FWUPD_RESULT_KEY_VENDOR, priv->vendor);
 	if (priv->flags != FWUPD_RELEASE_FLAG_NONE) {


### PR DESCRIPTION
…. Addresses Issue #10524

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation

"Urgency" field was not previously in the `--json` export. It should now appear with a text field e.g. "high" , "critical", etc.

Has been compiled and tested on Debian Trixie.