### PR TITLE
Require sealed memfd input to prevent TOCTOU attacks

### DIFF
--- a/libfwupd/fwupd-common.c
+++ b/libfwupd/fwupd-common.c
@@ -459,7 +459,7 @@ fwupd_unix_input_stream_from_bytes(GBytes *bytes, GError **error)
 #endif
 
 #ifdef HAVE_MEMFD_CREATE
-	fd = memfd_create("fwupd", MFD_CLOEXEC);
+	fd = memfd_create("fwupd", MFD_CLOEXEC | MFD_ALLOW_SEALING);
 #else
 	/* emulate in-memory file by an unlinked temporary file */
 	fd = g_mkstemp(tmp_file);
@@ -499,6 +499,16 @@ fwupd_unix_input_stream_from_bytes(GBytes *bytes, GError **error)
 			    fwupd_strerror(errno));
 		return NULL;
 	}
+#ifdef HAVE_MEMFD_CREATE
+	if (fcntl(fd, F_ADD_SEALS, F_SEAL_WRITE | F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_SEAL) < 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_FILE,
+			    "failed to seal memfd: %s",
+			    fwupd_strerror(errno));
+		return NULL;
+	}
+#endif
 	return G_UNIX_INPUT_STREAM(g_unix_input_stream_new(g_steal_fd(&fd), TRUE));
 }
 

--- a/src/fu-unix-seekable-input-stream-test.c
+++ b/src/fu-unix-seekable-input-stream-test.c
@@ -8,6 +8,9 @@
 
 #include <fcntl.h>
 #include <glib/gstdio.h>
+#ifdef HAVE_MEMFD_CREATE
+#include <sys/mman.h>
+#endif
 
 #include "fwupd-error.h"
 
@@ -77,6 +80,51 @@ fu_unix_seekable_input_stream_non_regular_func(void)
 #endif
 }
 
+static void
+fu_unix_seekable_input_stream_sealed_memfd_func(void)
+{
+#if defined(HAVE_GIO_UNIX) && defined(HAVE_MEMFD_CREATE)
+	g_autofd gint fd = -1;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GInputStream) stream = NULL;
+	const gchar data[] = "hello";
+
+	fd = memfd_create("fwupd-test", MFD_CLOEXEC | MFD_ALLOW_SEALING);
+	g_assert_cmpint(fd, >=, 0);
+	g_assert_cmpint(write(fd, data, sizeof(data)), ==, sizeof(data));
+	g_assert_cmpint(lseek(fd, 0, SEEK_SET), ==, 0);
+	g_assert_cmpint(fcntl(fd, F_ADD_SEALS, F_SEAL_WRITE | F_SEAL_SHRINK | F_SEAL_GROW), ==, 0);
+
+	stream = fu_unix_seekable_input_stream_new(g_steal_fd(&fd), TRUE, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(stream);
+#else
+	g_test_skip("No gio-unix-2.0 or memfd_create support, skipping");
+#endif
+}
+
+static void
+fu_unix_seekable_input_stream_unsealed_memfd_func(void)
+{
+#if defined(HAVE_GIO_UNIX) && defined(HAVE_MEMFD_CREATE)
+	g_autofd gint fd = -1;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GInputStream) stream = NULL;
+	const gchar data[] = "hello";
+
+	fd = memfd_create("fwupd-test", MFD_CLOEXEC | MFD_ALLOW_SEALING);
+	g_assert_cmpint(fd, >=, 0);
+	g_assert_cmpint(write(fd, data, sizeof(data)), ==, sizeof(data));
+	g_assert_cmpint(lseek(fd, 0, SEEK_SET), ==, 0);
+
+	stream = fu_unix_seekable_input_stream_new(g_steal_fd(&fd), TRUE, &error);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
+	g_assert_null(stream);
+#else
+	g_test_skip("No gio-unix-2.0 or memfd_create support, skipping");
+#endif
+}
+
 int
 main(int argc, char **argv)
 {
@@ -85,5 +133,9 @@ main(int argc, char **argv)
 	g_test_add_func("/fwupd/unix-seekable-input-stream", fu_unix_seekable_input_stream_func);
 	g_test_add_func("/fwupd/unix-seekable-input-stream/non-regular",
 			fu_unix_seekable_input_stream_non_regular_func);
+	g_test_add_func("/fwupd/unix-seekable-input-stream/sealed-memfd",
+			fu_unix_seekable_input_stream_sealed_memfd_func);
+	g_test_add_func("/fwupd/unix-seekable-input-stream/unsealed-memfd",
+			fu_unix_seekable_input_stream_unsealed_memfd_func);
 	return g_test_run();
 }

--- a/src/fu-unix-seekable-input-stream.c
+++ b/src/fu-unix-seekable-input-stream.c
@@ -8,6 +8,7 @@
 
 #include "config.h"
 
+#include <fcntl.h>
 #include <glib/gstdio.h>
 
 #include "fwupd-error.h"
@@ -115,6 +116,25 @@ fu_unix_seekable_input_stream_seekable_iface_init(GSeekableIface *iface)
 	iface->truncate_fn = fu_unix_seekable_input_stream_truncate;
 }
 
+static gboolean
+fu_unix_seekable_input_stream_verify_sealed(gint fd, GError **error)
+{
+#ifdef HAVE_MEMFD_CREATE
+	gint seals = fcntl(fd, F_GET_SEALS);
+	if (seals >= 0 && (seals & (F_SEAL_WRITE | F_SEAL_SHRINK | F_SEAL_GROW)) !=
+			      (F_SEAL_WRITE | F_SEAL_SHRINK | F_SEAL_GROW)) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_FILE,
+			    "fd is missing required seals, got 0x%x",
+			    (guint)seals);
+		return FALSE;
+	}
+#endif
+	/* success */
+	return TRUE;
+}
+
 /**
  * fu_unix_seekable_input_stream_new:
  * @fd: a UNIX file descriptor
@@ -156,6 +176,10 @@ fu_unix_seekable_input_stream_new(gint fd, gboolean close_fd, GError **error)
 			    st.st_mode);
 		return NULL;
 	}
+
+	/* if the fd supports sealing (i.e. is a memfd) then require immutability */
+	if (!fu_unix_seekable_input_stream_verify_sealed(fd, error))
+		return NULL;
 
 	/* success */
 	return g_steal_pointer(&stream);


### PR DESCRIPTION
Check F_GET_SEALS for F_SEAL_WRITE|F_SEAL_SHRINK on received fds and reject mutable descriptors. On the client side, seal memfds after writing with F_SEAL_WRITE|F_SEAL_SHRINK|F_SEAL_GROW|F_SEAL_SEAL.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
