### PR TITLE
redfish: Confirm the selected member identity after an update task

### DIFF
--- a/plugins/redfish/fu-redfish-common.c
+++ b/plugins/redfish/fu-redfish-common.c
@@ -134,3 +134,16 @@ fu_redfish_common_parse_version_lenovo(const gchar *version,
 		*out_version = g_strdup(versplit[1]);
 	return TRUE;
 }
+
+gchar *
+fu_redfish_common_normalize_software_id(const gchar *software_id)
+{
+	g_autofree gchar *software_id_lower = NULL;
+	if (software_id == NULL)
+		return NULL;
+	/* GUIDs compare case-insensitively, everything else stays exact */
+	software_id_lower = g_ascii_strdown(software_id, -1);
+	if (fwupd_guid_is_valid(software_id_lower))
+		return g_steal_pointer(&software_id_lower);
+	return g_strdup(software_id);
+}

--- a/plugins/redfish/fu-redfish-common.h
+++ b/plugins/redfish/fu-redfish-common.h
@@ -33,6 +33,8 @@ fu_redfish_common_buffer_to_mac(const guint8 *buffer);
 
 gchar *
 fu_redfish_common_fix_version(const gchar *version);
+gchar *
+fu_redfish_common_normalize_software_id(const gchar *software_id);
 gboolean
 fu_redfish_common_parse_version_lenovo(const gchar *version,
 				       gchar **out_build,

--- a/plugins/redfish/fu-redfish-device.c
+++ b/plugins/redfish/fu-redfish-device.c
@@ -15,6 +15,7 @@ typedef struct {
 	FwupdJsonObject *json_obj_member;
 	guint64 milestone;
 	gchar *build;
+	gchar *software_id;
 	guint reset_pre_delay;	/* default of 0ms */
 	guint reset_post_delay; /* default of 0ms */
 } FuRedfishDevicePrivate;
@@ -32,6 +33,7 @@ fu_redfish_device_to_string(FuDevice *device, guint idt, GString *str)
 	FuRedfishDevicePrivate *priv = GET_PRIVATE(self);
 	fwupd_codec_string_append_hex(str, idt, "Milestone", priv->milestone);
 	fwupd_codec_string_append(str, idt, "Build", priv->build);
+	fwupd_codec_string_append(str, idt, "SoftwareId", priv->software_id);
 	fwupd_codec_string_append_int(str, idt, "ResetPretDelay", priv->reset_pre_delay);
 	fwupd_codec_string_append_int(str, idt, "ResetPostDelay", priv->reset_post_delay);
 }
@@ -512,6 +514,10 @@ fu_redfish_device_probe(FuDevice *dev, GError **error)
 
 	/* some vendors use a GUID, others use an ID like BMC-AFBT-10 */
 	software_id = fwupd_json_object_get_string(priv->json_obj_member, "SoftwareId", NULL);
