### PR TITLE
steelseries: Fix possible NULL pointer dereference when updating firmware

### DIFF
--- a/plugins/steelseries/fu-steelseries-sonic.c
+++ b/plugins/steelseries/fu-steelseries-sonic.c
@@ -107,6 +107,8 @@ fu_steelseries_sonic_read_from_ram_chunk(FuSteelseriesSonic *self,
 		return FALSE;
 
 	buf_res = fu_steelseries_device_response(FU_STEELSERIES_DEVICE(self), error);
+	if (buf_res == NULL)
+		return FALSE;
 	st_res = fu_struct_steelseries_sonic_read_from_ram_res_parse(buf_res->data,
 								     buf_res->len,
 								     0x0,


### PR DESCRIPTION
fu_steelseries_device_response() can return NULL on error but the return value was dereferenced without a check.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
