### PR TITLE
jabra-gnp: use ENSURE_SEMVER flag to sanitise the device version

### DIFF
--- a/plugins/jabra-gnp/fu-jabra-gnp-child-device.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-child-device.c
@@ -403,6 +403,7 @@ fu_jabra_gnp_child_device_init(FuJabraGnpChildDevice *self)
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_USE_PROXY_FOR_OPEN);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_REFCOUNTED_PROXY);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_ADD_COUNTERPART_GUIDS);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_ENSURE_SEMVER);
 	fu_device_add_protocol(FU_DEVICE(self), "com.jabra.gnp");
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_firmware_gtype(FU_DEVICE(self), FU_TYPE_JABRA_GNP_FIRMWARE);

--- a/plugins/jabra-gnp/fu-jabra-gnp-common.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-common.c
@@ -285,15 +285,8 @@ fu_jabra_gnp_ensure_version(FuDevice *device, guint8 address, guint8 seq, GError
 	if (version == NULL)
 		return FALSE;
 
-	/* some devices append a few extra non number characters to the version, which can confuse
-	 * fwupd's formats, so remove it */
-	while (!(g_str_has_suffix(version, "0") || g_str_has_suffix(version, "1") ||
-		 g_str_has_suffix(version, "2") || g_str_has_suffix(version, "3") ||
-		 g_str_has_suffix(version, "4") || g_str_has_suffix(version, "5") ||
-		 g_str_has_suffix(version, "6") || g_str_has_suffix(version, "7") ||
-		 g_str_has_suffix(version, "8") || g_str_has_suffix(version, "9")))
-		version[strlen(version) - 1] = '\0';
-
+	/* some devices append a few extra non number characters to the version; the devices set
+	 * FU_DEVICE_PRIVATE_FLAG_ENSURE_SEMVER so fu_device_set_version() strips that for us */
 	fu_device_set_version(device, version);
 	return TRUE;
 }

--- a/plugins/jabra-gnp/fu-jabra-gnp-device.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-device.c
@@ -549,6 +549,7 @@ fu_jabra_gnp_device_init(FuJabraGnpDevice *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_DUAL_IMAGE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SELF_RECOVERY);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_ADD_COUNTERPART_GUIDS);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_ENSURE_SEMVER);
 	fu_device_add_protocol(FU_DEVICE(self), "com.jabra.gnp");
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_firmware_gtype(FU_DEVICE(self), FU_TYPE_JABRA_GNP_FIRMWARE);


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

**Out-of-bounds write trimming the version string**

`fu_jabra_gnp_ensure_version()` stripped trailing non-digit characters from the device version with `version[strlen(version) - 1] = '\0'` but never guarded against an empty string, so a version field holding no digit at all was trimmed down to "" and the next pass indexed `version[(gsize)-1]`, writing one byte before the heap allocation and then looping. The bytes come straight off the HID interrupt transfer during setup, so a misbehaving device reaches it (ASAN reports a heap-buffer-overflow write).

Per review, rather than guarding the bespoke loop this sets `FU_DEVICE_PRIVATE_FLAG_ENSURE_SEMVER` on both the parent and child devices so `fu_device_set_version()` builds a clean semver, and removes the trim loop entirely.