+	/* remember what the selected member denoted so we can confirm it did not
+	 * change once the update task completes; cleared even if now absent */
+	g_free(priv->software_id);
+	priv->software_id = fu_redfish_common_normalize_software_id(software_id);
 	if (software_id != NULL) {
 		g_autofree gchar *software_id_lower = g_ascii_strdown(software_id, -1);
 		if (fwupd_guid_is_valid(software_id_lower)) {
@@ -630,6 +636,83 @@ fu_redfish_device_get_backend(FuRedfishDevice *self, GError **error)
 		return NULL;
 	}
 	return priv->backend;
+}
+
+gboolean
+fu_redfish_device_verify_target_identity(FuRedfishDevice *self, GError **error)
+{
+	FuRedfishDevicePrivate *priv = GET_PRIVATE(self);
+	const gchar *logical_id = fu_device_get_logical_id(FU_DEVICE(self));
+	const gchar *software_id_now;
+	gboolean reset_pending;
+	g_autofree gchar *software_id_now_norm = NULL;
+	g_autoptr(FuRedfishRequest) request = NULL;
+	g_autoptr(FwupdJsonObject) json_obj = NULL;
+	g_autoptr(GError) error_local = NULL;
+
+	/* a wildcard update has no single member to re-confirm */
+	if (fu_device_has_private_flag(FU_DEVICE(self), FU_REDFISH_DEVICE_FLAG_WILDCARD_TARGETS))
+		return TRUE;
+
+	/* nothing was captured at probe to compare against */
+	if (logical_id == NULL || priv->software_id == NULL)
+		return TRUE;
+
+	/* while a reset or activation is pending the member is expected to be
+	 * unreachable or stale, so an unavailable readback is tolerated; otherwise
+	 * the task claimed completion and a missing readback is a real problem */
+	reset_pending = fu_device_has_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_NEEDS_REBOOT) ||
+			fu_device_has_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
+
+	request = fu_redfish_backend_request_new(priv->backend);
+	if (!fu_redfish_request_perform(request,
+					logical_id,
+					FU_REDFISH_REQUEST_PERFORM_FLAG_LOAD_JSON,
+					&error_local)) {
+		if (reset_pending) {
+			g_debug("failed to re-read %s to confirm target identity: %s",
+				logical_id,
+				error_local->message);
+			return TRUE;
+		}
+		g_propagate_prefixed_error(error,
+					   g_steal_pointer(&error_local),
+					   "failed to re-read %s to confirm target identity: ",
+					   logical_id);
+		return FALSE;
+	}
+
+	/* a success with an empty body parses no object, leaving nothing to compare */
+	json_obj = fu_redfish_request_get_json_object(request);
+	if (json_obj == NULL) {
+		if (reset_pending) {
+			g_debug("no readback body for %s to confirm target identity",
+				logical_id);
+			return TRUE;
+		}
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_FILE,
+			    "failed to re-read %s to confirm target identity: empty response",
+			    logical_id);
+		return FALSE;
+	}
+	software_id_now = fwupd_json_object_get_string(json_obj, "SoftwareId", NULL);
+	software_id_now_norm = fu_redfish_common_normalize_software_id(software_id_now);
+	if (g_strcmp0(software_id_now_norm, priv->software_id) != 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_FILE,
+			    "Redfish target identity changed: member %s reported SoftwareId %s at discovery "
+			    "but %s on re-read",
+			    logical_id,
+			    priv->software_id,
+			    software_id_now != NULL ? software_id_now : "(none)");
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
 }
 
 typedef struct {
@@ -1052,6 +1135,7 @@ fu_redfish_device_finalize(GObject *object)
 	if (priv->json_obj_member != NULL)
 		fwupd_json_object_unref(priv->json_obj_member);
 	g_free(priv->build);
+	g_free(priv->software_id);
 	G_OBJECT_CLASS(fu_redfish_device_parent_class)->finalize(object);
 }
 

--- a/plugins/redfish/fu-redfish-device.h
+++ b/plugins/redfish/fu-redfish-device.h
@@ -26,6 +26,8 @@ struct _FuRedfishDeviceClass {
 FuRedfishBackend *
 fu_redfish_device_get_backend(FuRedfishDevice *self, GError **error);
 gboolean
+fu_redfish_device_verify_target_identity(FuRedfishDevice *self, GError **error);
+gboolean
 fu_redfish_device_parse_message_id(FuRedfishDevice *self,
 				   const gchar *message_id,
 				   const gchar *message,

--- a/plugins/redfish/fu-redfish-hpe-device.c
+++ b/plugins/redfish/fu-redfish-hpe-device.c
@@ -294,6 +294,8 @@ fu_redfish_hpe_device_write_firmware(FuDevice *device,
 					     fu_progress_get_child(progress),
 					     error))
 		return FALSE;
+	if (!fu_redfish_device_verify_target_identity(FU_REDFISH_DEVICE(self), error))
+		return FALSE;
 	fu_progress_step_done(progress);
 
 	/* success */

--- a/plugins/redfish/fu-redfish-legacy-device.c
+++ b/plugins/redfish/fu-redfish-legacy-device.c
@@ -124,7 +124,9 @@ fu_redfish_legacy_device_write_firmware(FuDevice *device,
 			       fu_redfish_backend_get_push_uri_path(backend));
 		return FALSE;
 	}
