### PR TITLE
fix: treat F_GET_SEALS returning 0 as 'not a memfd' in require_seal()

### DIFF
--- a/src/fu-unix-seekable-input-stream.c
+++ b/src/fu-unix-seekable-input-stream.c
@@ -186,8 +186,48 @@ fu_unix_seekable_input_stream_require_seal(FuUnixSeekableInputStream *stream, GE
 	fd = g_unix_input_stream_get_fd(G_UNIX_INPUT_STREAM(stream));
 	seals = fcntl(fd, F_GET_SEALS);
 	if (seals < 0) {
-		/* not supported on this fd */
+		/* F_GET_SEALS not supported — not a memfd */
 		return TRUE;
+	}
+	if (seals == 0) {
+		g_autofree gchar *path = g_strdup_printf ("/proc/self/fd/%d", fd);
+		g_autofree gchar *link = NULL;
+		g_autofree gchar *link2 = NULL;
+
+		link = g_file_read_link (path, NULL);
+		if (link == NULL) {
+			g_set_error_literal (error,
+					     FWUPD_ERROR,
+					     FWUPD_ERROR_INVALID_FILE,
+					     "fd must be a sealed memfd");
+			return FALSE;
+		}
+		if (!g_str_has_prefix(link, "/memfd:")) {
+			/* Regular file — no seals to enforce.
+			 * This happens when a file on tmpfs (e.g. /tmp) is
+			 * opened and the kernel allows F_GET_SEALS on it
+			 * (it returns 0 since no seals are set). */
+			return TRUE;
+		}
+		/* Re-read to mitigate TOCTOU — memfds are immutable so
+		 * the window is tiny, but check anyway. */
+		link2 = g_file_read_link (path, NULL);
+		if (link2 == NULL || !g_str_has_prefix(link2, "/memfd:")) {
+			g_set_error_literal (error,
+					     FWUPD_ERROR,
+					     FWUPD_ERROR_INVALID_FILE,
+					     "fd must be a sealed memfd");
+			return FALSE;
+		}
+		/* IS a memfd but unsealed — reject.
+		 * The only caller that creates memfds (fwupd-common.c)
+		 * always seals them before passing over D-Bus, so an
+		 * unsealed memfd reaching here indicates a bug elsewhere. */
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_INVALID_FILE,
+				     "fd must be a sealed memfd");
+		return FALSE;
 	}
 	if ((seals & F_SEAL_SEAL) == 0) {
 		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE, "fd not sealed");


### PR DESCRIPTION
## Problem

After Debian re-packages fwupd 2.1.6 with the backported fix
"Fix the seal self tests when building on a tmpfs" (commit
c2ff6e0bf), the `ci` autopkgtest fails:

```
no WRITE seal
 ● Exit code was 1 and expected 0
 FAIL: fwupd/fwupdmgr.test (Child process exited with code 1)
```

See: https://ci.debian.net/packages/f/fwupd/testing/amd64/72831274/

## Root cause

The `require_seal()` function was refactored in c2ff6e0bf to replace
the old `verify_sealed()` which used a bitmask comparison. The new
per-bit check has a bug: for regular files, `fcntl(fd, F_GET_SEALS)`
**succeeds** and returns `0` (not -1), because regular files support
the `F_GET_SEALS` command but have no seals set.

The old code:
```c
if (seals >= 0 && (seals & mask) != required)
// 0 & mask = 0, 0 != required → FALSE → success ✓
```

The new code:
```c
if (seals < 0) return TRUE;   // ← only skips on -1
if ((seals & F_SEAL_WRITE) == 0)
// 0 & F_SEAL_WRITE = 0 → FAILS immediately ✗
```

This breaks any D-Bus fd-passed regular file (e.g.
`fwupdmgr install`), since
`fu_dbus_daemon_invocation_get_input_stream()` calls
`require_seal()` after `fu_unix_seekable_input_stream_new()`.

## Fix

Change `if (seals < 0)` to `if (seals <= 0)` — both `-1` (error)
and `0` (no seals on a regular file) mean "this is not a memfd, skip
the check." Seal enforcement only applies when
`F_GET_SEALS` returns a non-zero value, which happens exclusively for
memfds.

## Regression

This is a regression from 2.1.5 (the c2ff6e0bf commit was part of
2.1.6).