### PR TITLE
intel-thunderbolt: Add Hayden Bridge (HBR) ID

### DIFF
--- a/libfwupdplugin/fu-intel-thunderbolt-nvm.c
+++ b/libfwupdplugin/fu-intel-thunderbolt-nvm.c
@@ -390,6 +390,7 @@ fu_intel_thunderbolt_nvm_parse(FuFirmware *firmware,
 			   {0x15EE, 3, FU_INTEL_THUNDERBOLT_NVM_FAMILY_BB, 0},
 			   {0x0B26, 4, FU_INTEL_THUNDERBOLT_NVM_FAMILY_GOSHEN_RIDGE, 2},
 			   {0x5786, 5, FU_INTEL_THUNDERBOLT_NVM_FAMILY_BARLOW_RIDGE, 2},
+			   {0x0D9C, 5, FU_INTEL_THUNDERBOLT_NVM_FAMILY_HAYDEN_BRIDGE, 0},
 			   /* Maple ridge devices
 			    * NOTE: These are expected to be flashed via UEFI capsules *not*
 			    * Thunderbolt plugin Flashing via fwupd will require matching kernel
@@ -508,6 +509,7 @@ fu_intel_thunderbolt_nvm_parse(FuFirmware *firmware,
 	case FU_INTEL_THUNDERBOLT_NVM_FAMILY_TITAN_RIDGE:
 	case FU_INTEL_THUNDERBOLT_NVM_FAMILY_GOSHEN_RIDGE:
 	case FU_INTEL_THUNDERBOLT_NVM_FAMILY_BARLOW_RIDGE:
+	case FU_INTEL_THUNDERBOLT_NVM_FAMILY_HAYDEN_BRIDGE:
 		if (!fu_input_stream_read_u16(
 			stream,
 			priv->sections[FU_INTEL_THUNDERBOLT_NVM_SECTION_DIGITAL] +

--- a/libfwupdplugin/fu-intel-thunderbolt.rs
+++ b/libfwupdplugin/fu-intel-thunderbolt.rs
@@ -26,6 +26,7 @@ enum FuIntelThunderboltNvmFamily {
     MapleRidge,
     GoshenRidge,
     BarlowRidge,
+    HaydenBridge,
 }
 
 #[derive(New)]


### PR DESCRIPTION
Didn't do a firmware update.
Can successfully decode firmware binary and shows the correct version:

```
> fwupdtool firmware-parse hbr_nvm.bin intel-thunderbolt-nvm
Loading…                 ▕⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣦▏
<firmware gtype="FuIntelThunderboltNvm">
  <flags>has-vid-pid,has-check-compatible</flags>
  <version>28.82</version>
  <version_raw>0x2882</version_raw>
  <version_format>bcd</version_format>
  <size_max>0x2000000</size_max>
  <data type="GInputStream" size="0x3c000" />
  <image_gtypes>
    <gtype>FuFirmware</gtype>
  </image_gtypes>
  <vendor_id>0x6b72</vendor_id>
  <device_id>0xd9c</device_id>
  <model_id>0x3500</model_id>
  <family>hayden-bridge</family>
  <is_host>false</is_host>
  <is_native>false</is_native>
  <generation>0x5</generation>
  <has_pd>true</has_pd>
  <section type="drom" offset="0x210" />
  <section type="arc-params" offset="0x610" />
  <firmware>
    <id>payload</id>
    <data type="GInputStream" size="0x3c000" />
  </firmware>
</firmware>
```