### PR TITLE
hsi: Allow suspend-to-ram with encrypted RAM

### DIFF
--- a/libfwupdplugin/fu-security-attrs-test.c
+++ b/libfwupdplugin/fu-security-attrs-test.c
@@ -190,11 +190,147 @@ fu_security_attrs_hsi_func(void)
 	g_clear_object(&attr);
 }
 
+static void
+fu_security_attrs_test_add_attr(FuSecurityAttrs *attrs,
+				const gchar *appstream_id,
+				const gchar *plugin,
+				FwupdSecurityAttrResult result,
+				gboolean success)
+{
+	g_autoptr(FwupdSecurityAttr) attr = fwupd_security_attr_new(appstream_id);
+
+	fwupd_security_attr_set_plugin(attr, plugin);
+	fwupd_security_attr_set_result(attr, result);
+	if (success)
+		fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
+	fu_security_attrs_append(attrs, attr);
+}
+
+static void
+fu_security_attrs_hsi_suspend_to_ram_func(void)
+{
+	/* suspend-to-ram with encrypted RAM replaces s2idle */
+	{
+		g_autoptr(FuSecurityAttrs) attrs = fu_security_attrs_new();
+		g_autoptr(FwupdSecurityAttr) attr_s2idle = NULL;
+		g_autoptr(FwupdSecurityAttr) attr_s3 = NULL;
+
+		fu_security_attrs_test_add_attr(attrs,
+						FWUPD_SECURITY_ATTR_ID_SUSPEND_TO_IDLE,
+						"acpi-facp",
+						FWUPD_SECURITY_ATTR_RESULT_ENABLED,
+						TRUE);
+		fu_security_attrs_test_add_attr(attrs,
+						FWUPD_SECURITY_ATTR_ID_SUSPEND_TO_RAM,
+						"linux-sleep",
+						FWUPD_SECURITY_ATTR_RESULT_ENABLED,
+						FALSE);
+		fu_security_attrs_test_add_attr(attrs,
+						FWUPD_SECURITY_ATTR_ID_ENCRYPTED_RAM,
+						"msr",
+						FWUPD_SECURITY_ATTR_RESULT_ENCRYPTED,
+						TRUE);
+		attr_s2idle =
+		    fu_security_attrs_get_by_appstream_id(attrs,
+							  FWUPD_SECURITY_ATTR_ID_SUSPEND_TO_IDLE,
+							  NULL);
+		attr_s3 =
+		    fu_security_attrs_get_by_appstream_id(attrs,
+							  FWUPD_SECURITY_ATTR_ID_SUSPEND_TO_RAM,
+							  NULL);
+		g_assert_nonnull(attr_s2idle);
+		g_assert_nonnull(attr_s3);
+		fwupd_security_attr_add_flag(attr_s3, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_FW);
+		fwupd_security_attr_add_flag(attr_s3, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_OS);
+		fu_security_attrs_depsolve(attrs);
+		g_assert_true(
+		    fwupd_security_attr_has_flag(attr_s3, FWUPD_SECURITY_ATTR_FLAG_SUCCESS));
+		g_assert_false(
+		    fwupd_security_attr_has_flag(attr_s3,
+						 FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_FW));
+		g_assert_false(
+		    fwupd_security_attr_has_flag(attr_s3,
+						 FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_OS));
+		g_assert_true(
+		    fwupd_security_attr_has_flag(attr_s2idle, FWUPD_SECURITY_ATTR_FLAG_OBSOLETED));
+	}
+
+	/* RAM must be encrypted */
+	{
+		g_autoptr(FuSecurityAttrs) attrs = fu_security_attrs_new();
+		g_autoptr(FwupdSecurityAttr) attr_s2idle = NULL;
+		g_autoptr(FwupdSecurityAttr) attr_s3 = NULL;
+
+		fu_security_attrs_test_add_attr(attrs,
+						FWUPD_SECURITY_ATTR_ID_SUSPEND_TO_IDLE,
+						"acpi-facp",
+						FWUPD_SECURITY_ATTR_RESULT_ENABLED,
+						TRUE);
+		fu_security_attrs_test_add_attr(attrs,
+						FWUPD_SECURITY_ATTR_ID_SUSPEND_TO_RAM,
+						"linux-sleep",
+						FWUPD_SECURITY_ATTR_RESULT_ENABLED,
+						FALSE);
+		fu_security_attrs_test_add_attr(attrs,
+						FWUPD_SECURITY_ATTR_ID_ENCRYPTED_RAM,
+						"msr",
+						FWUPD_SECURITY_ATTR_RESULT_NOT_SUPPORTED,
+						FALSE);
+		attr_s2idle =
+		    fu_security_attrs_get_by_appstream_id(attrs,
+							  FWUPD_SECURITY_ATTR_ID_SUSPEND_TO_IDLE,
+							  NULL);
+		attr_s3 =
+		    fu_security_attrs_get_by_appstream_id(attrs,
+							  FWUPD_SECURITY_ATTR_ID_SUSPEND_TO_RAM,
+							  NULL);
+		g_assert_nonnull(attr_s2idle);
+		g_assert_nonnull(attr_s3);
+		fu_security_attrs_depsolve(attrs);
+		g_assert_false(
+		    fwupd_security_attr_has_flag(attr_s3, FWUPD_SECURITY_ATTR_FLAG_SUCCESS));
+		g_assert_false(
+		    fwupd_security_attr_has_flag(attr_s2idle, FWUPD_SECURITY_ATTR_FLAG_OBSOLETED));
+	}
+
+	/* encrypted RAM still requires suspend-to-ram to be configured */
+	{
+		g_autoptr(FuSecurityAttrs) attrs = fu_security_attrs_new();
+		g_autoptr(FwupdSecurityAttr) attr_s2idle = NULL;
+
+		fu_security_attrs_test_add_attr(attrs,
+						FWUPD_SECURITY_ATTR_ID_SUSPEND_TO_IDLE,
+						"acpi-facp",
+						FWUPD_SECURITY_ATTR_RESULT_ENABLED,
+						TRUE);
+		fu_security_attrs_test_add_attr(attrs,
+						FWUPD_SECURITY_ATTR_ID_SUSPEND_TO_RAM,
+						"linux-sleep",
+						FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED,
+						TRUE);
+		fu_security_attrs_test_add_attr(attrs,
+						FWUPD_SECURITY_ATTR_ID_ENCRYPTED_RAM,
+						"msr",
+						FWUPD_SECURITY_ATTR_RESULT_ENCRYPTED,
+						TRUE);
+		attr_s2idle =
+		    fu_security_attrs_get_by_appstream_id(attrs,
+							  FWUPD_SECURITY_ATTR_ID_SUSPEND_TO_IDLE,
+							  NULL);
+		g_assert_nonnull(attr_s2idle);
+		fu_security_attrs_depsolve(attrs);
+		g_assert_false(
+		    fwupd_security_attr_has_flag(attr_s2idle, FWUPD_SECURITY_ATTR_FLAG_OBSOLETED));
+	}
+}
+
 int
 main(int argc, char **argv)
 {
 	g_test_init(&argc, &argv, NULL);
 	g_test_add_func("/fwupd/security-attrs", fu_security_attrs_func);
 	g_test_add_func("/fwupd/security-attrs/hsi", fu_security_attrs_hsi_func);
+	g_test_add_func("/fwupd/security-attrs/hsi-suspend-to-ram",
+			fu_security_attrs_hsi_suspend_to_ram_func);
 	return g_test_run();
 }

