### PR TITLE
trivial: Do not binary-compare the zlib-compressed zip file

### DIFF
--- a/libfwupdplugin/fu-firmware-test.c
+++ b/libfwupdplugin/fu-firmware-test.c
@@ -1176,7 +1176,7 @@ fu_firmware_builder_round_trip_func(void)
 	    },
 	    {
 		"zip-compressed.builder.xml",
-		"10792ff01b036ed89d11a6480694ccfd89c4d9fd",
+		NULL, /* not byte-identical */
 		FU_FIRMWARE_BUILDER_FLAG_NONE,
 	    },
 	};


### PR DESCRIPTION
On s390x we get a valid hardware-accelerated zlib bitstream, but it's different from the libz software version.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
