### PR TITLE
Do not require seals on regular tmpfs files

### DIFF
--- a/src/fu-unix-seekable-input-stream-test.c
+++ b/src/fu-unix-seekable-input-stream-test.c
@@ -104,6 +104,34 @@ fu_unix_seekable_input_stream_sealed_memfd_func(void)
 }
 
 static void
+fu_unix_seekable_input_stream_tmpfs_func(void)
+{
+#if defined(HAVE_GIO_UNIX) && defined(HAVE_MEMFD_CREATE)
+	g_autofd gint fd = -1;
+	g_autofree gchar *fn = g_strdup("/dev/shm/fwupd-test-XXXXXX");
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GInputStream) stream = NULL;
+	const gchar data[] = "hello";
+
+	/* regular files on tmpfs also support F_GET_SEALS, reporting F_SEAL_SEAL */
+	fd = g_mkstemp(fn);
+	if (fd < 0) {
+		g_test_skip("cannot create file on /dev/shm, skipping");
+		return;
+	}
+	g_assert_cmpint(g_unlink(fn), ==, 0);
+	g_assert_cmpint(write(fd, data, sizeof(data)), ==, sizeof(data));
+	g_assert_cmpint(lseek(fd, 0, SEEK_SET), ==, 0);
+
+	stream = fu_unix_seekable_input_stream_new(g_steal_fd(&fd), TRUE, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(stream);
+#else
+	g_test_skip("No gio-unix-2.0 or memfd_create support, skipping");
+#endif
+}
+
+static void
 fu_unix_seekable_input_stream_unsealed_memfd_func(void)
 {
 #if defined(HAVE_GIO_UNIX) && defined(HAVE_MEMFD_CREATE)
@@ -135,6 +163,8 @@ main(int argc, char **argv)
 			fu_unix_seekable_input_stream_non_regular_func);
 	g_test_add_func("/fwupd/unix-seekable-input-stream/sealed-memfd",
 			fu_unix_seekable_input_stream_sealed_memfd_func);
+	g_test_add_func("/fwupd/unix-seekable-input-stream/tmpfs",
+			fu_unix_seekable_input_stream_tmpfs_func);
 	g_test_add_func("/fwupd/unix-seekable-input-stream/unsealed-memfd",
 			fu_unix_seekable_input_stream_unsealed_memfd_func);
 	return g_test_run();

--- a/src/fu-unix-seekable-input-stream.c
+++ b/src/fu-unix-seekable-input-stream.c
@@ -121,8 +121,13 @@ fu_unix_seekable_input_stream_verify_sealed(gint fd, GError **error)
 {
 #ifdef HAVE_MEMFD_CREATE
 	gint seals = fcntl(fd, F_GET_SEALS);
-	if (seals >= 0 && (seals & (F_SEAL_WRITE | F_SEAL_SHRINK | F_SEAL_GROW)) !=
-			      (F_SEAL_WRITE | F_SEAL_SHRINK | F_SEAL_GROW)) {
+
+	/* regular files on tmpfs also support F_GET_SEALS and report F_SEAL_SEAL as sealing was
+	 * not enabled at creation time; they can never be sealed and so have to be treated like
+	 * files on any other filesystem */
+	if (seals >= 0 && (seals & F_SEAL_SEAL) == 0 &&
+	    (seals & (F_SEAL_WRITE | F_SEAL_SHRINK | F_SEAL_GROW)) !=
+		(F_SEAL_WRITE | F_SEAL_SHRINK | F_SEAL_GROW)) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INVALID_FILE,


### PR DESCRIPTION
Regular files on tmpfs also support F_GET_SEALS, reporting F_SEAL_SEAL as sealing was not enabled at file creation time. This made fu_unix_seekable_input_stream_new() reject any regular file living on tmpfs, e.g. a firmware archive passed from /tmp by the client, and also made the self tests fail when building fwupd in a tmpfs-backed build directory:

    fd is missing required seals, got 0x1 (FwupdError, 7)

Only enforce F_SEAL_WRITE|F_SEAL_SHRINK|F_SEAL_GROW when sealing is actually possible on the fd; files that can never be sealed are treated like regular files on any other filesystem.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
