### PR TITLE
genesys: reject short mask project IC type before indexing

### DIFF
--- a/plugins/genesys/fu-genesys-usbhub-device.c
+++ b/plugins/genesys/fu-genesys-usbhub-device.c
@@ -1108,6 +1108,13 @@ fu_genesys_usbhub_device_get_info_from_static_ts(FuGenesysUsbhubDevice *self,
 	}
 
 	project_ic_type = fu_struct_genesys_ts_static_get_mask_project_ic_type(self->st_static_ts);
+	if (project_ic_type == NULL || strlen(project_ic_type) < 6) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "invalid mask project IC type");
+		return FALSE;
+	}
 
 	/* verify chip model and revision */
 	self->spec.chip.revision = (10 * (project_ic_type[4] - '0')) + (project_ic_type[5] - '0');


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

ASan, on the mask project IC type parsed from the device static tool-string descriptor:

    fu-genesys-usbhub-device.c:1113: heap-buffer-overflow READ of size 1, 1 bytes after a 3-byte region

The `[char; 6]` getter returns a `fu_strsafe()` copy that stops at the first NUL, so a hub whose `mask_project_ic_type` bytes are short or contain an early NUL hands back a string narrower than six characters (or NULL). The code then reads `project_ic_type[4]`/`[5]` and `memcmp(project_ic_type, "3521", 4)` as if the field were always full width. Those bytes come straight off a USB string descriptor, so the length is device-controlled. Reject anything shorter than the six characters the parser dereferences.
