### PR TITLE
hsi: Mark Coreboot VBOOT as obsoleting BootGuard verified

### DIFF
--- a/plugins/tpm/fu-self-test.c
+++ b/plugins/tpm/fu-self-test.c
@@ -335,6 +335,9 @@ fu_tpm_coreboot_vboot_not_found_func(void)
 	g_assert_cmpint(fwupd_security_attr_get_result(attr),
 			==,
 			FWUPD_SECURITY_ATTR_RESULT_NOT_FOUND);
+	g_assert_false(
+	    fwupd_security_attr_has_obsolete(attr,
+					     FWUPD_SECURITY_ATTR_ID_INTEL_BOOTGUARD_VERIFIED));
 }
 
 static void
@@ -406,6 +409,9 @@ fu_tpm_coreboot_vboot_enabled_func(void)
 			==,
 			FWUPD_SECURITY_ATTR_RESULT_ENABLED);
 	g_assert_true(fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS));
+	g_assert_true(
+	    fwupd_security_attr_has_obsolete(attr,
+					     FWUPD_SECURITY_ATTR_ID_INTEL_BOOTGUARD_VERIFIED));
 }
 
 static void
@@ -478,6 +484,9 @@ fu_tpm_coreboot_vboot_not_enabled_func(void)
 			FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED);
 	g_assert_true(
 	    fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_FW));
+	g_assert_false(
+	    fwupd_security_attr_has_obsolete(attr,
+					     FWUPD_SECURITY_ATTR_ID_INTEL_BOOTGUARD_VERIFIED));
 }
 
 int

--- a/plugins/tpm/fu-tpm-plugin.c
+++ b/plugins/tpm/fu-tpm-plugin.c
@@ -302,6 +302,7 @@ fu_tpm_plugin_add_security_attr_coreboot_vboot(FuPlugin *plugin, FuSecurityAttrs
 		return;
 	}
 
+	fwupd_security_attr_add_obsolete(attr, FWUPD_SECURITY_ATTR_ID_INTEL_BOOTGUARD_VERIFIED);
 	fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
 }
 


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

When Coreboot VBOOT is enabled, mark `org.fwupd.hsi.IntelBootguard.Verified` as obsoleted. This keeps the HSI logic based on concrete attributes and uses the existing depsolve obsolete path rather than adding a synthetic firmware root-of-trust attribute.

The obsolete relationship is only added on the successful Coreboot VBOOT path; missing eventlog data or a Coreboot eventlog without VBOOT data does not obsolete BootGuard.

Tested:
- `meson test -C /home/sean/Documents/26.06_testing/fwupd_main_hsi_20260704T200443Z/build-pr10594 tpm-self-test fwupdplugin-security-attrs-test --print-errorlogs`