### PR TITLE
wacom-usb: Fix maybe impossible memory leaks in wacom-usb module error paths

### DIFF
--- a/plugins/wacom-usb/fu-wacom-usb-module-bluetooth.c
+++ b/plugins/wacom-usb/fu-wacom-usb-module-bluetooth.c
@@ -78,7 +78,7 @@ fu_wacom_usb_module_bluetooth_parse_blocks(const guint8 *data,
 					   GError **error)
 {
 	const guint8 preamble[] = {0x02, 0x00, 0x0f, 0x06, 0x01, 0x08, 0x01};
-	GPtrArray *blocks = g_ptr_array_new_with_free_func(g_free);
+	g_autoptr(GPtrArray) blocks = g_ptr_array_new_with_free_func(g_free);
 	for (guint addr = 0x0; addr < sz; addr += FU_WACOM_USB_MODULE_BLUETOOTH_PAYLOAD_SZ) {
 		g_autofree FuWacomUsbModuleBluetoothBlockData *bd = NULL;
 		gsize cdata_sz = FU_WACOM_USB_MODULE_BLUETOOTH_PAYLOAD_SZ;
@@ -110,7 +110,7 @@ fu_wacom_usb_module_bluetooth_parse_blocks(const guint8 *data,
 		    FU_WACOM_USB_MODULE_BLUETOOTH_PAYLOAD_SZ);
 		g_ptr_array_add(blocks, g_steal_pointer(&bd));
 	}
-	return blocks;
+	return g_steal_pointer(&blocks);
 }
 
 static gboolean

--- a/plugins/wacom-usb/fu-wacom-usb-module-scaler.c
+++ b/plugins/wacom-usb/fu-wacom-usb-module-scaler.c
@@ -31,7 +31,7 @@ typedef struct __attribute__((__packed__)) { /* nocheck:blocked */
 static GPtrArray *
 fu_wacom_usb_module_scaler_parse_blocks(const guint8 *data, gsize sz, GError **error)
 {
-	GPtrArray *blocks = g_ptr_array_new_with_free_func(g_free);
+	g_autoptr(GPtrArray) blocks = g_ptr_array_new_with_free_func(g_free);
 	for (guint addr = 0x0; addr < sz; addr += FU_WACOM_USB_MODULE_SCALER_PAYLOAD_SZ) {
 		g_autofree FuWacomUsbModuleScalerBlockData *bd = NULL;
 		gsize cdata_sz = FU_WACOM_USB_MODULE_SCALER_PAYLOAD_SZ;
@@ -57,7 +57,7 @@ fu_wacom_usb_module_scaler_parse_blocks(const guint8 *data, gsize sz, GError **e
 		bd->crc = fu_crc8(FU_CRC_KIND_B8_STANDARD, bd->cdata, sizeof(bd->cdata));
 		g_ptr_array_add(blocks, g_steal_pointer(&bd));
 	}
-	return blocks;
+	return g_steal_pointer(&blocks);
 }
 
 static gboolean

--- a/plugins/wacom-usb/fu-wacom-usb-module-sub-cpu.c
+++ b/plugins/wacom-usb/fu-wacom-usb-module-sub-cpu.c
@@ -83,7 +83,7 @@ fu_wacom_usb_module_sub_cpu_parse_chunks(FuSrecFirmware *srec_firmware,
 					 guint32 *data_len,
 					 GError **error)
 {
-	GPtrArray *chunks = g_ptr_array_new_with_free_func(g_free);
+	g_autoptr(GPtrArray) chunks = g_ptr_array_new_with_free_func(g_free);
 	guint record_num = 0;
 	GPtrArray *records = fu_srec_firmware_get_records(srec_firmware);
 
@@ -98,7 +98,7 @@ fu_wacom_usb_module_sub_cpu_parse_chunks(FuSrecFirmware *srec_firmware,
 		g_ptr_array_add(chunks, g_steal_pointer(&chunk));
 	}
 
-	return chunks;
+	return g_steal_pointer(&chunks);
 }
 
 static GBytes *


### PR DESCRIPTION
Use g_autoptr(GPtrArray) so the array is freed automatically when returning NULL on error, preventing leaks of the array and all elements added in prior loop iterations.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