--- a/libfwupdplugin/fu-security-attrs.c
+++ b/libfwupdplugin/fu-security-attrs.c
@@ -533,6 +533,43 @@ fu_security_attrs_ensure_fwupd_version(FwupdSecurityAttr *attr)
 	g_warning("cannot map %s to a fwupd version", appstream_id);
 }
 
+static gboolean
+fu_security_attrs_has_success(FuSecurityAttrs *self, const gchar *appstream_id)
+{
+	for (guint i = 0; i < self->attrs->len; i++) {
+		FwupdSecurityAttr *attr = g_ptr_array_index(self->attrs, i);
+		const gchar *attr_id = fwupd_security_attr_get_appstream_id(attr);
+
+		if (g_strcmp0(attr_id, appstream_id) != 0)
+			continue;
+		if (fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS))
+			return TRUE;
+	}
+
+	return FALSE;
+}
+
+static void
+fu_security_attrs_add_suspend_to_ram_obsoletes(FuSecurityAttrs *self)
+{
+	if (!fu_security_attrs_has_success(self, FWUPD_SECURITY_ATTR_ID_ENCRYPTED_RAM))
+		return;
+
+	for (guint i = 0; i < self->attrs->len; i++) {
+		FwupdSecurityAttr *attr = g_ptr_array_index(self->attrs, i);
+		const gchar *attr_id = fwupd_security_attr_get_appstream_id(attr);
+
+		if (g_strcmp0(attr_id, FWUPD_SECURITY_ATTR_ID_SUSPEND_TO_RAM) != 0)
+			continue;
+		if (fwupd_security_attr_get_result(attr) != FWUPD_SECURITY_ATTR_RESULT_ENABLED)
+			continue;
+		fwupd_security_attr_remove_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_FW);
+		fwupd_security_attr_remove_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_OS);
+		fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
+		fwupd_security_attr_add_obsolete(attr, FWUPD_SECURITY_ATTR_ID_SUSPEND_TO_IDLE);
+	}
+}
+
 /**
  * fu_security_attrs_depsolve:
  * @self: a #FuSecurityAttrs
@@ -556,6 +593,8 @@ fu_security_attrs_depsolve(FuSecurityAttrs *self)
 		fu_security_attrs_ensure_level(attr);
 		fu_security_attrs_ensure_fwupd_version(attr);
 	}
+
+	fu_security_attrs_add_suspend_to_ram_obsoletes(self);
 
 	/* set flat where required */
 	for (guint i = 0; i < self->attrs->len; i++) {


### PR DESCRIPTION
## Summary

- allow `org.fwupd.hsi.SuspendToRam` to obsolete `org.fwupd.hsi.SuspendToIdle` only when `org.fwupd.hsi.EncryptedRam` succeeds
- mark S3 as successful and remove the firmware/OS action flags in that encrypted-RAM case
- drop the previous S4/TCG path, as kernel lockdown hibernation needs kernel-mediated image measurement/authentication rather than storage locking alone

## Testing

- `git diff --check origin/main..HEAD`
- `meson compile -C builddir fwupdplugin-security-attrs-test`
- `meson test -C builddir fwupdplugin-security-attrs-test --print-errorlogs`

Still draft while the S3 policy wording is reviewed.