### PR TITLE
Add appstream IDs for BIOS settings

### DIFF
--- a/data/bios-settings.quirk
+++ b/data/bios-settings.quirk
@@ -1,0 +1,78 @@
+# Maps vendor-specific BIOS setting IDs to a registered fwupd AppStream ID.
+#
+# The hardware group key is the BIOS setting ID as constructed by fwupd, i.e.
+# `com.<driver>.<Name>`, and points at an abstract `org.fwupd.bios.*` ID. The
+# name and icon for each abstract ID are defined in fu-bios-settings.c so the
+# name can be marked for translation.
+#
+# The group key is automatically converted to a GUID on load.
+
+# Secure Boot
+[com.dell-wmi-sysman.SecureBoot]
+AppstreamId = org.fwupd.bios.secure-boot
+[com.thinklmi.SecureBoot]
+AppstreamId = org.fwupd.bios.secure-boot
+
+# Firmware update opt-in (BIOS updates delivered via LVFS or the OS)
+[com.dell-wmi-sysman.CapsuleFirmwareUpdate]
+AppstreamId = org.fwupd.bios.firmware-update-opt-in
+[com.thinklmi.WindowsUEFIFirmwareUpdate]
+AppstreamId = org.fwupd.bios.firmware-update-opt-in
+
+# Wake on LAN
+[com.dell-wmi-sysman.WakeOnLan]
+AppstreamId = org.fwupd.bios.wake-on-lan
+[com.thinklmi.WakeonLAN]
+AppstreamId = org.fwupd.bios.wake-on-lan
+
+# Boot-up Num Lock state
+[com.dell-wmi-sysman.NumLock]
+AppstreamId = org.fwupd.bios.num-lock
+[com.thinklmi.BootUpNumLockStatus]
+AppstreamId = org.fwupd.bios.num-lock
+
+# Memory encryption
+[com.thinklmi.AMDMemoryGuard]
+AppstreamId = org.fwupd.bios.memory-encryption
+
+# Video memory (UMA / dedicated graphics memory allocation)
+[com.hp-bioscfg.Dedicated_Graphics_Memory]
+AppstreamId = org.fwupd.bios.video-memory
+
+# Camera
+[com.dell-wmi-sysman.Camera]
+AppstreamId = org.fwupd.bios.camera.enabled
+
+# Microphone
+[com.dell-wmi-sysman.Microphone]
+AppstreamId = org.fwupd.bios.microphone.enabled
+
+# Bluetooth
+[com.dell-wmi-sysman.BluetoothDevice]
+AppstreamId = org.fwupd.bios.bluetooth.enabled
+
+# Wireless LAN
+[com.dell-wmi-sysman.WirelessLan]
+AppstreamId = org.fwupd.bios.wireless-lan.enabled
+
+# Fingerprint reader
+[com.dell-wmi-sysman.FingerprintReader]
+AppstreamId = org.fwupd.bios.fingerprint-reader.enabled
+
+# Touchscreen
+[com.dell-wmi-sysman.Touchscreen]
+AppstreamId = org.fwupd.bios.touchscreen.enabled
+
+# Integrated audio
+[com.dell-wmi-sysman.IntegratedAudio]
+AppstreamId = org.fwupd.bios.audio.enabled
+
+# Media/SD card reader
+[com.dell-wmi-sysman.SdCard]
+AppstreamId = org.fwupd.bios.media-card-reader.enabled
+[com.thinklmi.MediaCardReader]
+AppstreamId = org.fwupd.bios.media-card-reader.enabled
+
+# Keyboard backlight / illumination
+[com.dell-wmi-sysman.KeyboardIllumination]
+AppstreamId = org.fwupd.bios.keyboard-backlight.enabled

