### PR TITLE
trivial: Fix FIRMARE typo in identifier names

### DIFF
--- a/libfwupdplugin/fu-dfu-firmware.c
+++ b/libfwupdplugin/fu-dfu-firmware.c
@@ -398,7 +398,7 @@ fu_dfu_firmware_init(FuDfuFirmware *self)
 	priv->vid = 0xffff;
 	priv->pid = 0xffff;
 	priv->release = 0xffff;
-	priv->dfu_version = FU_DFU_FIRMARE_VERSION_DFU_1_0;
+	priv->dfu_version = FU_DFU_FIRMWARE_VERSION_DFU_1_0;
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_CHECKSUM);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_VID_PID);
 	fu_firmware_set_size_max(FU_FIRMWARE(self), 128 * FU_MB);

--- a/libfwupdplugin/fu-dfu-firmware.h
+++ b/libfwupdplugin/fu-dfu-firmware.h
@@ -16,49 +16,39 @@ struct _FuDfuFirmwareClass {
 };
 
 /**
- * FU_DFU_FIRMARE_VERSION_UNKNOWN:
+ * FU_DFU_FIRMWARE_VERSION_UNKNOWN:
  *
  * Unknown version of the DFU standard in BCD format.
- *
- * Since: 1.6.1
  **/
-#define FU_DFU_FIRMARE_VERSION_UNKNOWN (0u)
+#define FU_DFU_FIRMWARE_VERSION_UNKNOWN (0u)
 
 /**
- * FU_DFU_FIRMARE_VERSION_DFU_1_0:
+ * FU_DFU_FIRMWARE_VERSION_DFU_1_0:
  *
  * The 1.0 version of the DFU standard in BCD format.
- *
- * Since: 1.6.1
  **/
-#define FU_DFU_FIRMARE_VERSION_DFU_1_0 (0x0100)
+#define FU_DFU_FIRMWARE_VERSION_DFU_1_0 (0x0100)
 
 /**
- * FU_DFU_FIRMARE_VERSION_DFU_1_1:
+ * FU_DFU_FIRMWARE_VERSION_DFU_1_1:
  *
  * The 1.1 version of the DFU standard in BCD format.
- *
- * Since: 1.6.1
  **/
-#define FU_DFU_FIRMARE_VERSION_DFU_1_1 (0x0110)
+#define FU_DFU_FIRMWARE_VERSION_DFU_1_1 (0x0110)
 
 /**
- * FU_DFU_FIRMARE_VERSION_DFUSE:
+ * FU_DFU_FIRMWARE_VERSION_DFUSE:
  *
  * The DfuSe version of the DFU standard in BCD format, defined by ST.
- *
- * Since: 1.6.1
  **/
-#define FU_DFU_FIRMARE_VERSION_DFUSE (0x011a)
+#define FU_DFU_FIRMWARE_VERSION_DFUSE (0x011a)
 
 /**
- * FU_DFU_FIRMARE_VERSION_ATMEL_AVR:
+ * FU_DFU_FIRMWARE_VERSION_ATMEL_AVR:
  *
  * The Atmel AVR version of the DFU standard in BCD format.
- *
- * Since: 1.6.1
  **/
-#define FU_DFU_FIRMARE_VERSION_ATMEL_AVR (0xff01)
+#define FU_DFU_FIRMWARE_VERSION_ATMEL_AVR (0xff01)
 
 FuFirmware *
 fu_dfu_firmware_new(void);

--- a/libfwupdplugin/fu-dfuse-firmware.c
+++ b/libfwupdplugin/fu-dfuse-firmware.c
@@ -294,7 +294,7 @@ fu_dfuse_firmware_write(FuFirmware *firmware, GError **error)
 static void
 fu_dfuse_firmware_init(FuDfuseFirmware *self)
 {
-	fu_dfu_firmware_set_version(FU_DFU_FIRMWARE(self), FU_DFU_FIRMARE_VERSION_DFUSE);
+	fu_dfu_firmware_set_version(FU_DFU_FIRMWARE(self), FU_DFU_FIRMWARE_VERSION_DFUSE);
 	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 255);
 	fu_firmware_set_size_max(FU_FIRMWARE(self), 256 * FU_MB);

