### PR TITLE
libfwupd: check network reachability without enumerating the route table (#10525)

### DIFF
--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -30,6 +30,7 @@
 #include "fwupd-error.h"
 #include "fwupd-json-array.h"
 #include "fwupd-json-parser.h"
+#include "fwupd-network.h"
 #include "fwupd-plugin.h"
 #include "fwupd-release.h"
 #include "fwupd-remote-private.h"
@@ -5987,11 +5988,9 @@ fwupd_client_download_error_is_fatal(const GError *error)
 static gboolean
 fwupd_client_test_network(const gchar *url, GError **error)
 {
-#if GLIB_CHECK_VERSION(2, 66, 0)
-	GNetworkMonitor *monitor;
 	g_autoptr(GUri) uri = NULL;
-	g_autoptr(GError) error_monitor = NULL;
-	g_autoptr(GSocketConnectable) address = NULL;
+	const gchar *hostname;
+	gint port;
 
 	if (g_getenv("FWUPD_IGNORE_NETWORK_REACHABLE") != NULL)
 		return TRUE;
@@ -6000,22 +5999,20 @@ fwupd_client_test_network(const gchar *url, GError **error)
 	if (uri == NULL)
 		return FALSE;
 
-	address = g_network_address_parse(g_uri_get_host(uri), g_uri_get_port(uri), error);
-	if (address == NULL)
-		return FALSE;
-
-	monitor = g_network_monitor_get_default();
-	if (!g_network_monitor_can_reach(monitor, address, NULL, &error_monitor)) {
-		g_set_error(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_NOT_REACHABLE,
-			    "network is unreachable: %s",
-			    error_monitor->message);
+	hostname = g_uri_get_host(uri);
+	if (hostname == NULL || hostname[0] == '\0') {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "no hostname in URL");
 		return FALSE;
 	}
-#endif
-	/* success */
-	return TRUE;
+
+	port = g_uri_get_port(uri);
+	if (port == -1)
+		port = 80; /* default HTTP port */
+
+	return fwupd_network_is_reachable(hostname, port, error);
 }
 
 typedef struct {

--- a/libfwupd/fwupd-network-fallback.c
+++ b/libfwupd/fwupd-network-fallback.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Mario Limonciello <superm1@kernel.org>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include <gio/gio.h>
+
+#include "fwupd-error.h"
+#include "fwupd-network.h"
+
+/**
+ * fwupd_network_is_reachable:
+ * @hostname: the hostname to check reachability for
+ * @port: the port number
+ * @error: (nullable): optional return location for an error
+ *
+ * Fallback implementation for non-Linux platforms.
+ * Uses GNetworkMonitor which is fine on these platforms (the performance
+ * issue with netlink route table enumeration is Linux-specific).
+ *
+ * Returns: %TRUE if the network is reachable
+ *
+ * Since: 2.1.8
+ **/
+gboolean
+fwupd_network_is_reachable(const gchar *hostname, gint port, GError **error) /* nocheck:name */
+{
+	GNetworkMonitor *monitor;
+	g_autoptr(GSocketConnectable) address = NULL;
+
+	/* check connectivity to the target host */
+	address = g_network_address_new(hostname, port);
+	monitor = g_network_monitor_get_default();
+	if (!g_network_monitor_can_reach(monitor, address, NULL, error))
+		return FALSE;
+
+	return TRUE;
+}

--- a/libfwupd/fwupd-network-linux.c
+++ b/libfwupd/fwupd-network-linux.c
@@ -10,9 +10,12 @@
 #include <glib/gstdio.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
+#include <netdb.h>
+#include <netinet/in.h>
 #include <string.h>
 #include <sys/socket.h>
 
+#include "fwupd-build.h"
 #include "fwupd-error.h"
 #include "fwupd-network.h"
 
@@ -121,27 +124,67 @@ fwupd_network_addr_is_routable(GInetAddress *addr, GError **error)
 }
 
 typedef struct {
-	GMainLoop *loop;
+	gchar *hostname;
 	GList *addresses; /* (element-type GInetAddress) */
-	GError *error;
+	gboolean done;
+	gint refcount;
+	GMutex mutex;
+	GCond cond;
 } FwupdNetworkResolveData;
 
 static void
-fwupd_network_resolve_done_cb(GObject *source_object, GAsyncResult *res, gpointer user_data)
+fwupd_network_resolve_data_unref(FwupdNetworkResolveData *data)
 {
-	FwupdNetworkResolveData *data = user_data;
-	data->addresses =
-	    g_resolver_lookup_by_name_finish(G_RESOLVER(source_object), res, &data->error);
-	g_main_loop_quit(data->loop);
+	if (!g_atomic_int_dec_and_test(&data->refcount))
+		return;
+
+	g_list_free_full(data->addresses, g_object_unref);
+	g_free(data->hostname);
+	g_mutex_clear(&data->mutex);
+	g_cond_clear(&data->cond);
+	g_free(data);
 }
 
-static gboolean
-fwupd_network_resolve_timeout_cb(gpointer user_data)
+/*
+ * Runs on a throwaway thread so a stalled getaddrinfo() cannot block us past the
+ * timeout: if we give up first, the thread keeps running until the resolver
+ * returns and then drops the last reference, freeing the (now unwanted) result.
+ */
+static gpointer
+fwupd_network_resolve_worker(gpointer user_data)
 {
-	GCancellable *cancellable = G_CANCELLABLE(user_data);
-	/* makes the async lookup complete with G_IO_ERROR_CANCELLED */
-	g_cancellable_cancel(cancellable);
-	return G_SOURCE_REMOVE;
+	FwupdNetworkResolveData *data = user_data;
+	struct addrinfo hints = {.ai_socktype = SOCK_STREAM};
+	struct addrinfo *res = NULL;
+	GList *addresses = NULL;
+
+	if (getaddrinfo(data->hostname, NULL, &hints, &res) == 0) {
+		for (struct addrinfo *ai = res; ai != NULL; ai = ai->ai_next) {
+			GInetAddress *addr = NULL;
+
+			if (ai->ai_family == AF_INET) {
+				struct sockaddr_in *sin = (struct sockaddr_in *)ai->ai_addr;
+				addr = g_inet_address_new_from_bytes((guint8 *)&sin->sin_addr,
+								     G_SOCKET_FAMILY_IPV4);
+			} else if (ai->ai_family == AF_INET6) {
+				struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)ai->ai_addr;
+				addr = g_inet_address_new_from_bytes((guint8 *)&sin6->sin6_addr,
+								     G_SOCKET_FAMILY_IPV6);
+			}
+			if (addr != NULL)
+				addresses = g_list_prepend(addresses, addr);
+		}
+		freeaddrinfo(res);
+	}
+
+	g_mutex_lock(&data->mutex);
+	data->addresses = g_list_reverse(addresses);
+	data->done = TRUE;
+	g_cond_signal(&data->cond);
+	g_mutex_unlock(&data->mutex);
+
+	fwupd_network_resolve_data_unref(data);
+	return NULL;
 }
 
 /*
@@ -149,54 +192,60 @@ fwupd_network_resolve_timeout_cb(gpointer user_data)
  * @hostname: the hostname to resolve
  * @error: (nullable): optional return location for an error
  *
- * Resolve @hostname like g_resolver_lookup_by_name(), but give up after
- * %FWUPD_NETWORK_DNS_TIMEOUT_MS so a stalled resolver cannot block the caller
- * indefinitely.
+ * Resolve @hostname with getaddrinfo(), bounded by %FWUPD_NETWORK_DNS_TIMEOUT_MS.
+ * getaddrinfo() is used rather than GResolver because the latter, since GLib
+ * 2.85, instantiates the default GNetworkMonitor on the first lookup -- whose
+ * netlink backend dumps the entire kernel route table, the very cost #10525 is
+ * about. getaddrinfo() touches no GNetworkMonitor.
  *
  * Returns: (transfer full) (element-type GInetAddress): the addresses, or %NULL.
  */
 static GList *
 fwupd_network_lookup_by_name_timeout(const gchar *hostname, GError **error)
 {
-	g_autoptr(GMainContext) context = g_main_context_new();
-	g_autoptr(GMainLoop) loop = NULL;
-	g_autoptr(GResolver) resolver = g_resolver_get_default();
-	g_autoptr(GCancellable) cancellable = g_cancellable_new();
-	g_autoptr(GSource) timeout_source = NULL;
-	FwupdNetworkResolveData data = {0};
+	FwupdNetworkResolveData *data = g_new0(FwupdNetworkResolveData, 1);
+	GThread *thread;
+	GList *addresses = NULL;
+	gboolean done;
+	gint64 deadline;
 
-	g_main_context_push_thread_default(context);
-	loop = g_main_loop_new(context, FALSE);
-	data.loop = loop;
+	g_mutex_init(&data->mutex);
+	g_cond_init(&data->cond);
+	data->hostname = g_strdup(hostname);
+	data->refcount = 2; /* this function + the worker thread */
 
-	timeout_source = g_timeout_source_new(FWUPD_NETWORK_DNS_TIMEOUT_MS);
-	g_source_set_callback(timeout_source, fwupd_network_resolve_timeout_cb, cancellable, NULL);
-	g_source_attach(timeout_source, context);
+	thread = g_thread_new("fwupd-resolve", fwupd_network_resolve_worker, data);
+	g_thread_unref(thread); /* detached; reclaimed via the shared refcount */
 
-	g_resolver_lookup_by_name_async(resolver,
-					hostname,
-					cancellable,
-					fwupd_network_resolve_done_cb,
-					&data);
-	g_main_loop_run(loop);
+	deadline =
+	    g_get_monotonic_time() + (FWUPD_NETWORK_DNS_TIMEOUT_MS * G_TIME_SPAN_MILLISECOND);
+	g_mutex_lock(&data->mutex);
+	while (!data->done) {
+		if (!g_cond_wait_until(&data->cond, &data->mutex, deadline))
+			break; /* timed out */
+	}
+	done = data->done;
+	if (done)
+		addresses = g_steal_pointer(&data->addresses);
+	g_mutex_unlock(&data->mutex);
 
-	g_source_destroy(timeout_source);
-	g_main_context_pop_thread_default(context);
+	fwupd_network_resolve_data_unref(data);
 
-	if (data.addresses != NULL)
-		return data.addresses;
-
-	/* our timeout surfaces as a cancellation; turn it into a clear error */
-	if (g_error_matches(data.error, G_IO_ERROR, G_IO_ERROR_CANCELLED)) {
-		g_clear_error(&data.error);
+	if (!done) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_NOT_REACHABLE,
 				    "timed out resolving hostname");
 		return NULL;
 	}
