### PR TITLE
synaptics-mst: Add missing break in synaptics-mst switch statement

### DIFF
--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -1813,6 +1813,7 @@ fu_synaptics_mst_device_setup(FuDevice *device, GError **error)
 	case FU_SYNAPTICS_MST_FAMILY_SPYDER:
 	case FU_SYNAPTICS_MST_FAMILY_CARRERA:
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_DUAL_IMAGE);
+		break;
 	default:
 		break;
 	}


### PR DESCRIPTION
Add the missing break after the CARRERA case to prevent implicit fallthrough into the default case.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
