### PR TITLE
trivial: Fix a dmesg MCHI warning when resuming Intel systems

### DIFF
--- a/libfwupdplugin/fu-mei-device.c
+++ b/libfwupdplugin/fu-mei-device.c
@@ -140,6 +140,15 @@ fu_mei_device_probe(FuDevice *device, GError **error)
 {
 	FuMeiDevice *self = FU_MEI_DEVICE(device);
 
+	/* sanity check */
+	if (fu_udev_device_get_device_file(FU_UDEV_DEVICE(self)) == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no device file for MEI device");
+		return FALSE;
+	}
+
 	/* copy the PCI-specific vendor */
 	if (!fu_mei_device_pci_probe(self, error))
 		return FALSE;


### PR DESCRIPTION
Ignore the transient 'Dynamic Application Loader Host Interface' that appears on resume. This fixes the `failed to connect to MCHI: BootGuard Configuration has not been opened` warning on resume.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