-	g_propagate_error(error, g_steal_pointer(&data.error));
-	return NULL;
+	if (addresses == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_REACHABLE,
+				    "failed to resolve hostname");
+		return NULL;
+	}
+	return addresses;
 }
 
 /**

--- a/libfwupd/fwupd-network-linux.c
+++ b/libfwupd/fwupd-network-linux.c
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2026 Sorah Fukumori <her@sorah.jp>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include <gio/gio.h>
+#include <glib/gstdio.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <string.h>
+#include <sys/socket.h>
+
+#include "fwupd-error.h"
+#include "fwupd-network.h"
+
+/*
+ * Cap on the synchronous DNS lookup, which can be tens of seconds when
+ * DNS servers are unreachable.
+ */
+#define FWUPD_NETWORK_DNS_TIMEOUT_MS 2000
+
+/*
+ * fwupd_network_addr_is_routable:
+ * @addr: destination address
+ * @error: (nullable): optional return location for an error
+ *
+ * Ask the kernel whether it has a usable route to a single destination using
+ * RTM_GETROUTE with RTM_F_FIB_MATCH. Cost is independent of the kernel FIB
+ * size (#10525).
+ *
+ * Returns: %TRUE if a usable route exists.
+ */
+static gboolean
+fwupd_network_addr_is_routable(GInetAddress *addr, GError **error)
+{
+	g_autofd gint fd = -1;
+	gssize len;
+	gsize addr_len = g_inet_address_get_native_size(addr);
+	gboolean is_ipv6 = g_inet_address_get_family(addr) == G_SOCKET_FAMILY_IPV6;
+	struct sockaddr_nl sa = {.nl_family = AF_NETLINK};
+	const struct nlmsghdr *nlh;
+	const struct rtmsg *rtm;
+	struct {
+		struct nlmsghdr nlh;
+		struct rtmsg rtm;
+		struct rtattr rta;
+		guint8 addr[16];
+	} req = {0};
+	guint8 buf[8192] = {0};
+
+	req.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(req.rtm)) + RTA_LENGTH(addr_len);
+	req.nlh.nlmsg_type = RTM_GETROUTE;
+	req.nlh.nlmsg_flags = NLM_F_REQUEST;
+	req.nlh.nlmsg_seq = 1;
+	req.rtm.rtm_family = is_ipv6 ? AF_INET6 : AF_INET;
+	req.rtm.rtm_dst_len = addr_len * 8; /* subnet length, /128 or /64 bits */
+	req.rtm.rtm_flags = RTM_F_FIB_MATCH;
+	req.rta.rta_type = RTA_DST;
+	req.rta.rta_len = RTA_LENGTH(addr_len);
+
+	/* nocheck:blocked - bounded by addr_len, which is 4 or 16 by construction */
+	memcpy(req.addr, g_inet_address_to_bytes(addr), addr_len);
+
+	fd = socket(AF_NETLINK, SOCK_RAW | SOCK_CLOEXEC, NETLINK_ROUTE);
+	if (fd < 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_REACHABLE,
+				    "failed to create netlink socket");
+		return FALSE;
+	}
+	if (sendto(fd, &req, req.nlh.nlmsg_len, 0, (struct sockaddr *)&sa, sizeof(sa)) < 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_REACHABLE,
+				    "failed to send netlink route request");
+		return FALSE;
+	}
+	len = recv(fd, buf, sizeof(buf), 0);
+	if (len < 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_REACHABLE,
+				    "failed to receive netlink route reply");
+		return FALSE;
+	}
+
+	nlh = (const struct nlmsghdr *)buf;
+	if (!NLMSG_OK(nlh, (gsize)len)) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_REACHABLE,
+				    "truncated netlink route reply");
+		return FALSE;
+	}
+
+	/* an unreachable destination comes back as a netlink error */
+	if (nlh->nlmsg_type != RTM_NEWROUTE) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_REACHABLE,
+				    "network is unreachable");
+		return FALSE;
+	}
+
+	/* a route may still be a reject type (unreachable/blackhole/prohibit) */
+	rtm = NLMSG_DATA(nlh);
+	if (rtm->rtm_type == RTN_UNREACHABLE || rtm->rtm_type == RTN_BLACKHOLE ||
+	    rtm->rtm_type == RTN_PROHIBIT || rtm->rtm_type == RTN_THROW) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_REACHABLE,
+				    "route to destination is unreachable");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+typedef struct {
+	GMainLoop *loop;
+	GList *addresses; /* (element-type GInetAddress) */
+	GError *error;
+} FwupdNetworkResolveData;
+
+static void
+fwupd_network_resolve_done_cb(GObject *source_object, GAsyncResult *res, gpointer user_data)
+{
+	FwupdNetworkResolveData *data = user_data;
+	data->addresses =
+	    g_resolver_lookup_by_name_finish(G_RESOLVER(source_object), res, &data->error);
+	g_main_loop_quit(data->loop);
+}
+
+static gboolean
+fwupd_network_resolve_timeout_cb(gpointer user_data)
+{
+	GCancellable *cancellable = G_CANCELLABLE(user_data);
+	/* makes the async lookup complete with G_IO_ERROR_CANCELLED */
+	g_cancellable_cancel(cancellable);
+	return G_SOURCE_REMOVE;
+}
+
+/*
+ * fwupd_network_lookup_by_name_timeout:
+ * @hostname: the hostname to resolve
+ * @error: (nullable): optional return location for an error
+ *
+ * Resolve @hostname like g_resolver_lookup_by_name(), but give up after
+ * %FWUPD_NETWORK_DNS_TIMEOUT_MS so a stalled resolver cannot block the caller
+ * indefinitely.
+ *
+ * Returns: (transfer full) (element-type GInetAddress): the addresses, or %NULL.
+ */
+static GList *
+fwupd_network_lookup_by_name_timeout(const gchar *hostname, GError **error)
+{
+	g_autoptr(GMainContext) context = g_main_context_new();
+	g_autoptr(GMainLoop) loop = NULL;
+	g_autoptr(GResolver) resolver = g_resolver_get_default();
+	g_autoptr(GCancellable) cancellable = g_cancellable_new();
+	g_autoptr(GSource) timeout_source = NULL;
+	FwupdNetworkResolveData data = {0};
+
+	g_main_context_push_thread_default(context);
+	loop = g_main_loop_new(context, FALSE);
+	data.loop = loop;
+
+	timeout_source = g_timeout_source_new(FWUPD_NETWORK_DNS_TIMEOUT_MS);
+	g_source_set_callback(timeout_source, fwupd_network_resolve_timeout_cb, cancellable, NULL);
+	g_source_attach(timeout_source, context);
+
+	g_resolver_lookup_by_name_async(resolver,
+					hostname,
+					cancellable,
+					fwupd_network_resolve_done_cb,
+					&data);
+	g_main_loop_run(loop);
+
+	g_source_destroy(timeout_source);
+	g_main_context_pop_thread_default(context);
+
+	if (data.addresses != NULL)
+		return data.addresses;
+
+	/* our timeout surfaces as a cancellation; turn it into a clear error */
+	if (g_error_matches(data.error, G_IO_ERROR, G_IO_ERROR_CANCELLED)) {
+		g_clear_error(&data.error);
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_REACHABLE,
+				    "timed out resolving hostname");
+		return NULL;
+	}
+	g_propagate_error(error, g_steal_pointer(&data.error));
+	return NULL;
+}
+
+/**
+ * fwupd_network_is_reachable:
+ * @hostname: the hostname to check reachability for
+ * @port: the port number
+ * @error: (nullable): optional return location for an error
+ *
+ * Check if the network is reachable without spawning subprocesses, using
+ * GNetworkMonitor, or enumerating the kernel route table.
+ *
+ * The check works as follows:
+ *
+ * 1. Resolve the hostname; DNS working is itself a sign of connectivity, and
+ *    a concrete destination address is needed to query the kernel
+ * 2. For each resolved address, perform a single netlink query to the kernel
+ *    for FIB lookup and report reachable if the kernel has a usable route
+ *
+ * This avoids the GNetworkMonitor path, whose Linux netlink backend (used when
+ * NetworkManager is absent) dumps the entire kernel route table into memory,
+ * causing CPU/RAM exhaustion on systems with very large route tables (#10525).
+ *
+ * Returns: %TRUE if the network is reachable
+ *
+ * Since: 2.1.8
+ **/
+gboolean
+fwupd_network_is_reachable(const gchar *hostname, gint port, GError **error)
+{
+	g_autolist(GInetAddress) addresses = NULL;
+
+	g_debug("checking reachability of %s:%d", hostname, port);
+
+	/* verify DNS resolution works for the target host */
+	addresses = fwupd_network_lookup_by_name_timeout(hostname, error);
+	if (addresses == NULL)
+		return FALSE;
+
+	/* reachable if the kernel has a usable route to any resolved address */
+	for (GList *l = addresses; l != NULL; l = l->next) {
+		g_autoptr(GError) error_local = NULL;
+		if (fwupd_network_addr_is_routable(G_INET_ADDRESS(l->data), &error_local))
+			return TRUE;
+		g_debug("%s", error_local->message);
+	}
+
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_REACHABLE,
+			    "network is unreachable");
+	return FALSE;
+}