-	return fu_redfish_device_poll_task(FU_REDFISH_DEVICE(self), location, progress, error);
+	if (!fu_redfish_device_poll_task(FU_REDFISH_DEVICE(self), location, progress, error))
+		return FALSE;
+	return fu_redfish_device_verify_target_identity(FU_REDFISH_DEVICE(self), error);
 }
 
 static void

--- a/plugins/redfish/fu-redfish-multipart-device.c
+++ b/plugins/redfish/fu-redfish-multipart-device.c
@@ -169,7 +169,11 @@ fu_redfish_multipart_device_write_firmware(FuDevice *device,
 		g_free(location);
 		location = g_strdup(location_tmp);
 	}
-	return fu_redfish_device_poll_task(FU_REDFISH_DEVICE(self), location, progress, error);
+	if (!fu_redfish_device_poll_task(FU_REDFISH_DEVICE(self), location, progress, error))
+		return FALSE;
+
+	/* confirm the member still denotes the component we selected */
+	return fu_redfish_device_verify_target_identity(FU_REDFISH_DEVICE(self), error);
 }
 
 static void

--- a/plugins/redfish/fu-redfish-request.c
+++ b/plugins/redfish/fu-redfish-request.c
@@ -29,6 +29,9 @@ FwupdJsonObject *
 fu_redfish_request_get_json_object(FuRedfishRequest *self)
 {
 	g_return_val_if_fail(FU_IS_REDFISH_REQUEST(self), NULL);
+	/* an empty response body leaves nothing parsed */
+	if (self->json_obj == NULL)
+		return NULL;
 	return fwupd_json_object_ref(self->json_obj);
 }
 

--- a/plugins/redfish/fu-redfish-smc-device.c
+++ b/plugins/redfish/fu-redfish-smc-device.c
@@ -209,9 +209,13 @@ fu_redfish_smc_device_write_firmware(FuDevice *device,
 					 fu_progress_get_child(progress),
 					 error))
 		return FALSE;
+	if (!fu_redfish_device_verify_target_identity(FU_REDFISH_DEVICE(self), error))
+		return FALSE;
 	fu_progress_step_done(progress);
 
 	if (!fu_redfish_smc_device_start_update(self, fu_progress_get_child(progress), error))
+		return FALSE;
+	if (!fu_redfish_device_verify_target_identity(FU_REDFISH_DEVICE(self), error))
 		return FALSE;
 	fu_progress_step_done(progress);
 	return TRUE;

--- a/plugins/redfish/fu-self-test.c
+++ b/plugins/redfish/fu-self-test.c
@@ -277,6 +277,29 @@ fu_redfish_common_lenovo_func(void)
 }
 
 static void
+fu_redfish_common_software_id_func(void)
+{
+	struct {
+		const gchar *in;
+		const gchar *op;
+	} strs[] = {/* GUIDs are normalized to lower case */
+		    {"1624828D-8D1C-4E5D-8F5A-000000000000",
+		     "1624828d-8d1c-4e5d-8f5a-000000000000"},
+		    {"1624828d-8d1c-4e5d-8f5a-000000000000",
+		     "1624828d-8d1c-4e5d-8f5a-000000000000"},
+		    /* non-GUIDs are left untouched */
+		    {"UEFI-AFE1-6", "UEFI-AFE1-6"},
+		    {"BMC-AFBT-10", "BMC-AFBT-10"},
+		    {NULL, NULL}};
+	g_autofree gchar *empty = fu_redfish_common_normalize_software_id(NULL);
+	g_assert_null(empty);
+	for (guint i = 0; strs[i].in != NULL; i++) {
+		g_autofree gchar *tmp = fu_redfish_common_normalize_software_id(strs[i].in);
+		g_assert_cmpstr(tmp, ==, strs[i].op);
+	}
+}
+
+static void
 fu_redfish_network_mac_addr_func(void)
 {
 	FuRedfishNetworkDeviceState state = FU_REDFISH_NETWORK_DEVICE_STATE_UNKNOWN;
@@ -634,6 +657,133 @@ fu_redfish_smc_update_func(gconstpointer user_data)
 }
 
 static void
