### PR TITLE
Opt out FuLinearFirmware from the image typechecks

### DIFF
--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -1920,6 +1920,11 @@ static gboolean
 fu_firmware_check_image_gtype(FuFirmware *self, GType gtype, GError **error)
 {
 	FuFirmwareClassPrivate *cpriv = fu_firmware_get_class_private(FU_FIRMWARE_GET_CLASS(self));
+
+	/* certain GTypes can opt-out of this check */
+	if (fu_firmware_has_flag(self, FU_FIRMWARE_FLAG_NO_IMAGE_TYPE_CHECK))
+		return TRUE;
+
 	if (cpriv->image_gtypes_cnt == 0) {
 #ifndef SUPPORTED_BUILD
 		g_critical("%s did not add image GType %s with fu_firmware_add_image_gtype()",

--- a/libfwupdplugin/fu-firmware.rs
+++ b/libfwupdplugin/fu-firmware.rs
@@ -41,6 +41,7 @@ enum FuFirmwareFlags {
     IsLastImage = 1 << 9, // use for FuLinearFirmware when padding is present
     AllowLinear = 1 << 10, // parse as an array of firmwares
     IsAbstract = 1 << 11, // cannot parse a blob directly
+    NoImageTypeCheck = 1 << 12,
 }
 
 enum FuFirmwareAlignment {

--- a/libfwupdplugin/fu-linear-firmware.c
+++ b/libfwupdplugin/fu-linear-firmware.c
@@ -79,7 +79,6 @@ fu_linear_firmware_build(FuFirmware *firmware, XbNode *n, GError **error)
 				    tmp);
 			return FALSE;
 		}
-		fu_firmware_add_image_gtype(FU_FIRMWARE_GET_CLASS(firmware), priv->image_gtype);
 	}
 
 	/* success */
@@ -192,7 +191,6 @@ fu_linear_firmware_set_property(GObject *object,
 	switch (prop_id) {
 	case PROP_IMAGE_GTYPE:
 		priv->image_gtype = g_value_get_gtype(value);
-		fu_firmware_add_image_gtype(FU_FIRMWARE_GET_CLASS(self), priv->image_gtype);
 		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
@@ -204,6 +202,7 @@ static void
 fu_linear_firmware_init(FuLinearFirmware *self)
 {
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_NO_AUTO_DETECTION);
+	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_NO_IMAGE_TYPE_CHECK);
 }
 
 static void


### PR DESCRIPTION
The parser already checks the runtime-assigned image type (and there can only be one) and it is not appropriate to add the linear image GTypes to the per-class set.

This fixes a bug where the self tests use `FuLinearFirmare` with more that 10 different types of contained image.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