--- a/data/meson.build
+++ b/data/meson.build
@@ -33,6 +33,7 @@ if build_standalone
     install_mode: 'rw-r-----',
   )
   plugin_quirks += files(
+    'bios-settings.quirk',
     'cfi.quirk',
     'ds20.quirk',
     'power.quirk',

--- a/docs/bios-settings.md
+++ b/docs/bios-settings.md
@@ -178,6 +178,30 @@ All of those setting types are accepted by fwupd. It is expected that drivers or
 
 fwupd will also do a mapping where it can accept multiple cases or synonyms for words that are obviously positive or negative.  So for example if the setting expects `Enabled` but the user passes `tRUE` fwupd will map this into `Enabled` before sending it to the driver and the driver sending it to the firmware.
 
+## Vendor-neutral AppStream IDs
+
+Most BIOS settings are esoteric and vendor-specific, both in how they are named (`com.dell-wmi-sysman.SecureBoot` vs `com.thinklmi.SecureBoot`) and in the values they accept (`Enabled;Disabled;` vs `Disable,Enable`).  This makes it hard for a graphical client to present a small, consistent list of settings that are safe and useful for an end user to change.
+
+To help with this, fwupd 2.1.7 and later expose additional metadata on each `FwupdBiosSetting`:
+
+* An **AppStream ID** (`fwupd_bios_setting_get_appstream_id()`): a registered, vendor-neutral fwupd identifier such as `org.fwupd.bios.secure-boot`.  When two vendors expose the same conceptual setting, they share the same AppStream ID, so a client can group, label, and behave consistently across vendors.  Clients can show settings that have an AppStream ID by default and hide the rest behind an "advanced" view.
+* An **icon** (`fwupd_bios_setting_get_icon()`): an icon name for the abstract setting, e.g. `application-certificate`.
+
+The vendor-specific setting ID (`com.<driver>.<Name>`) is mapped to an abstract AppStream ID in the `bios-settings.quirk` data file:
+
+```ini
+[com.dell-wmi-sysman.SecureBoot]
+AppstreamId = org.fwupd.bios.secure-boot
+[com.thinklmi.SecureBoot]
+AppstreamId = org.fwupd.bios.secure-boot
+```
+
+The human-readable name and icon for each AppStream ID are defined in `fu-bios-settings.c`, where the name is marked for translation and localized at runtime by the client.  The description is available untranslated from `fwupd_bios_setting_get_description()`; clients translate it with `dgettext("fwupd", ...)`.
+
+Settings that are created by a plugin rather than parsed from the kernel firmware-attributes class (such as the AMD `Dedicated Video Memory` setting) set this metadata directly on the object.
+
+None of this metadata is sensitive, so it is always available to unprivileged clients even when the current value is not.
+
 ## libfwupd
 
 `fwupdmgr` internally uses `FwupdClient` to manage BIOS settings.  Any other clients that are interested in managing BIOS settings can use this library as well. A sample python application is included in the `contrib/` directory in the fwupd source tree.

--- a/libfwupd/fwupd-bios-setting-test.c
+++ b/libfwupd/fwupd-bios-setting-test.c
@@ -127,10 +127,19 @@ fwupd_bios_settings_func(void)
 	fwupd_bios_setting_set_filename(attr1, "current_value");
 	g_assert_cmpstr(fwupd_bios_setting_get_filename(attr1), ==, "current_value");
 
+	fwupd_bios_setting_set_appstream_id(attr1, "org.fwupd.bios.secure-boot");
+	g_assert_cmpstr(fwupd_bios_setting_get_appstream_id(attr1),
+			==,
+			"org.fwupd.bios.secure-boot");
+	fwupd_bios_setting_set_icon(attr1, "application-certificate");
+	g_assert_cmpstr(fwupd_bios_setting_get_icon(attr1), ==, "application-certificate");
+
 	str1 = fwupd_codec_to_string(FWUPD_CODEC(attr1));
 	ret = fu_test_compare_lines(str1,
 				    "FwupdBiosSetting:\n"
 				    "  Name:                 UEFISecureBoot\n"
+				    "  AppstreamId:          org.fwupd.bios.secure-boot\n"
+				    "  BiosSettingIcon:      application-certificate\n"
 				    "  Description:          Controls Secure boot\n"
 				    "  Filename:             /path/to/bar\n"
 				    "  BiosSettingType:      1\n"
@@ -152,6 +161,8 @@ fwupd_bios_settings_func(void)
 	ret = fu_test_compare_lines(str2,
 				    "FwupdBiosSetting:\n"
 				    "  Name:                 UEFISecureBoot\n"
+				    "  AppstreamId:          org.fwupd.bios.secure-boot\n"
+				    "  BiosSettingIcon:      application-certificate\n"
 				    "  Description:          Controls Secure boot\n"
 				    "  Filename:             /path/to/bar\n"
 				    "  BiosSettingType:      1\n"
@@ -173,6 +184,8 @@ fwupd_bios_settings_func(void)
 				    "  \"Name\": \"UEFISecureBoot\",\n"
 				    "  \"Description\": \"Controls Secure boot\",\n"
 				    "  \"Filename\": \"/path/to/bar\",\n"
+				    "  \"AppstreamId\": \"org.fwupd.bios.secure-boot\",\n"
+				    "  \"BiosSettingIcon\": \"application-certificate\",\n"
 				    "  \"BiosSettingCurrentValue\": \"Disabled\",\n"
 				    "  \"BiosSettingFilename\": \"current_value\",\n"
 				    "  \"BiosSettingReadOnly\": false,\n"
@@ -209,6 +222,8 @@ fwupd_bios_settings_func(void)
 	ret = fu_test_compare_lines(str4,
 				    "FwupdBiosSetting:\n"
 				    "  Name:                 UEFISecureBoot\n"
+				    "  AppstreamId:          org.fwupd.bios.secure-boot\n"
+				    "  BiosSettingIcon:      application-certificate\n"
 				    "  Description:          Controls Secure boot\n"
 				    "  Filename:             /path/to/bar\n"
 				    "  BiosSettingType:      1\n"
@@ -229,6 +244,8 @@ fwupd_bios_settings_func(void)
 				    "  \"Name\": \"UEFISecureBoot\",\n"
 				    "  \"Description\": \"Controls Secure boot\",\n"
 				    "  \"Filename\": \"/path/to/bar\",\n"
+				    "  \"AppstreamId\": \"org.fwupd.bios.secure-boot\",\n"
+				    "  \"BiosSettingIcon\": \"application-certificate\",\n"
 				    "  \"BiosSettingCurrentValue\": \"Disabled\",\n"
 				    "  \"BiosSettingFilename\": \"current_value\",\n"
 				    "  \"BiosSettingReadOnly\": false,\n"

--- a/libfwupd/fwupd-bios-setting.c
+++ b/libfwupd/fwupd-bios-setting.c
@@ -26,6 +26,8 @@ fwupd_bios_setting_finalize(GObject *object);
 typedef struct {
 	FwupdBiosSettingKind kind;
 	gchar *id;
+	gchar *appstream_id;
+	gchar *icon;
 	gchar *name;
 	gchar *description;
 	gchar *path;
@@ -91,6 +93,93 @@ fwupd_bios_setting_set_id(FwupdBiosSetting *self, const gchar *id)
 
 	g_free(priv->id);
 	priv->id = g_strdup(id);
+}
+
+/**
+ * fwupd_bios_setting_get_appstream_id
+ * @self: a #FwupdBiosSetting
+ *
+ * Gets the vendor-neutral fwupd AppStream identifier for this setting,
+ * e.g. `org.fwupd.bios.secure-boot`.
+ *
+ * This is a registered identifier documented by fwupd that allows software to
+ * treat the same conceptual setting consistently even though vendors name and
+ * value it differently.
+ *
+ * Returns: AppStream ID if set otherwise NULL
+ *
+ * Since: 2.1.7
+ **/
+const gchar *
+fwupd_bios_setting_get_appstream_id(FwupdBiosSetting *self)
+{
+	FwupdBiosSettingPrivate *priv = GET_PRIVATE(self);
+	g_return_val_if_fail(FWUPD_IS_BIOS_SETTING(self), NULL);
+	return priv->appstream_id;
+}
+
+/**
+ * fwupd_bios_setting_set_appstream_id
+ * @self: a #FwupdBiosSetting
+ * @appstream_id: (nullable): the fwupd AppStream identifier
+ *
+ * Sets the vendor-neutral fwupd AppStream identifier for this setting.
+ *
+ * Since: 2.1.7
+ **/
+void
+fwupd_bios_setting_set_appstream_id(FwupdBiosSetting *self, const gchar *appstream_id)
+{
+	FwupdBiosSettingPrivate *priv = GET_PRIVATE(self);
+	g_return_if_fail(FWUPD_IS_BIOS_SETTING(self));
+
+	/* not changed */
+	if (g_strcmp0(priv->appstream_id, appstream_id) == 0)
+		return;
+
+	g_free(priv->appstream_id);
+	priv->appstream_id = g_strdup(appstream_id);
+}
+
+/**
+ * fwupd_bios_setting_get_icon
+ * @self: a #FwupdBiosSetting
+ *
+ * Gets the icon name for this setting, e.g. `application-certificate`.
+ *
+ * Returns: icon name if set otherwise NULL
+ *
+ * Since: 2.1.7
+ **/
+const gchar *
+fwupd_bios_setting_get_icon(FwupdBiosSetting *self)
+{
+	FwupdBiosSettingPrivate *priv = GET_PRIVATE(self);
+	g_return_val_if_fail(FWUPD_IS_BIOS_SETTING(self), NULL);
+	return priv->icon;
+}
+
+/**
+ * fwupd_bios_setting_set_icon
+ * @self: a #FwupdBiosSetting
+ * @icon: (nullable): the icon name
+ *
+ * Sets the icon name for this setting.
+ *
+ * Since: 2.1.7
+ **/
+void
+fwupd_bios_setting_set_icon(FwupdBiosSetting *self, const gchar *icon)
+{
+	FwupdBiosSettingPrivate *priv = GET_PRIVATE(self);
+	g_return_if_fail(FWUPD_IS_BIOS_SETTING(self));
+
+	/* not changed */
+	if (g_strcmp0(priv->icon, icon) == 0)
+		return;
+
+	g_free(priv->icon);
+	priv->icon = g_strdup(icon);
 }
 
 /**
@@ -946,6 +1035,18 @@ fwupd_bios_setting_add_variant(FwupdCodec *codec, GVariantBuilder *builder, Fwup
 				      FWUPD_RESULT_KEY_BIOS_SETTING_ID,
 				      g_variant_new_string(priv->id));
 	}
+	if (priv->appstream_id != NULL) {
+		g_variant_builder_add(builder,
+				      "{sv}",
+				      FWUPD_RESULT_KEY_APPSTREAM_ID,
+				      g_variant_new_string(priv->appstream_id));
+	}
+	if (priv->icon != NULL) {
+		g_variant_builder_add(builder,
+				      "{sv}",
+				      FWUPD_RESULT_KEY_BIOS_SETTING_ICON,
+				      g_variant_new_string(priv->icon));
+	}
 	if (priv->name != NULL) {
 		g_variant_builder_add(builder,
 				      "{sv}",
@@ -1023,6 +1124,14 @@ fwupd_bios_setting_from_key_value(FwupdBiosSetting *self, const gchar *key, GVar
 		fwupd_bios_setting_set_id(self, fwupd_variant_get_string(value));
 		return;
 	}
+	if (g_strcmp0(key, FWUPD_RESULT_KEY_APPSTREAM_ID) == 0) {
+		fwupd_bios_setting_set_appstream_id(self, fwupd_variant_get_string(value));
+		return;
+	}
+	if (g_strcmp0(key, FWUPD_RESULT_KEY_BIOS_SETTING_ICON) == 0) {
+		fwupd_bios_setting_set_icon(self, fwupd_variant_get_string(value));
+		return;
+	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_NAME) == 0) {
 		fwupd_bios_setting_set_name(self, fwupd_variant_get_string(value));
 		return;
@@ -1085,6 +1194,12 @@ fwupd_bios_setting_from_json(FwupdCodec *codec, FwupdJsonObject *json_obj, GErro
 	fwupd_bios_setting_set_id(
 	    self,
 	    fwupd_json_object_get_string(json_obj, FWUPD_RESULT_KEY_BIOS_SETTING_ID, NULL));
+	fwupd_bios_setting_set_appstream_id(
+	    self,
+	    fwupd_json_object_get_string(json_obj, FWUPD_RESULT_KEY_APPSTREAM_ID, NULL));
+	fwupd_bios_setting_set_icon(
+	    self,
+	    fwupd_json_object_get_string(json_obj, FWUPD_RESULT_KEY_BIOS_SETTING_ICON, NULL));
 
 	fwupd_bios_setting_set_name(
 	    self,
@@ -1161,6 +1276,15 @@ fwupd_bios_setting_add_json(FwupdCodec *codec, FwupdJsonObject *json_obj, FwupdC
 		fwupd_json_object_add_string(json_obj, FWUPD_RESULT_KEY_FILENAME, priv->path);
 	if (priv->id != NULL)
 		fwupd_json_object_add_string(json_obj, FWUPD_RESULT_KEY_BIOS_SETTING_ID, priv->id);
+	if (priv->appstream_id != NULL) {
+		fwupd_json_object_add_string(json_obj,
+					     FWUPD_RESULT_KEY_APPSTREAM_ID,
+					     priv->appstream_id);
+	}
+	if (priv->icon != NULL)
+		fwupd_json_object_add_string(json_obj,
+					     FWUPD_RESULT_KEY_BIOS_SETTING_ICON,
+					     priv->icon);
 	if (priv->current_value != NULL) {
 		fwupd_json_object_add_string(json_obj,
 					     FWUPD_RESULT_KEY_BIOS_SETTING_CURRENT_VALUE,
@@ -1212,6 +1336,8 @@ fwupd_bios_setting_add_string(FwupdCodec *codec, guint idt, GString *str)
 
 	fwupd_codec_string_append(str, idt, FWUPD_RESULT_KEY_NAME, priv->name);
 	fwupd_codec_string_append(str, idt, FWUPD_RESULT_KEY_BIOS_SETTING_ID, priv->id);
+	fwupd_codec_string_append(str, idt, FWUPD_RESULT_KEY_APPSTREAM_ID, priv->appstream_id);
+	fwupd_codec_string_append(str, idt, FWUPD_RESULT_KEY_BIOS_SETTING_ICON, priv->icon);
 	fwupd_codec_string_append(str, idt, FWUPD_RESULT_KEY_DESCRIPTION, priv->description);
 	fwupd_codec_string_append(str, idt, FWUPD_RESULT_KEY_FILENAME, priv->path);
 	fwupd_codec_string_append_int(str, idt, FWUPD_RESULT_KEY_BIOS_SETTING_TYPE, priv->kind);
@@ -1293,6 +1419,8 @@ fwupd_bios_setting_finalize(GObject *object)
 
 	g_free(priv->current_value);
 	g_free(priv->id);
+	g_free(priv->appstream_id);
+	g_free(priv->icon);
 	g_free(priv->name);
 	g_free(priv->description);
 	g_free(priv->path);

--- a/libfwupd/fwupd-bios-setting.h
+++ b/libfwupd/fwupd-bios-setting.h
@@ -108,6 +108,17 @@ void
 fwupd_bios_setting_set_id(FwupdBiosSetting *self, const gchar *id) G_GNUC_NON_NULL(1);
 
 const gchar *
+fwupd_bios_setting_get_appstream_id(FwupdBiosSetting *self) G_GNUC_NON_NULL(1);
+void
+fwupd_bios_setting_set_appstream_id(FwupdBiosSetting *self, const gchar *appstream_id)
+    G_GNUC_NON_NULL(1);
+
+const gchar *
+fwupd_bios_setting_get_icon(FwupdBiosSetting *self) G_GNUC_NON_NULL(1);
+void
+fwupd_bios_setting_set_icon(FwupdBiosSetting *self, const gchar *icon) G_GNUC_NON_NULL(1);
+
+const gchar *
 fwupd_bios_setting_get_filename(FwupdBiosSetting *self) G_GNUC_NON_NULL(1);
 void
 fwupd_bios_setting_set_filename(FwupdBiosSetting *self, const gchar *filename) G_GNUC_NON_NULL(1);

--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -655,6 +655,14 @@ G_BEGIN_DECLS
  **/
 #define FWUPD_RESULT_KEY_BIOS_SETTING_FILENAME "BiosSettingFilename"
 /**
+ * FWUPD_RESULT_KEY_BIOS_SETTING_ICON: (skip)
+ *
+ * Result key to represent the icon name of a BIOS setting.
+ *
+ * The D-Bus type signature string is 's' i.e. a string.
+ **/
+#define FWUPD_RESULT_KEY_BIOS_SETTING_ICON "BiosSettingIcon"
+/**
  * FWUPD_RESULT_KEY_KERNEL_TARGET_VALUE: (skip)
  *
  * Result key to represent the target kernel setting.

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -1201,3 +1201,12 @@ LIBFWUPD_2.1.6 {
     fwupd_bios_setting_setup;
   local: *;
 } LIBFWUPD_2.1.4;
+
+LIBFWUPD_2.1.7 {
+  global:
+    fwupd_bios_setting_get_appstream_id;
+    fwupd_bios_setting_get_icon;
+    fwupd_bios_setting_set_appstream_id;
+    fwupd_bios_setting_set_icon;
+  local: *;
+} LIBFWUPD_2.1.6;

--- a/libfwupdplugin/fu-bios-settings-private.h
+++ b/libfwupdplugin/fu-bios-settings-private.h
@@ -7,10 +7,10 @@
 #pragma once
 
 #include "fu-bios-settings.h"
-#include "fu-path-store.h"
+#include "fu-context.h"
 
 FuBiosSettings *
-fu_bios_settings_new(FuPathStore *pstore);
+fu_bios_settings_new(FuContext *ctx);
 gboolean
 fu_bios_settings_setup(FuBiosSettings *self, GError **error) G_GNUC_NON_NULL(1);
 

--- a/libfwupdplugin/fu-bios-settings-test.c
+++ b/libfwupdplugin/fu-bios-settings-test.c
@@ -21,8 +21,10 @@ fu_bios_settings_load_func(void)
 	FwupdBiosSetting *setting;
 	FwupdBiosSettingKind kind;
 	g_autofree gchar *base_dir = NULL;
+	g_autofree gchar *quirks_dir = NULL;
 	g_autofree gchar *test_dir = NULL;
 	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(FuBiosSettings) p620_6_3_settings = NULL;
 	g_autoptr(GPtrArray) p620_6_3_items = NULL;
@@ -41,6 +43,14 @@ fu_bios_settings_load_func(void)
 		g_test_skip("Missing test data");
 		return;
 	}
+
+	/* load quirks so the canonical-ID and flags mappings are available */
+	quirks_dir = g_test_build_filename(G_TEST_DIST, "tests", "quirks.d", NULL);
+	fu_context_set_path(ctx, FU_PATH_KIND_DATADIR_QUIRKS, quirks_dir);
+	fu_context_add_flag(ctx, FU_CONTEXT_FLAG_NO_CACHE);
+	ret = fu_context_load(ctx, progress, FU_CONTEXT_LOAD_FLAG_NONE, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
 
 	/* load BIOS settings from a Lenovo P620 (with thinklmi driver problems) */
 	test_dir = g_build_filename(base_dir, "lenovo-p620", NULL);
@@ -185,6 +195,31 @@ fu_bios_settings_load_func(void)
 		g_assert_nonnull(setting);
 		ret = fwupd_bios_setting_get_read_only(setting);
 		g_assert_true(ret);
+
+		/* the AppStream ID comes from the quirk mapping; the icon and name
+		 * come from the abstract table in fu-bios-settings.c */
+		tmp = fwupd_bios_setting_get_appstream_id(setting);
+		g_assert_cmpstr(tmp, ==, "org.fwupd.bios.secure-boot");
+		tmp = fwupd_bios_setting_get_icon(setting);
+		g_assert_cmpstr(tmp, ==, "application-certificate");
+		tmp = fwupd_bios_setting_get_description(setting);
+		g_assert_cmpstr(tmp, ==, "Secure Boot");
+
+		/* the same setting can be looked up by its AppStream ID */
+		g_assert_true(fu_context_get_bios_setting(ctx, "org.fwupd.bios.secure-boot") ==
+			      setting);
+
+		/* a device-toggle setting also picks up its AppStream ID */
+		setting = fu_context_get_bios_setting(ctx, "com.dell-wmi-sysman.Camera");
+		g_assert_nonnull(setting);
+		tmp = fwupd_bios_setting_get_appstream_id(setting);
+		g_assert_cmpstr(tmp, ==, "org.fwupd.bios.camera.enabled");
+
+		/* an esoteric setting has no AppStream ID */
+		setting = fu_context_get_bios_setting(ctx, "com.dell-wmi-sysman.Asset");
+		g_assert_nonnull(setting);
+		tmp = fwupd_bios_setting_get_appstream_id(setting);
+		g_assert_null(tmp);
 	}
 	g_free(test_dir);
 
@@ -198,11 +233,48 @@ fu_bios_settings_load_func(void)
 	}
 }
 
+/* make sure setup still works, and canonical IDs stay unset, when quirks are disabled */
+static void
+fu_bios_settings_no_quirks_func(void)
+{
+	gboolean ret;
+	const gchar *tmp;
+	FwupdBiosSetting *setting;
+	g_autofree gchar *base_dir = NULL;
+	g_autofree gchar *test_dir = NULL;
+	g_autoptr(FuContext) ctx = fu_context_new_full(FU_CONTEXT_FLAG_NO_QUIRKS);
+	g_autoptr(GError) error = NULL;
+
+#ifdef _WIN32
+	g_test_skip("BIOS settings not supported on Windows");
+	return;
+#endif
+
+	base_dir = g_test_build_filename(G_TEST_DIST, "tests", "bios-attrs", NULL);
+	test_dir = g_build_filename(base_dir, "dell-xps13-9310", NULL);
+	if (!g_file_test(test_dir, G_FILE_TEST_EXISTS)) {
+		g_test_skip("Missing test data");
+		return;
+	}
+
+	fu_context_set_path(ctx, FU_PATH_KIND_SYSFSDIR_FW_ATTRIB, test_dir);
+	ret = fu_context_reload_bios_settings(ctx, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* the setting still loads, but has no AppStream ID */
+	setting = fu_context_get_bios_setting(ctx, "com.dell-wmi-sysman.SecureBoot");
+	g_assert_nonnull(setting);
+	tmp = fwupd_bios_setting_get_appstream_id(setting);
+	g_assert_null(tmp);
+}
+
 int
 main(int argc, char **argv)
 {
 	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 	g_test_add_func("/fwupd/bios-settings/load", fu_bios_settings_load_func);
+	g_test_add_func("/fwupd/bios-settings/no-quirks", fu_bios_settings_no_quirks_func);
 	return g_test_run();
 }

--- a/libfwupdplugin/fu-bios-settings.c
+++ b/libfwupdplugin/fu-bios-settings.c
@@ -15,14 +15,18 @@
 #include "fu-bios-setting.h"
 #include "fu-bios-settings-private.h"
 #include "fu-common.h"
+#include "fu-context.h"
 #include "fu-path.h"
+#include "fu-quirks.h"
 #include "fu-string.h"
+
+#include "fwupd-bios-setting-struct.h"
 
 #define LENOVO_READ_ONLY_NEEDLE "[Status:ShowOnly]"
 
 struct _FuBiosSettings {
 	GObject parent_instance;
-	FuPathStore *pstore;
+	FuContext *ctx; /* weak: the context owns us */
 	GHashTable *descriptions;
 	GHashTable *read_only;
 	GPtrArray *attrs;
@@ -40,8 +44,8 @@ static void
 fu_bios_settings_finalize(GObject *obj)
 {
 	FuBiosSettings *self = FU_BIOS_SETTINGS(obj);
-	if (self->pstore != NULL)
-		g_object_unref(self->pstore);
+	if (self->ctx != NULL)
+		g_object_remove_weak_pointer(G_OBJECT(self->ctx), (gpointer *)&self->ctx);
 	g_ptr_array_unref(self->attrs);
 	g_hash_table_unref(self->descriptions);
 	g_hash_table_unref(self->read_only);
@@ -350,6 +354,58 @@ fu_bios_settings_populate_read_only(FuBiosSettings *self)
 			    g_strdup(_("Enabled")));
 }
 
+/* the abstract name and icon for each fwupd AppStream ID; the name is marked
+ * for translation with N_() and translated at runtime by the client. The
+ * vendor-specific ID to AppStream-ID mapping lives in bios-settings.quirk. */
+static const struct {
+	const gchar *appstream_id;
+	const gchar *name;
+	const gchar *icon;
+} fu_bios_settings_appstream[] = {
+    {"org.fwupd.bios.secure-boot", N_("Secure Boot"), "application-certificate"},
+    {"org.fwupd.bios.firmware-update-opt-in", N_("Firmware Update Opt-in"), "system-software-update"},
+    {"org.fwupd.bios.wake-on-lan", N_("Wake on LAN"), "network-wired"},
+    {"org.fwupd.bios.num-lock", N_("Num Lock"), "input-keyboard"},
+    {"org.fwupd.bios.memory-encryption", N_("Memory Encryption"), "security-high"},
+    {"org.fwupd.bios.video-memory", N_("Video Memory"), "video-display"},
+    {"org.fwupd.bios.camera.enabled", N_("Camera"), "camera-web"},
+    {"org.fwupd.bios.microphone.enabled", N_("Microphone"), "audio-input-microphone"},
+    {"org.fwupd.bios.bluetooth.enabled", N_("Bluetooth"), "bluetooth"},
+    {"org.fwupd.bios.wireless-lan.enabled", N_("Wireless LAN"), "network-wireless"},
+    {"org.fwupd.bios.fingerprint-reader.enabled", N_("Fingerprint Reader"), "auth-fingerprint"},
+    {"org.fwupd.bios.touchscreen.enabled", N_("Touchscreen"), "input-touchpad"},
+    {"org.fwupd.bios.audio.enabled", N_("Audio"), "audio-card"},
+    {"org.fwupd.bios.media-card-reader.enabled", N_("Media Card Reader"), "media-flash"},
+    {"org.fwupd.bios.keyboard-backlight.enabled", N_("Keyboard Backlight"), "input-keyboard"},
+};
+
+static void
+fu_bios_settings_set_appstream(FuBiosSettings *self, FwupdBiosSetting *attr)
+{
+	const gchar *id = fwupd_bios_setting_get_id(attr);
+	const gchar *appstream_id;
+	g_autofree gchar *guid = NULL;
+
+	if (self->ctx == NULL || id == NULL)
+		return;
+
+	/* the hardware-assigned setting points at an abstract fwupd AppStream ID */
+	guid = fwupd_guid_hash_string(id);
+	appstream_id = fu_context_lookup_quirk_by_id(self->ctx, guid, FU_QUIRKS_APPSTREAM_ID);
+	if (appstream_id == NULL)
+		return;
+	fwupd_bios_setting_set_appstream_id(attr, appstream_id);
+
+	/* the abstract thing carries the name (translated by the client) and icon */
+	for (guint i = 0; i < G_N_ELEMENTS(fu_bios_settings_appstream); i++) {
+		if (g_strcmp0(appstream_id, fu_bios_settings_appstream[i].appstream_id) != 0)
+			continue;
+		fwupd_bios_setting_set_description(attr, fu_bios_settings_appstream[i].name);
+		fwupd_bios_setting_set_icon(attr, fu_bios_settings_appstream[i].icon);
+		break;
+	}
+}
+
 static void
 fu_bios_settings_combination_fixups(FuBiosSettings *self)
 {
@@ -384,6 +440,7 @@ fu_bios_settings_setup(FuBiosSettings *self, GError **error)
 {
 	guint count = 0;
 	const gchar *sysfsfwdir = NULL;
+	FuPathStore *pstore = NULL;
 	g_autoptr(GDir) class_dir = NULL;
 	g_autoptr(GError) error_local = NULL;
 
@@ -399,8 +456,12 @@ fu_bios_settings_setup(FuBiosSettings *self, GError **error)
 	if (g_hash_table_size(self->read_only) == 0)
 		fu_bios_settings_populate_read_only(self);
 
-	sysfsfwdir =
-	    fu_path_store_get_path(self->pstore, FU_PATH_KIND_SYSFSDIR_FW_ATTRIB, &error_local);
+	if (self->ctx == NULL) {
+		g_debug("ignoring BIOS settings: no context set");
+		return TRUE;
+	}
+	pstore = fu_context_get_path_store(self->ctx);
+	sysfsfwdir = fu_path_store_get_path(pstore, FU_PATH_KIND_SYSFSDIR_FW_ATTRIB, &error_local);
 	if (sysfsfwdir == NULL) {
 		g_debug("ignoring BIOS settings: %s", error_local->message);
 		return TRUE;
@@ -445,6 +506,12 @@ fu_bios_settings_setup(FuBiosSettings *self, GError **error)
 	} while (TRUE);
 	g_info("loaded %u BIOS settings", count);
 
+	/* apply the abstract AppStream ID, icon and name from quirks */
+	for (guint i = 0; i < self->attrs->len; i++) {
+		FwupdBiosSetting *attr = g_ptr_array_index(self->attrs, i);
+		fu_bios_settings_set_appstream(self, attr);
+	}
+
 	fu_bios_settings_combination_fixups(self);
 
 	return TRUE;
@@ -461,9 +528,10 @@ fu_bios_settings_init(FuBiosSettings *self)
 /**
  * fu_bios_settings_get_attr:
  * @self: a #FuBiosSettings
- * @val: the attribute ID or name to check for
+ * @val: the attribute ID, name or AppStream ID to check for
  *
- * Returns: (transfer none): the attribute with the given ID or name or NULL if it doesn't exist.
+ * Returns: (transfer none): the attribute with the given ID, name or AppStream ID, or NULL if it
+ * doesn't exist.
  *
  * Since: 1.8.4
  **/
@@ -475,9 +543,9 @@ fu_bios_settings_get_attr(FuBiosSettings *self, const gchar *val)
 
 	for (guint i = 0; i < self->attrs->len; i++) {
 		FwupdBiosSetting *attr = g_ptr_array_index(self->attrs, i);
-		const gchar *tmp_id = fwupd_bios_setting_get_id(attr);
-		const gchar *tmp_name = fwupd_bios_setting_get_name(attr);
-		if (g_strcmp0(val, tmp_id) == 0 || g_strcmp0(val, tmp_name) == 0)
+		if (g_strcmp0(val, fwupd_bios_setting_get_id(attr)) == 0 ||
+		    g_strcmp0(val, fwupd_bios_setting_get_name(attr)) == 0 ||
+		    g_strcmp0(val, fwupd_bios_setting_get_appstream_id(attr)) == 0)
 			return attr;
 	}
 	return NULL;
@@ -642,20 +710,22 @@ fu_bios_settings_is_supported(FuBiosSettings *self)
 
 /**
  * fu_bios_settings_new:
- * @pstore: (nullable): a #FuPathStore
+ * @ctx: (nullable): a #FuContext
  *
  * Returns: #FuBiosSettings
  *
  * Since: 1.8.4
  **/
 FuBiosSettings *
-fu_bios_settings_new(FuPathStore *pstore)
+fu_bios_settings_new(FuContext *ctx)
 {
 	FuBiosSettings *self;
-	g_return_val_if_fail(FU_IS_PATH_STORE(pstore) || pstore == NULL, NULL);
+	g_return_val_if_fail(FU_IS_CONTEXT(ctx) || ctx == NULL, NULL);
 	self = g_object_new(FU_TYPE_FIRMWARE_ATTRS, NULL);
-	if (pstore != NULL)
-		self->pstore = g_object_ref(pstore);
+	if (ctx != NULL) {
+		self->ctx = ctx;
+		g_object_add_weak_pointer(G_OBJECT(ctx), (gpointer *)&self->ctx);
+	}
 	return self;
 }
 

--- a/libfwupdplugin/fu-context.c
+++ b/libfwupdplugin/fu-context.c
@@ -1154,6 +1154,9 @@ fu_context_lookup_quirk_by_id(FuContext *self, const gchar *guid, const gchar *k
 	g_return_val_if_fail(guid != NULL, NULL);
 	g_return_val_if_fail(key != NULL, NULL);
 
+	if (priv->flags & FU_CONTEXT_FLAG_NO_QUIRKS)
+		return NULL;
+
 	/* exact ID */
 	return fu_quirks_lookup_by_id(priv->quirks, guid, key);
 }
@@ -3017,7 +3020,7 @@ fu_context_init(FuContext *self)
 						      (GDestroyNotify)g_ptr_array_unref);
 	priv->firmware_gtypes = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
 	priv->quirks = fu_quirks_new(self);
-	priv->host_bios_settings = fu_bios_settings_new(priv->pstore);
+	priv->host_bios_settings = fu_bios_settings_new(self);
 	priv->esp_volumes = g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
 	priv->runtime_versions = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 	priv->compile_versions = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);

--- a/libfwupdplugin/fu-quirks.c
+++ b/libfwupdplugin/fu-quirks.c
@@ -1129,6 +1129,7 @@ fu_quirks_init(FuQuirks *self)
 	fu_quirks_add_possible_key(self, FU_QUIRKS_PRIORITY);
 	fu_quirks_add_possible_key(self, FU_QUIRKS_PROTOCOL);
 	fu_quirks_add_possible_key(self, FU_QUIRKS_PROXY_GUID);
+	fu_quirks_add_possible_key(self, FU_QUIRKS_APPSTREAM_ID);
 	fu_quirks_add_possible_key(self, FU_QUIRKS_BATTERY_THRESHOLD);
 	fu_quirks_add_possible_key(self, FU_QUIRKS_REMOVE_DELAY);
 	fu_quirks_add_possible_key(self, FU_QUIRKS_SUMMARY);

--- a/libfwupdplugin/fu-quirks.h
+++ b/libfwupdplugin/fu-quirks.h
@@ -300,6 +300,14 @@ fu_quirks_add_possible_key(FuQuirks *self, const gchar *possible_key) G_GNUC_NON
  **/
 #define FU_QUIRKS_BATTERY_THRESHOLD "BatteryThreshold"
 /**
+ * FU_QUIRKS_APPSTREAM_ID:
+ *
+ * The quirk key for the fwupd AppStream identifier, e.g. `org.fwupd.bios.secure-boot`.
+ *
+ * Since: 2.1.7
+ **/
+#define FU_QUIRKS_APPSTREAM_ID "AppstreamId"
+/**
  * FU_QUIRKS_REMOVE_DELAY:
  *
  * The quirk key for the device removal delay in milliseconds, e.g. `2500`.

--- a/libfwupdplugin/tests/meson.build
+++ b/libfwupdplugin/tests/meson.build
@@ -205,6 +205,24 @@ install_data(
 
 install_data(
   [
+    'bios-attrs/dell-xps13-9310/dell-wmi-sysman/attributes/Camera/current_value',
+    'bios-attrs/dell-xps13-9310/dell-wmi-sysman/attributes/Camera/default_value',
+    'bios-attrs/dell-xps13-9310/dell-wmi-sysman/attributes/Camera/dell_modifier',
+    'bios-attrs/dell-xps13-9310/dell-wmi-sysman/attributes/Camera/dell_value_modifier',
+    'bios-attrs/dell-xps13-9310/dell-wmi-sysman/attributes/Camera/display_name',
+    'bios-attrs/dell-xps13-9310/dell-wmi-sysman/attributes/Camera/display_name_language_code',
+    'bios-attrs/dell-xps13-9310/dell-wmi-sysman/attributes/Camera/possible_values',
+    'bios-attrs/dell-xps13-9310/dell-wmi-sysman/attributes/Camera/type',
+  ],
+  install_dir: join_paths(
+    installed_test_datadir,
+    'tests/bios-attrs/dell-xps13-9310/dell-wmi-sysman/attributes/Camera',
+  ),
+  follow_symlinks: true,
+)
+
+install_data(
+  [
     'bios-attrs/hp-z2-mini-g1a/hp-bioscfg/attributes/Enhanced HP Firmware Runtime Intrusion Prevention and Detection/current_value',
     'bios-attrs/hp-z2-mini-g1a/hp-bioscfg/attributes/Enhanced HP Firmware Runtime Intrusion Prevention and Detection/display_name',
     'bios-attrs/hp-z2-mini-g1a/hp-bioscfg/attributes/Enhanced HP Firmware Runtime Intrusion Prevention and Detection/display_name_language_code',

--- a/libfwupdplugin/tests/quirks.d/tests.quirk
+++ b/libfwupdplugin/tests/quirks.d/tests.quirk
@@ -38,3 +38,10 @@ Plugin = two
 Flags = hwid-test-flag
 [c4e7b7b9-2520-5397-8040-8ac279f540d8]
 Flags = ~hwid-test-flag
+
+# BIOS setting AppStream mappings
+[com.dell-wmi-sysman.SecureBoot]
+AppstreamId = org.fwupd.bios.secure-boot
+
+[com.dell-wmi-sysman.Camera]
+AppstreamId = org.fwupd.bios.camera.enabled

--- a/plugins/amd-gpu/fu-amd-gpu-uma-test.c
+++ b/plugins/amd-gpu/fu-amd-gpu-uma-test.c
@@ -118,6 +118,12 @@ fu_amd_gpu_uma_get_setting_valid_func(void)
 	g_assert_cmpint(possible_values->len, ==, 3);
 
 	g_assert_cmpstr(fwupd_bios_setting_get_current_value(setting), ==, "Minimum (512 MB)");
+
+	/* setting with a vendor-neutral AppStream ID and icon */
+	g_assert_cmpstr(fwupd_bios_setting_get_appstream_id(setting),
+			==,
+			"org.fwupd.bios.video-memory");
+	g_assert_cmpstr(fwupd_bios_setting_get_icon(setting), ==, "video-display");
 }
 
 static void

--- a/plugins/amd-gpu/fu-amd-gpu-uma.c
+++ b/plugins/amd-gpu/fu-amd-gpu-uma.c
@@ -188,6 +188,9 @@ fu_amd_gpu_uma_get_setting(const gchar *device_sysfs_path, GError **error)
 	fwupd_bios_setting_set_kind(FWUPD_BIOS_SETTING(attr), FWUPD_BIOS_SETTING_KIND_ENUMERATION);
 	fwupd_bios_setting_set_path(FWUPD_BIOS_SETTING(attr), uma_dir);
 	fwupd_bios_setting_set_filename(FWUPD_BIOS_SETTING(attr), UMA_CARVEOUT_FILE);
+	fwupd_bios_setting_set_appstream_id(FWUPD_BIOS_SETTING(attr),
+					    "org.fwupd.bios.video-memory");
+	fwupd_bios_setting_set_icon(FWUPD_BIOS_SETTING(attr), "video-display");
 
 	options_file = g_build_filename(uma_dir, UMA_CARVEOUT_OPTIONS_FILE, NULL);
 	options_content = fu_amd_gpu_uma_read_file(options_file, error);

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -8059,10 +8059,9 @@ fu_engine_cleanup_state(GError **error)
 static gboolean
 fu_engine_apply_default_bios_settings_policy(FuEngine *self, GError **error)
 {
-	FuPathStore *pstore = fu_context_get_path_store(self->ctx);
 	const gchar *tmp;
 	g_autofree gchar *dirname = NULL;
-	g_autoptr(FuBiosSettings) new_bios_settings = fu_bios_settings_new(pstore);
+	g_autoptr(FuBiosSettings) new_bios_settings = fu_bios_settings_new(self->ctx);
 	g_autoptr(GHashTable) hashtable = NULL;
 	g_autoptr(GDir) dir = NULL;
 

--- a/src/fu-util-bios-setting.c
+++ b/src/fu-util-bios-setting.c
@@ -17,10 +17,13 @@
 static void
 fu_util_bios_setting_update_description(FwupdBiosSetting *setting)
 {
+	const gchar *tmp = fwupd_bios_setting_get_description(setting);
 	const gchar *new = NULL;
 
 	/* try to look it up from translations */
-	new = gettext(fwupd_bios_setting_get_description(setting));
+	if (tmp == NULL)
+		return;
+	new = dgettext(GETTEXT_PACKAGE, tmp);
 	if (new != NULL)
 		fwupd_bios_setting_set_description(setting, new);
 }
@@ -46,16 +49,17 @@ fu_util_bios_setting_kind_to_string(FwupdBiosSettingKind kind)
 gboolean
 fu_util_bios_setting_matches_args(FwupdBiosSetting *setting, gchar **values)
 {
-	const gchar *name;
-
 	/* no arguments set */
 	if (g_strv_length(values) == 0)
 		return TRUE;
-	name = fwupd_bios_setting_get_name(setting);
 
 	/* check all arguments */
 	for (guint j = 0; j < g_strv_length(values); j++) {
-		if (g_strcmp0(name, values[j]) == 0)
+		if (g_strcmp0(fwupd_bios_setting_get_name(setting), values[j]) == 0)
+			return TRUE;
+		if (g_strcmp0(fwupd_bios_setting_get_id(setting), values[j]) == 0)
+			return TRUE;
+		if (g_strcmp0(fwupd_bios_setting_get_appstream_id(setting), values[j]) == 0)
 			return TRUE;
 	}
 	return FALSE;
@@ -119,6 +123,18 @@ fu_util_bios_setting_to_string(FwupdBiosSetting *setting, guint idt)
 				  /* TRANSLATORS: description of BIOS setting */
 				  _("Description"),
 				  fwupd_bios_setting_get_description(setting));
+
+	tmp = fwupd_bios_setting_get_appstream_id(setting);
+	if (tmp != NULL) {
+		/* TRANSLATORS: vendor-neutral AppStream identifier of a BIOS setting */
+		fwupd_codec_string_append(str, idt + 1, _("AppStream ID"), tmp);
+	}
+
+	tmp = fwupd_bios_setting_get_icon(setting);
+	if (tmp != NULL) {
+		/* TRANSLATORS: icon name for a BIOS setting */
+		fwupd_codec_string_append(str, idt + 1, _("Icon"), tmp);
+	}
 
 	if (fwupd_bios_setting_get_read_only(setting)) {
 		/* TRANSLATORS: item is TRUE */


### PR DESCRIPTION
  Most BIOS settings are esoteric and vendor-specific in both naming and accepted values, which makes it hard for graphical clients to present a small, consistent list of settings that are safe for an end user to change. Each client would otherwise have to maintain its own
  whitelist and per-vendor name mapping.

  Expose new metadata on FwupdBiosSetting so any client can key off fwupd instead: a vendor-neutral AppStream ID (e.g. org.fwupd.bios.secure-boot) so the same conceptual setting is grouped and labelled consistently across vendors. Clients can show settings that have an AppStream ID
  by default and hide the rest behind an "advanced" view. The vendor-ID to AppStream-ID mapping ships as an editable quirk file; plugin-created settings such as the AMD Dedicated Video Memory carveout set the metadata directly.

  Also guard fu_context_lookup_quirk_by_id() against FU_CONTEXT_FLAG_NO_QUIRKS to match the existing _iter() variant, so BIOS settings setup works whether or not quirks are loaded.

  Type of pull request:

  - [ ] New plugin (Please include new plugin checklist (https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
  - [ ] Code fix
  - [x] Feature
  - [ ] Documentation