+fu_redfish_target_identity_func(gconstpointer user_data)
+{
+	FuDevice *dev;
+	FuTest *self = (FuTest *)user_data;
+	GPtrArray *devices;
+	gboolean ret;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GBytes) blob_fw = NULL;
+	g_autoptr(FuFirmware) firmware = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+
+	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_NO_PROFILE);
+
+	devices = fu_plugin_get_devices(self->plugin);
+	g_assert_nonnull(devices);
+	if (devices->len == 0) {
+		g_test_skip("no redfish support");
+		return;
+	}
+	g_assert_cmpint(devices->len, ==, 2);
+
+	/* the mock reassigns this member to a different component as the task
+	 * completes, so the update must not be credited to the selected device */
+	dev = g_ptr_array_index(devices, 1);
+
+	/* an earlier update on this device may have left the reboot flag set, which
+	 * would short-circuit polling before the task reaches completion */
+	fu_device_remove_flag(dev, FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
+
+	blob_fw = g_bytes_new_static("shift", 5);
+	firmware = fu_firmware_new_from_bytes(blob_fw);
+	fu_firmware_set_filename(firmware, "firmware.exe");
+	ret = fu_plugin_runner_write_firmware(self->plugin,
+					      dev,
+					      firmware,
+					      progress,
+					      FWUPD_INSTALL_FLAG_NONE,
+					      &error);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
+	g_assert_false(ret);
+	g_assert_nonnull(g_strstr_len(error->message, -1, "target identity changed"));
+}
+
+static void
+fu_redfish_target_identity_reset_func(gconstpointer user_data)
+{
+	FuDevice *dev;
+	FuTest *self = (FuTest *)user_data;
+	GPtrArray *devices;
+	gboolean ret;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GBytes) blob_fw = NULL;
+	g_autoptr(FuFirmware) firmware = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+
+	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_NO_PROFILE);
+
+	devices = fu_plugin_get_devices(self->plugin);
+	g_assert_nonnull(devices);
+	if (devices->len == 0) {
+		g_test_skip("no redfish support");
+		return;
+	}
+	g_assert_cmpint(devices->len, ==, 2);
+
+	dev = g_ptr_array_index(devices, 1);
+	fu_device_remove_flag(dev, FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
+
+	/* the task signals a required reset before it completes, so polling stops
+	 * early; the member has not settled yet, so identity is not confirmed here
+	 * and the update proceeds with the reboot flag set */
+	blob_fw = g_bytes_new_static("reset-shift", 11);
+	firmware = fu_firmware_new_from_bytes(blob_fw);
+	fu_firmware_set_filename(firmware, "firmware.exe");
+	ret = fu_plugin_runner_write_firmware(self->plugin,
+					      dev,
+					      firmware,
+					      progress,
+					      FWUPD_INSTALL_FLAG_NONE,
+					      &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_true(fu_device_has_flag(dev, FWUPD_DEVICE_FLAG_NEEDS_REBOOT));
+}
+
+static void
+fu_redfish_target_identity_empty_func(gconstpointer user_data)
+{
+	FuDevice *dev;
+	FuTest *self = (FuTest *)user_data;
+	GPtrArray *devices;
+	gboolean ret;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GBytes) blob_fw = NULL;
+	g_autoptr(FuFirmware) firmware = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+
+	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_NO_PROFILE);
+
+	devices = fu_plugin_get_devices(self->plugin);
+	g_assert_nonnull(devices);
+	if (devices->len == 0) {
+		g_test_skip("no redfish support");
+		return;
+	}
+	g_assert_cmpint(devices->len, ==, 2);
+
+	dev = g_ptr_array_index(devices, 1);
+	fu_device_remove_flag(dev, FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
+
+	/* the task completes, but the member readback returns an empty body; this
+	 * must fail cleanly rather than dereference a missing JSON object */
+	blob_fw = g_bytes_new_static("empty-shift", 11);
+	firmware = fu_firmware_new_from_bytes(blob_fw);
+	fu_firmware_set_filename(firmware, "firmware.exe");
+	ret = fu_plugin_runner_write_firmware(self->plugin,
+					      dev,
+					      firmware,
+					      progress,
+					      FWUPD_INSTALL_FLAG_NONE,
+					      &error);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
+	g_assert_false(ret);
+	g_assert_nonnull(g_strstr_len(error->message, -1, "empty response"));
+}
+
+static void
 fu_self_free(FuTest *self)
 {
 	if (self->plugin != NULL)
@@ -672,6 +822,7 @@ main(int argc, char **argv)
 	g_test_add_func("/redfish/common", fu_redfish_common_func);
 	g_test_add_func("/redfish/common/version", fu_redfish_common_version_func);
 	g_test_add_func("/redfish/common/lenovo", fu_redfish_common_lenovo_func);
+	g_test_add_func("/redfish/common/software-id", fu_redfish_common_software_id_func);
 	g_test_add_func("/redfish/network/mac_addr", fu_redfish_network_mac_addr_func);
 	g_test_add_func("/redfish/network/vid_pid", fu_redfish_network_vid_pid_func);
 	g_test_add_data_func("/redfish/unlicensed-plugin/devices",
@@ -683,5 +834,14 @@ main(int argc, char **argv)
 	g_test_add_data_func("/redfish/plugin/devices", self, fu_redfish_devices_func);
 	g_test_add_data_func("/redfish/dell/devices", self, fu_redfish_dell_devices_func);
 	g_test_add_data_func("/redfish/plugin/update", self, fu_redfish_update_func);
+	g_test_add_data_func("/redfish/plugin/target-identity",
+			     self,
+			     fu_redfish_target_identity_func);
+	g_test_add_data_func("/redfish/plugin/target-identity-reset",
+			     self,
+			     fu_redfish_target_identity_reset_func);
+	g_test_add_data_func("/redfish/plugin/target-identity-empty",
+			     self,
+			     fu_redfish_target_identity_empty_func);
 	return g_test_run();
 }

--- a/plugins/redfish/tests/redfish.py
+++ b/plugins/redfish/tests/redfish.py
@@ -26,6 +26,11 @@ HARDCODED_PASSWORD = "password2"
 
 app._percentage545: int = 0
 app._percentage546: int = 0
+app._percentage547: int = 0
+app._percentage548: int = 0
+app._reassign_bmc: bool = False
+app._bmc_reassigned: bool = False
+app._empty_bmc: bool = False
 app._hpeupdatestate: str = "Idle"
 app._hpeupdateresult = None
 
@@ -44,6 +49,11 @@ def index():
     # reset counter
     app._percentage545 = 0
     app._percentage546 = 0
+    app._percentage547 = 0
+    app._percentage548 = 0
+    app._reassign_bmc = False
+    app._bmc_reassigned = False
+    app._empty_bmc = False
     app._hpeupdatestate = "Idle"
     app._hpeupdateresult = None
 
@@ -172,6 +182,10 @@ def firmware_inventory():
 
 @app.route("/redfish/v1/UpdateService/FirmwareInventory/BMC")
 def firmware_inventory_bmc():
+    # emulate a completed task whose member readback returns an empty body
+    if app._bmc_reassigned and app._empty_bmc:
+        return Response(response="", status=200, mimetype="application/json")
+    software_id = "UEFI-NIC-9" if app._bmc_reassigned else "UEFI-AFE1-6"
     res = {
         "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/BMC",
         "@odata.type": "#SoftwareInventory.v1_2_3.SoftwareInventory",
@@ -189,7 +203,7 @@ def firmware_inventory_bmc():
             }
         },
         "RelatedItem": [{"@odata.id": "/redfish/v1/Managers/BMC"}],
