### PR TITLE
system76-launch: bound version string read in version cb

### DIFF
--- a/plugins/system76-launch/fu-system76-launch-device.c
+++ b/plugins/system76-launch/fu-system76-launch-device.c
@@ -108,7 +108,9 @@ fu_system76_launch_device_version_cb(FuDevice *device, gpointer user_data, GErro
 		return FALSE;
 	}
 
-	version = g_strdup_printf("%s", &data[2]);
+	version = fu_memstrsafe(data, sizeof(data), 0x2, sizeof(data) - 2, error);
+	if (version == NULL)
+		return FALSE;
 	fu_device_set_version(device, version);
 
 	return TRUE;


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

**Unbounded version string read in `version_cb`**

The 32-byte `data` buffer is filled in full by the device over the interrupt endpoint, but the version was built with `g_strdup_printf("%s", &data[2])`, so a reply without a NUL terminator lets `strlen` run off the end of the stack buffer. Bounded the read with `fu_memstrsafe()` so it stays within the array, which also keeps it consistent with the other device string reads.