--- a/libfwupd/fwupd-network.h
+++ b/libfwupd/fwupd-network.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2026 Mario Limonciello <superm1@kernel.org>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <glib.h>
+
+gboolean
+fwupd_network_is_reachable(const gchar *hostname, gint port, GError **error);

--- a/libfwupd/meson.build
+++ b/libfwupd/meson.build
@@ -136,6 +136,12 @@ libfwupd_src = [
   'fwupd-version.c',
 ]
 
+if host_machine.system() == 'linux'
+  libfwupd_src += 'fwupd-network-linux.c'
+else
+  libfwupd_src += 'fwupd-network-fallback.c'
+endif
+
 fwupd_mapfile = 'fwupd.map'
 vflag = '-Wl,--version-script,@0@/@1@'.format(meson.current_source_dir(), fwupd_mapfile)
 fwupd = library(


### PR DESCRIPTION
This is a different approach to #10525 #10539. See https://github.com/fwupd/fwupd/issues/10525#issuecomment-4785136745 for rationale.

----

On Linux, g_network_monitor_get_default() falls back to a netlink-based monitor when NetworkManager is not running, and that monitor dumps the entire kernel route table (RTM_GETROUTE | NLM_F_DUMP) into memory. On systems with very large route tables this causes CPU/RAM exhaustion during fwupdmgr refresh (#10525).

Replace the GNetworkMonitor path with a lightweight check that spawns no subprocesses and does not use GNetworkMonitor:

  1. Resolve the target hostname, bounded by a 2s timeout so a stalled resolver cannot hang the refresh (GLib only gained a default resolver timeout in 2.78, and the floor here is 2.68)
  2. For each resolved address, issue a single RTM_GETROUTE + RTM_F_FIB_MATCH netlink lookup and treat the destination as reachable if the kernel has a usable route to it

The per-destination FIB lookup never scans the route table; its cost is a longest-prefix match, independent of how many routes exist, and so stays reasonably cheap no matter how large the table grows. It mirrors the kernel's real forwarding decision (admin-down nexthops are excluded and failover is applied) and is deliberately permissive: a carrier-down route still counts as reachable, since a false "unreachable" would needlessly block the refresh.

The implementation is split into platform-specific files:
- fwupd-network-linux.c: Linux netlink implementation
- fwupd-network-fallback.c: GNetworkMonitor on other platforms
- conditional compilation in meson.build selects the right one

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