--- a/libfwupdplugin/fu-uswid-firmware.c
+++ b/libfwupdplugin/fu-uswid-firmware.c
@@ -35,7 +35,7 @@ typedef struct {
 G_DEFINE_TYPE_WITH_PRIVATE(FuUswidFirmware, fu_uswid_firmware, FU_TYPE_FIRMWARE)
 #define GET_PRIVATE(o) (fu_uswid_firmware_get_instance_private(o))
 
-#define FU_USWID_FIRMARE_MINIMUM_HDRVER 1
+#define FU_USWID_FIRMWARE_MINIMUM_HDRVER 1
 
 static void
 fu_uswid_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuilderNode *bn)
@@ -97,7 +97,7 @@ fu_uswid_firmware_parse(FuFirmware *firmware,
 
 	/* hdrver */
 	priv->hdrver = fu_struct_uswid_get_hdrver(st);
-	if (priv->hdrver < FU_USWID_FIRMARE_MINIMUM_HDRVER) {
+	if (priv->hdrver < FU_USWID_FIRMWARE_MINIMUM_HDRVER) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_NOT_SUPPORTED,
@@ -357,7 +357,7 @@ static void
 fu_uswid_firmware_init(FuUswidFirmware *self)
 {
 	FuUswidFirmwarePrivate *priv = GET_PRIVATE(self);
-	priv->hdrver = FU_USWID_FIRMARE_MINIMUM_HDRVER;
+	priv->hdrver = FU_USWID_FIRMWARE_MINIMUM_HDRVER;
 	priv->compression = FU_USWID_PAYLOAD_COMPRESSION_NONE;
 	priv->format = FU_USWID_PAYLOAD_FORMAT_COSWID;
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_STORED_SIZE);

--- a/plugins/dfu/fu-dfu-device.c
+++ b/plugins/dfu/fu-dfu-device.c
@@ -123,7 +123,7 @@ fu_dfu_device_get_transfer_size(FuDfuDevice *self)
  *
  * Gets the DFU specification version supported by the device.
  *
- * Returns: integer, or 0 for unknown, e.g. %FU_DFU_FIRMARE_VERSION_DFU_1_1
+ * Returns: integer, or 0 for unknown, e.g. %FU_DFU_FIRMWARE_VERSION_DFU_1_1
  **/
 guint16
 fu_dfu_device_get_version(FuDfuDevice *self)
@@ -200,7 +200,7 @@ fu_dfu_device_parse_iface_data(FuDfuDevice *self, GBytes *iface_data, GError **e
 	attributes = fu_usb_dfu_descriptor_hdr_get_attributes(st);
 
 	/* ST-specific */
-	if (priv->version == FU_DFU_FIRMARE_VERSION_DFUSE &&
+	if (priv->version == FU_DFU_FIRMWARE_VERSION_DFUSE &&
 	    attributes & FU_DFU_DEVICE_ATTR_CAN_ACCELERATE)
 		priv->transfer_size = 4 * FU_KB;
 
@@ -301,24 +301,24 @@ fu_dfu_device_add_targets(FuDfuDevice *self, GError **error)
 		/* fix up the version */
 		if (priv->force_version != G_MAXUINT16)
 			priv->version = priv->force_version;
-		if (priv->version == FU_DFU_FIRMARE_VERSION_DFU_1_0 ||
-		    priv->version == FU_DFU_FIRMARE_VERSION_DFU_1_1) {
+		if (priv->version == FU_DFU_FIRMWARE_VERSION_DFU_1_0 ||
+		    priv->version == FU_DFU_FIRMWARE_VERSION_DFU_1_1) {
 			g_info("DFU v1.1");
-		} else if (priv->version == FU_DFU_FIRMARE_VERSION_ATMEL_AVR) {
+		} else if (priv->version == FU_DFU_FIRMWARE_VERSION_ATMEL_AVR) {
 			g_info("AVR-DFU support");
-			priv->version = FU_DFU_FIRMARE_VERSION_ATMEL_AVR;
-		} else if (priv->version == FU_DFU_FIRMARE_VERSION_DFUSE) {
+			priv->version = FU_DFU_FIRMWARE_VERSION_ATMEL_AVR;
+		} else if (priv->version == FU_DFU_FIRMWARE_VERSION_DFUSE) {
 			g_info("STM-DFU support");
 		} else if (priv->version == 0x0101) {
 			g_info("DFU v1.1 assumed");
-			priv->version = FU_DFU_FIRMARE_VERSION_DFU_1_1;
+			priv->version = FU_DFU_FIRMWARE_VERSION_DFU_1_1;
 		} else {
 			g_debug("DFU version 0x%04x invalid, v1.1 assumed", priv->version);
-			priv->version = FU_DFU_FIRMARE_VERSION_DFU_1_1;
+			priv->version = FU_DFU_FIRMWARE_VERSION_DFU_1_1;
 		}
 
 		/* set expected protocol */
-		if (priv->version == FU_DFU_FIRMARE_VERSION_DFUSE) {
+		if (priv->version == FU_DFU_FIRMWARE_VERSION_DFUSE) {
 			fu_device_add_protocol(FU_DEVICE(self), "com.st.dfuse");
 		} else {
 			fu_device_add_protocol(FU_DEVICE(self), "org.usb.dfu");
@@ -340,10 +340,10 @@ fu_dfu_device_add_targets(FuDfuDevice *self, GError **error)
 
 		/* create a target of the required type */
 		switch (priv->version) {
-		case FU_DFU_FIRMARE_VERSION_DFUSE:
+		case FU_DFU_FIRMWARE_VERSION_DFUSE:
 			target = fu_dfu_target_stm_new();
 			break;
-		case FU_DFU_FIRMARE_VERSION_ATMEL_AVR:
+		case FU_DFU_FIRMWARE_VERSION_ATMEL_AVR:
 			target = fu_dfu_target_avr_new();
 			break;
 		default:

--- a/plugins/dfu/fu-dfu-target.c
+++ b/plugins/dfu/fu-dfu-target.c
@@ -504,7 +504,7 @@ fu_dfu_target_check_status(FuDfuTarget *self, GError **error)
 
 	/* STM32-specific long errors */
 	status = fu_dfu_device_get_status(FU_DFU_DEVICE(proxy));
-	if (fu_dfu_device_get_version(FU_DFU_DEVICE(proxy)) == FU_DFU_FIRMARE_VERSION_DFUSE) {
+	if (fu_dfu_device_get_version(FU_DFU_DEVICE(proxy)) == FU_DFU_FIRMWARE_VERSION_DFUSE) {
 		if (status == FU_DFU_STATUS_ERR_VENDOR) {
 			g_set_error_literal(error,
 					    FWUPD_ERROR,
@@ -729,7 +729,7 @@ fu_dfu_target_download_chunk(FuDfuTarget *self,
 
 	/* for STM32 devices, the action only occurs when we do GetStatus --
 	 * and it can take a long time to complete! */
-	if (fu_dfu_device_get_version(FU_DFU_DEVICE(proxy)) == FU_DFU_FIRMARE_VERSION_DFUSE) {
+	if (fu_dfu_device_get_version(FU_DFU_DEVICE(proxy)) == FU_DFU_FIRMWARE_VERSION_DFUSE) {
 		if (!fu_dfu_device_refresh(FU_DFU_DEVICE(proxy), 35000, error))
 			return FALSE;
 	}


### PR DESCRIPTION
Rename FU_DFU_FIRMARE_VERSION_* to FU_DFU_FIRMWARE_VERSION_* and FU_USWID_FIRMARE_MINIMUM_HDRVER to FU_USWID_FIRMWARE_MINIMUM_HDRVER.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