-        "SoftwareId": "UEFI-AFE1-6",
+        "SoftwareId": software_id,
         "UefiDevicePaths": ["BMC(0x1,0x0ABCDEF)"],
         "Updateable": True,
         "Version": "11A-1.02",
@@ -411,6 +425,78 @@ def task_status_546():
     return Response(response=json.dumps(res), status=200, mimetype="application/json")
 
 
+@app.route("/redfish/v1/TaskService/Tasks/547")
+def task_status_547():
+    res = {
+        "@odata.id": "/redfish/v1/TaskService/Tasks/547",
+        "@odata.type": "#Task.v1_4_3.Task",
+        "@odata.etag": "653b835e9ee4af9ea7ea",
+        "Id": "547",
+        "Name": "Task 547",
+        "PercentComplete": app._percentage547,
+    }
+    if app._percentage547 == 0:
+        res["TaskState"] = "Running"
+    elif app._percentage547 in [25, 50, 75]:
+        res["TaskState"] = "Running"
+        res["TaskStatus"] = "OK"
+        res["Messages"] = [
+            {
+                "Message": "Applying image",
+                "MessageId": "Update.1.1.TransferringToComponent",
+            }
+        ]
+    elif app._percentage547 == 100:
+        res["TaskState"] = "Completed"
+        res["TaskStatus"] = "OK"
+        res["Messages"] = [
+            {
+                "Message": "Task completed OK",
+                "MessageId": "TaskEvent.1.0.TaskCompletedOK",
+            }
+        ]
+        if app._reassign_bmc:
+            app._bmc_reassigned = True
+    else:
+        res["TaskState"] = "Exception"
+    app._percentage547 += 25
+    return Response(response=json.dumps(res), status=200, mimetype="application/json")
+
+
+@app.route("/redfish/v1/TaskService/Tasks/548")
+def task_status_548():
+    # signals a required reset before reaching Completed, which short-circuits
+    # polling; the reassignment would only surface at true completion
+    res = {
+        "@odata.id": "/redfish/v1/TaskService/Tasks/548",
+        "@odata.type": "#Task.v1_4_3.Task",
+        "@odata.etag": "653b835e9ee4af9ea7ea",
+        "Id": "548",
+        "Name": "Task 548",
+        "PercentComplete": app._percentage548,
+    }
+    if app._percentage548 == 0:
+        res["TaskState"] = "Running"
+    elif app._percentage548 in [25, 50, 75]:
+        res["TaskState"] = "Running"
+        res["TaskStatus"] = "OK"
+        res["Messages"] = [
+            {
+                "Message": "A reset is required",
+                "MessageId": "Base.1.10.ResetRequired",
+            }
+        ]
+    elif app._percentage548 == 100:
+        res["TaskState"] = "Completed"
+        res["TaskStatus"] = "OK"
+        if app._reassign_bmc:
+            app._bmc_reassigned = True
+    else:
+        res["TaskState"] = "Exception"
+    app._percentage548 += 25
+    return Response(response=json.dumps(res), status=200, mimetype="application/json")
+
+
 @app.route("/FWUpdate-unlicensed", methods=["GET"])
 def fwupdate_unlicensed():
     res = {
@@ -537,11 +623,33 @@ def fwupdate():
     fileitem = request.files["UpdateFile"]
     if not fileitem.filename.endswith(".exe"):
         return _failure("filename invalid")
-    if fileitem.read().decode() != "hello":
+    contents = fileitem.read().decode()
+    app._reassign_bmc = False
+    app._bmc_reassigned = False
+    app._empty_bmc = False
+    if contents == "hello":
+        location = "/redfish/v1/TaskService/Tasks/545"
+    elif contents == "shift":
+        # reassign the member once the task reaches completion
+        app._reassign_bmc = True
+        app._percentage547 = 0
+        location = "/redfish/v1/TaskService/Tasks/547"
+    elif contents == "empty-shift":
+        # completes cleanly, but the member readback then has an empty body
+        app._reassign_bmc = True
+        app._empty_bmc = True
+        app._percentage547 = 0
+        location = "/redfish/v1/TaskService/Tasks/547"
+    elif contents == "reset-shift":
+        # same, but the task requires a reset before it completes
+        app._reassign_bmc = True
+        app._percentage548 = 0
+        location = "/redfish/v1/TaskService/Tasks/548"
+    else:
         return _failure("data invalid")
     res = {
         "Version": "P79 v1.45",
-        "@odata.id": "/redfish/v1/TaskService/Tasks/545",
+        "@odata.id": location,
         "@odata.etag": "653b835e9ee4af9ea7ea",
         "TaskMonitor": "/redfish/v1/TaskService/999",
     }
@@ -550,7 +658,7 @@ def fwupdate():
         json.dumps(res),
         status=202,
         mimetype="application/json",
-        headers={"Location": "/redfish/v1/TaskService/Tasks/545"},
+        headers={"Location": location},
     )
 
 


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Verify that a Redfish firmware inventory member still reports the same SoftwareId after an update task completes. This prevents an update from being credited to a selected target if the member identity changed during the task.