### PR TITLE
efi-section: validate section size against the actual header length

### DIFF
--- a/libfwupdplugin/fu-efi-section.c
+++ b/libfwupdplugin/fu-efi-section.c
@@ -280,7 +280,7 @@ fu_efi_section_parse(FuFirmware *firmware,
 		size = fu_struct_efi_section_get_size(st);
 		stlen = st->buf->len;
 	}
-	if (size < FU_STRUCT_EFI_SECTION_SIZE) {
+	if (size < stlen) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INTERNAL,

--- a/libfwupdplugin/fu-firmware-test.c
+++ b/libfwupdplugin/fu-firmware-test.c
@@ -619,6 +619,30 @@ fu_firmware_ifwi_cpd_manifest_overflow_func(void)
 }
 
 static void
+fu_firmware_efi_section_extended_size_func(void)
+{
+	gboolean ret;
+	g_autoptr(FuFirmware) firmware = fu_efi_section_new();
+	g_autoptr(GByteArray) buf = g_byte_array_new();
+	g_autoptr(GBytes) blob = NULL;
+	g_autoptr(GError) error = NULL;
+
+	/* a size of 0xffffff selects the 8-byte extended header, but the declared
+	 * extended_size of 0x7 is smaller than that header, so size - headerlen
+	 * underflows; a value of exactly headerlen-1 wraps to G_MAXSIZE, which the
+	 * partial-stream helper reads as "to end of stream" rather than rejecting */
+	fu_byte_array_append_uint24(buf, 0xffffff, G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint8(buf, 0x19); /* raw */
+	fu_byte_array_append_uint32(buf, 0x7, G_LITTLE_ENDIAN);
+	fu_byte_array_set_size(buf, 0x20, 0x0);
+
+	blob = g_bytes_new(buf->data, buf->len);
+	ret = fu_firmware_parse_bytes(firmware, blob, 0x0, FU_FIRMWARE_PARSE_FLAG_NONE, &error);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL);
+	g_assert_false(ret);
+}
+
+static void
 fu_firmware_ifwi_fpt_func(void)
 {
 	g_autofree gchar *filename = NULL;
@@ -1185,6 +1209,8 @@ main(int argc, char **argv)
 	g_test_add_func("/fwupd/firmware/ifwi-cpd", fu_firmware_ifwi_cpd_func);
 	g_test_add_func("/fwupd/firmware/ifwi-cpd-manifest-overflow",
 			fu_firmware_ifwi_cpd_manifest_overflow_func);
+	g_test_add_func("/fwupd/firmware/efi-section-extended-size",
+			fu_firmware_efi_section_extended_size_func);
 	g_test_add_func("/fwupd/firmware/ifwi-fpt", fu_firmware_ifwi_fpt_func);
 	g_test_add_func("/fwupd/firmware/oprom", fu_firmware_oprom_func);
 	g_test_add_func("/fwupd/firmware/dfu", fu_firmware_dfu_func);


### PR DESCRIPTION
Type of pull request:

- [x] Code fix

A UEFI section can use the extended header (the 8-byte `FuStructEfiSection2`) by setting the small size field to `0xffffff` and carrying the real length in `extended_size`. The minimum-length check compares that size against `FU_STRUCT_EFI_SECTION_SIZE`, which is the 4-byte base header, so an extended section is only required to be as large as the shorter header it does not actually use. `offset` is then advanced by the true header length `stlen` (8 bytes) and `size - offset` is evaluated as a `gsize`, so a declared size below 8 underflows; a value of exactly 7 wraps to `G_MAXSIZE`, which `fu_partial_input_stream_new()` reads as "to the end of the stream" rather than rejecting, and the malformed section is parsed as covering the rest of the image. I came across it while comparing this path with `fu_efi_file_parse()`, which already checks against `st->buf->len`. Comparing against `stlen` mirrors that sibling and leaves the normal (non-extended) path unchanged, as there `stlen` equals `FU_STRUCT_EFI_SECTION_SIZE`. I have added a regression test that builds such a section and confirms it is now rejected.