### PR TITLE
amd-kria: avoid truncating the FRU board area offset

### DIFF
--- a/plugins/amd-kria/fu-amd-kria-som-eeprom.c
+++ b/plugins/amd-kria/fu-amd-kria-som-eeprom.c
@@ -35,7 +35,7 @@ fu_amd_kria_som_eeprom_parse(FuFirmware *firmware,
 	FuAmdKriaSomEeprom *self = FU_AMD_KRIA_SOM_EEPROM(firmware);
 	guint8 str_len = 0;
 	guint8 str_offset = FU_STRUCT_BOARD_INFO_OFFSET_MANUFACTURER_LEN;
-	guint8 board_offset;
+	gsize board_offset;
 	const guint8 *buf;
 	gsize bufsz = 0;
 	g_autoptr(FuStructIpmiCommon) st_common = NULL;


### PR DESCRIPTION
fu_amd_kria_som_eeprom_parse scales the ipmi fru board-area offset byte to bytes with get_board_offset() * 8, since fru area offsets are stored in eight-byte units and can address up to 2040 bytes, but kept the result in a guint8. an offset field of 0x20 or above therefore wraps modulo 256 and the board info area is parsed and read at the wrong, smaller offset (0x20 lands back on the common header at 0). the eeprom is read over i2c in fu-amd-kria-device.c so the field is device-controlled. widen board_offset to gsize so the full range survives; the board_info parse and the following read already take gsize offsets and stay bounds-checked.