### PR TITLE
trivial: Hide a warning when probing an unsupported device that matched a quirk

### DIFF
--- a/src/fu-udev-backend.c
+++ b/src/fu-udev-backend.c
@@ -880,7 +880,8 @@ fu_udev_backend_get_device_parent(FuBackend *backend,
 				return FU_DEVICE(g_steal_pointer(&device_new));
 			}
 		} else {
-			if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND))
+			if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND) &&
+			    !g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED))
 				g_warning("failed to create device: %s", error_local->message);
 		}
 


### PR DESCRIPTION
Fixes:

    failed to create device: failed to probe: not probing

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
