### PR TITLE
Move the status and percentage properties to FuDaemon

### DIFF
--- a/src/fu-daemon.c
+++ b/src/fu-daemon.c
@@ -25,12 +25,111 @@ typedef struct {
 	gboolean update_in_progress;
 	gboolean pending_stop;
 	guint process_quit_id;
+	FwupdStatus status; /* last emitted */
+	guint set_status_id;
+	gdouble percentage; /* last emitted */
 } FuDaemonPrivate;
+
+enum { PROP_0, PROP_STATUS, PROP_PERCENTAGE, PROP_LAST };
 
 G_DEFINE_TYPE_WITH_PRIVATE(FuDaemon, fu_daemon, G_TYPE_OBJECT)
 #define GET_PRIVATE(o) (fu_daemon_get_instance_private(o))
 
 #define FU_DAEMON_HOUSEKEEPING_DELAY 10 /* seconds */
+
+static void
+fu_daemon_set_status_internal(FuDaemon *self, FwupdStatus status)
+{
+	FuDaemonPrivate *priv = GET_PRIVATE(self);
+
+	/* sanity check */
+	if (priv->status == status)
+		return;
+	priv->status = status;
+	g_object_notify(G_OBJECT(self), "status");
+}
+
+FwupdStatus
+fu_daemon_get_status(FuDaemon *self)
+{
+	FuDaemonPrivate *priv = GET_PRIVATE(self);
+	g_return_val_if_fail(FU_IS_DAEMON(self), FWUPD_STATUS_UNKNOWN);
+	return priv->status;
+}
+
+typedef struct {
+	FuDaemon *self;
+	FwupdStatus status;
+} FuDaemonSetStatusHelper;
+
+static gboolean
+fu_daemon_set_status_cb(gpointer user_data)
+{
+	FuDaemonSetStatusHelper *helper = (FuDaemonSetStatusHelper *)user_data;
+	FuDaemon *self = FU_DAEMON(helper->self);
+	FuDaemonPrivate *priv = GET_PRIVATE(self);
+	priv->set_status_id = 0;
+	fu_daemon_set_status_internal(self, helper->status);
+	return G_SOURCE_REMOVE;
+}
+
+void
+fu_daemon_set_status(FuDaemon *self, FwupdStatus status)
+{
+	FuDaemonPrivate *priv = GET_PRIVATE(self);
+	FuDaemonSetStatusHelper *helper;
+
+	g_return_if_fail(FU_IS_DAEMON(self));
+
+	/* cancel anything pending */
+	if (priv->set_status_id != 0) {
+		g_source_remove(priv->set_status_id);
+		priv->set_status_id = 0;
+	}
+
+	/* sanity check */
+	if (priv->status == status)
+		return;
+
+	/* starting or stopping */
+	if ((priv->status == FWUPD_STATUS_IDLE && status != FWUPD_STATUS_WAITING_FOR_AUTH) ||
+	    status == FWUPD_STATUS_IDLE) {
+		fu_daemon_set_status_internal(self, status);
+		return;
+	}
+
+	/* defer all updates to avoid flickering the UI */
+	helper = g_new0(FuDaemonSetStatusHelper, 1);
+	helper->self = self;
+	helper->status = status;
+	priv->set_status_id = g_timeout_add_full(G_PRIORITY_DEFAULT,
+						 250, /* ms */
+						 fu_daemon_set_status_cb,
+						 helper,
+						 g_free);
+}
+
+void
+fu_daemon_set_percentage(FuDaemon *self, gdouble percentage)
+{
+	FuDaemonPrivate *priv = GET_PRIVATE(self);
+	gboolean notify;
+
+	g_return_if_fail(FU_IS_DAEMON(self));
+
+	notify = fwupd_percentage_delta_notify(priv->percentage, percentage);
+	priv->percentage = percentage;
+	if (notify)
+		g_object_notify(G_OBJECT(self), "percentage");
+}
+
+gdouble
+fu_daemon_get_percentage(FuDaemon *self)
+{
+	FuDaemonPrivate *priv = GET_PRIVATE(self);
+	g_return_val_if_fail(FU_IS_DAEMON(self), -1.f);
+	return priv->percentage;
+}
 
 FuEngine *
 fu_daemon_get_engine(FuDaemon *self)
@@ -250,12 +349,41 @@ fu_daemon_stop(FuDaemon *self, GError **error)
 }
 
 static void
+fu_daemon_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
+{
+	FuDaemon *self = FU_DAEMON(object);
+	FuDaemonPrivate *priv = GET_PRIVATE(self);
+	switch (prop_id) {
+	case PROP_STATUS:
+		g_value_set_uint(value, priv->status);
+		break;
+	case PROP_PERCENTAGE:
+		g_value_set_double(value, priv->percentage);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+		break;
+	}
+}
+
+static void
+fu_daemon_set_property(GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec)
+{
+	switch (prop_id) {
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+		break;
+	}
+}
+
+static void
 fu_daemon_init(FuDaemon *self)
 {
 	FuDaemonPrivate *priv = GET_PRIVATE(self);
 	g_autoptr(FuContext) ctx = fu_context_new();
 	priv->engine = fu_engine_new(ctx);
 	priv->loop = g_main_loop_new(NULL, FALSE);
+	priv->status = FWUPD_STATUS_IDLE;
 }
 
 static void
@@ -270,6 +398,8 @@ fu_daemon_finalize(GObject *obj)
 		g_source_remove(priv->housekeeping_id);
 	if (priv->process_quit_id != 0)
 		g_source_remove(priv->process_quit_id);
+	if (priv->set_status_id != 0)
+		g_source_remove(priv->set_status_id);
 	if (priv->engine != NULL)
 		g_object_unref(priv->engine);
 
@@ -280,5 +410,27 @@ static void
 fu_daemon_class_init(FuDaemonClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	GParamSpec *pspec;
+
 	object_class->finalize = fu_daemon_finalize;
+	object_class->get_property = fu_daemon_get_property;
+	object_class->set_property = fu_daemon_set_property;
+
+	pspec = g_param_spec_uint("status",
+				  NULL,
+				  NULL,
+				  FWUPD_STATUS_UNKNOWN,
+				  FWUPD_STATUS_LAST,
+				  FWUPD_STATUS_UNKNOWN,
+				  G_PARAM_READABLE | G_PARAM_STATIC_NAME);
+	g_object_class_install_property(object_class, PROP_STATUS, pspec);
+
+	pspec = g_param_spec_double("percentage",
+				    NULL,
+				    NULL,
+				    0.0,
+				    100.0,
+				    0.0,
+				    G_PARAM_READABLE | G_PARAM_STATIC_NAME);
+	g_object_class_install_property(object_class, PROP_PERCENTAGE, pspec);
 }

--- a/src/fu-daemon.h
+++ b/src/fu-daemon.h
@@ -42,3 +42,11 @@ void
 fu_daemon_set_update_in_progress(FuDaemon *self, gboolean update_in_progress) G_GNUC_NON_NULL(1);
 gboolean
 fu_daemon_get_pending_stop(FuDaemon *self) G_GNUC_NON_NULL(1);
+FwupdStatus
+fu_daemon_get_status(FuDaemon *self) G_GNUC_NON_NULL(1);
+void
+fu_daemon_set_status(FuDaemon *self, FwupdStatus status) G_GNUC_NON_NULL(1);
+gdouble
+fu_daemon_get_percentage(FuDaemon *self) G_GNUC_NON_NULL(1);
+void
+fu_daemon_set_percentage(FuDaemon *self, gdouble percentage) G_GNUC_NON_NULL(1);

--- a/src/fu-dbus-daemon.c
+++ b/src/fu-dbus-daemon.c
@@ -39,11 +39,8 @@ struct _FuDbusDaemon {
 	FuClientList *client_list;
 	guint32 clients_inhibit_id;
 	FuPolkitAuthority *authority;
-	FwupdStatus status; /* last emitted */
-	gdouble percentage; /* last emitted */
 	guint owner_id;
 	GPtrArray *system_inhibits;
-	guint set_status_id;
 };
 
 G_DEFINE_TYPE(FuDbusDaemon, fu_dbus_daemon, FU_TYPE_DAEMON)
@@ -174,69 +171,9 @@ fu_dbus_daemon_emit_property_changed(FuDbusDaemon *self,
 }
 
 static void
-fu_dbus_daemon_set_status_internal(FuDbusDaemon *self, FwupdStatus status)
-{
-	/* sanity check */
-	if (self->status == status)
-		return;
-	self->status = status;
-
-	g_debug("emitting PropertyChanged('Status'='%s')", fwupd_status_to_string(status));
-	fu_dbus_daemon_emit_property_changed(self, "Status", g_variant_new_uint32(status));
-}
-
-typedef struct {
-	FuDbusDaemon *self;
-	FwupdStatus status;
-} FuDbusDaemonSetStatusHelper;
-
-static gboolean
-fu_dbus_daemon_set_status_cb(gpointer user_data)
-{
-	FuDbusDaemonSetStatusHelper *helper = (FuDbusDaemonSetStatusHelper *)user_data;
-	FuDbusDaemon *self = FU_DBUS_DAEMON(helper->self);
-	self->set_status_id = 0;
-	fu_dbus_daemon_set_status_internal(self, helper->status);
-	return G_SOURCE_REMOVE;
-}
-
-static void
-fu_dbus_daemon_set_status(FuDbusDaemon *self, FwupdStatus status)
-{
-	FuDbusDaemonSetStatusHelper *helper;
-
-	/* cancel anything pending */
-	if (self->set_status_id != 0) {
-		g_source_remove(self->set_status_id);
-		self->set_status_id = 0;
-	}
-
-	/* sanity check */
-	if (self->status == status)
-		return;
-
-	/* starting or stopping */
-	if ((self->status == FWUPD_STATUS_IDLE && status != FWUPD_STATUS_WAITING_FOR_AUTH) ||
-	    status == FWUPD_STATUS_IDLE) {
-		fu_dbus_daemon_set_status_internal(self, status);
-		return;
-	}
-
-	/* defer all updates to avoid flickering the UI */
-	helper = g_new0(FuDbusDaemonSetStatusHelper, 1);
-	helper->self = self;
-	helper->status = status;
-	self->set_status_id = g_timeout_add_full(G_PRIORITY_DEFAULT,
-						 250, /* ms */
-						 fu_dbus_daemon_set_status_cb,
-						 helper,
-						 g_free);
-}
-
-static void
 fu_dbus_daemon_engine_status_changed_cb(FuEngine *engine, FwupdStatus status, FuDbusDaemon *self)
 {
-	fu_dbus_daemon_set_status(self, status);
+	fu_daemon_set_status(FU_DAEMON(self), status);
 
 	/* engine has gone idle */
 	if (status == FWUPD_STATUS_SHUTDOWN)
@@ -349,7 +286,7 @@ static void
 fu_dbus_daemon_auth_helper_free(FuMainAuthHelper *helper)
 {
 	/* always return to IDLE even in event of an auth error */
-	fu_dbus_daemon_set_status(helper->self, FWUPD_STATUS_IDLE);
+	fu_daemon_set_status(FU_DAEMON(helper->self), FWUPD_STATUS_IDLE);
 
 	if (helper->cabinet != NULL)
 		g_object_unref(helper->cabinet);
@@ -607,19 +544,7 @@ fu_dbus_daemon_progress_percentage_changed_cb(FuProgress *progress,
 					      gdouble percentage,
 					      FuDbusDaemon *self)
 {
-	gboolean notify = fwupd_percentage_delta_notify(self->percentage, percentage);
-	self->percentage = percentage;
-	if (notify) {
-		g_debug("emitting PropertyChanged('Percentage'='%.1f%%')", percentage);
-		fu_dbus_daemon_emit_property_changed(
-		    self,
-		    "Percentage",
-		    g_variant_new_uint32(fwupd_percentage_is_valid(percentage) ? (guint32)percentage
-									       : 0));
-		fu_dbus_daemon_emit_property_changed(self,
-						     "PercentageFull",
-						     g_variant_new_double(percentage));
-	}
+	fu_daemon_set_percentage(FU_DAEMON(self), percentage);
 }
 
 static void
@@ -627,7 +552,7 @@ fu_dbus_daemon_progress_status_changed_cb(FuProgress *progress,
 					  FwupdStatus status,
 					  FuDbusDaemon *self)
 {
-	fu_dbus_daemon_set_status(self, status);
+	fu_daemon_set_status(FU_DAEMON(self), status);
 }
 
 static void
@@ -1054,7 +979,7 @@ fu_dbus_daemon_install_with_helper(FuMainAuthHelper *helper_ref, GError **error)
 	}
 
 	/* authenticate all things in the action_ids */
-	fu_dbus_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+	fu_daemon_set_status(FU_DAEMON(self), FWUPD_STATUS_WAITING_FOR_AUTH);
 	fu_dbus_daemon_authorize_install_queue(g_steal_pointer(&helper));
 	return TRUE;
 }
@@ -1370,7 +1295,7 @@ fu_dbus_daemon_method_set_approved_firmware(FuDbusDaemon *self,
 	g_variant_get(parameters, "(^as)", &checksums);
 
 	/* authenticate */
-	fu_dbus_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+	fu_daemon_set_status(FU_DAEMON(self), FWUPD_STATUS_WAITING_FOR_AUTH);
 	helper = g_new0(FuMainAuthHelper, 1);
 	helper->self = self;
 	helper->flags = FU_FIRMWARE_PARSE_FLAG_NO_SEARCH;
@@ -1421,7 +1346,7 @@ fu_dbus_daemon_method_quit(FuDbusDaemon *self,
 	}
 
 	/* authenticate */
-	fu_dbus_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+	fu_daemon_set_status(FU_DAEMON(self), FWUPD_STATUS_WAITING_FOR_AUTH);
 	helper = g_new0(FuMainAuthHelper, 1);
 	helper->self = self;
 	helper->request = g_object_ref(request);
@@ -1463,7 +1388,7 @@ fu_dbus_daemon_method_self_sign(FuDbusDaemon *self,
 	}
 
 	/* authenticate */
-	fu_dbus_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+	fu_daemon_set_status(FU_DAEMON(self), FWUPD_STATUS_WAITING_FOR_AUTH);
 	helper->self = self;
 	helper->value = g_steal_pointer(&value);
 	helper->request = g_object_ref(request);
@@ -1585,7 +1510,7 @@ fu_dbus_daemon_method_get_remotes(FuDbusDaemon *self,
 	helper->self = self;
 
 	/* authenticate */
-	fu_dbus_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+	fu_daemon_set_status(FU_DAEMON(self), FWUPD_STATUS_WAITING_FOR_AUTH);
 	fu_polkit_authority_check(self->authority,
 				  fu_engine_request_get_sender(request),
 				  "org.freedesktop.fwupd.get-remotes",
@@ -1700,7 +1625,7 @@ fu_dbus_daemon_method_clear_results(FuDbusDaemon *self,
 	g_variant_get(parameters, "(&s)", &device_id);
 
 	/* authenticate */
-	fu_dbus_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+	fu_daemon_set_status(FU_DAEMON(self), FWUPD_STATUS_WAITING_FOR_AUTH);
 	helper = g_new0(FuMainAuthHelper, 1);
 	helper->self = self;
 	helper->request = g_object_ref(request);
@@ -1783,7 +1708,7 @@ fu_dbus_daemon_method_emulation_load(FuDbusDaemon *self,
 
 	g_variant_get(parameters, "(h)", &fd_handle);
 
-	fu_dbus_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+	fu_daemon_set_status(FU_DAEMON(self), FWUPD_STATUS_WAITING_FOR_AUTH);
 	helper = g_new0(FuMainAuthHelper, 1);
 	helper->self = self;
 	helper->request = g_object_ref(request);
@@ -1839,7 +1764,7 @@ fu_dbus_daemon_method_emulation_save(FuDbusDaemon *self,
 
 	g_variant_get(parameters, "(h)", &fd_handle);
 
-	fu_dbus_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+	fu_daemon_set_status(FU_DAEMON(self), FWUPD_STATUS_WAITING_FOR_AUTH);
 	helper = g_new0(FuMainAuthHelper, 1);
 	helper->self = self;
 	helper->request = g_object_ref(request);
@@ -1938,7 +1863,7 @@ fu_dbus_daemon_method_modify_device(FuDbusDaemon *self,
 	helper->device_id = g_strdup(device_id);
 	helper->key = g_strdup(key);
 	helper->value = g_strdup(value);
-	fu_dbus_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+	fu_daemon_set_status(FU_DAEMON(self), FWUPD_STATUS_WAITING_FOR_AUTH);
 	fu_polkit_authority_check(self->authority,
 				  fu_engine_request_get_sender(request),
 				  action_id,
@@ -2049,7 +1974,7 @@ fu_dbus_daemon_method_update_metadata(FuDbusDaemon *self,
 	g_variant_get(parameters, "(&shh)", &remote_id, &fd_data, &fd_sig);
 
 	/* authenticate */
-	fu_dbus_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+	fu_daemon_set_status(FU_DAEMON(self), FWUPD_STATUS_WAITING_FOR_AUTH);
 	helper = g_new0(FuMainAuthHelper, 1);
 	helper->self = self;
 	helper->request = g_object_ref(request);
@@ -2082,7 +2007,7 @@ fu_dbus_daemon_method_unlock(FuDbusDaemon *self,
 	g_variant_get(parameters, "(&s)", &device_id);
 
 	/* authenticate */
-	fu_dbus_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+	fu_daemon_set_status(FU_DAEMON(self), FWUPD_STATUS_WAITING_FOR_AUTH);
 	helper = g_new0(FuMainAuthHelper, 1);
 	helper->self = self;
 	helper->request = g_object_ref(request);
@@ -2109,7 +2034,7 @@ fu_dbus_daemon_method_activate(FuDbusDaemon *self,
 	g_variant_get(parameters, "(&s)", &device_id);
 
 	/* authenticate */
-	fu_dbus_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+	fu_daemon_set_status(FU_DAEMON(self), FWUPD_STATUS_WAITING_FOR_AUTH);
 	helper = g_new0(FuMainAuthHelper, 1);
 	helper->self = self;
 	helper->request = g_object_ref(request);
@@ -2235,7 +2160,7 @@ fu_dbus_daemon_method_modify_remote(FuDbusDaemon *self,
 	helper->self = self;
 
 	/* authenticate */
-	fu_dbus_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+	fu_daemon_set_status(FU_DAEMON(self), FWUPD_STATUS_WAITING_FOR_AUTH);
 	fu_polkit_authority_check(self->authority,
 				  fu_engine_request_get_sender(request),
 				  action_id,
@@ -2265,7 +2190,7 @@ fu_dbus_daemon_method_clean_remote(FuDbusDaemon *self,
 	helper->self = self;
 
 	/* authenticate */
-	fu_dbus_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+	fu_daemon_set_status(FU_DAEMON(self), FWUPD_STATUS_WAITING_FOR_AUTH);
 	fu_polkit_authority_check(self->authority,
 				  fu_engine_request_get_sender(request),
 				  "org.freedesktop.fwupd.clean-remote",
@@ -2295,7 +2220,7 @@ fu_dbus_daemon_method_verify_update(FuDbusDaemon *self,
 	helper->self = self;
 
 	/* authenticate */
-	fu_dbus_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+	fu_daemon_set_status(FU_DAEMON(self), FWUPD_STATUS_WAITING_FOR_AUTH);
 	fu_polkit_authority_check(self->authority,
 				  fu_engine_request_get_sender(request),
 				  "org.freedesktop.fwupd.verify-update",
@@ -2359,7 +2284,7 @@ fu_dbus_daemon_method_verify(FuDbusDaemon *self,
 	helper->self = self;
 
 	/* authenticate */
-	fu_dbus_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+	fu_daemon_set_status(FU_DAEMON(self), FWUPD_STATUS_WAITING_FOR_AUTH);
 	fu_polkit_authority_check(self->authority,
 				  fu_engine_request_get_sender(request),
 				  "org.freedesktop.fwupd.verify",
@@ -2667,7 +2592,7 @@ fu_dbus_daemon_method_get_bios_settings(FuDbusDaemon *self,
 		g_autoptr(FuMainAuthHelper) helper = NULL;
 
 		/* authenticate */
-		fu_dbus_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+		fu_daemon_set_status(FU_DAEMON(self), FWUPD_STATUS_WAITING_FOR_AUTH);
 		helper = g_new0(FuMainAuthHelper, 1);
 		helper->self = self;
 		helper->request = g_object_ref(request);
@@ -2697,7 +2622,7 @@ fu_dbus_daemon_method_set_bios_settings(FuDbusDaemon *self,
 	g_variant_get(parameters, "(a{ss})", &iter);
 
 	/* authenticate */
-	fu_dbus_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+	fu_daemon_set_status(FU_DAEMON(self), FWUPD_STATUS_WAITING_FOR_AUTH);
 	helper = g_new0(FuMainAuthHelper, 1);
 	helper->self = self;
 	helper->request = g_object_ref(request);
@@ -2727,7 +2652,7 @@ fu_dbus_daemon_method_fix_host_security_attr(FuDbusDaemon *self,
 	g_variant_get(parameters, "(&s)", &appstream_id);
 
 	/* authenticate */
-	fu_dbus_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+	fu_daemon_set_status(FU_DAEMON(self), FWUPD_STATUS_WAITING_FOR_AUTH);
 	helper = g_new0(FuMainAuthHelper, 1);
 	helper->self = self;
 	helper->request = g_object_ref(request);
@@ -2755,7 +2680,7 @@ fu_dbus_daemon_method_undo_host_security_attr(FuDbusDaemon *self,
 	g_variant_get(parameters, "(&s)", &appstream_id);
 
 	/* authenticate */
-	fu_dbus_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+	fu_daemon_set_status(FU_DAEMON(self), FWUPD_STATUS_WAITING_FOR_AUTH);
 	helper = g_new0(FuMainAuthHelper, 1);
 	helper->self = self;
 	helper->request = g_object_ref(request);
@@ -2931,14 +2856,16 @@ fu_dbus_daemon_get_property(GDBusConnection *connection_,
 		return g_variant_new_boolean(FALSE);
 
 	if (g_strcmp0(property_name, "Status") == 0)
-		return g_variant_new_uint32(self->status);
+		return g_variant_new_uint32(fu_daemon_get_status(FU_DAEMON(self)));
 
-	if (g_strcmp0(property_name, "Percentage") == 0)
+	if (g_strcmp0(property_name, "Percentage") == 0) {
+		gdouble percentage = fu_daemon_get_percentage(FU_DAEMON(self));
 		return g_variant_new_uint32(
-		    fwupd_percentage_is_valid(self->percentage) ? (guint32)self->percentage : 0);
+		    fwupd_percentage_is_valid(percentage) ? (guint32)percentage : 0);
+	}
 
 	if (g_strcmp0(property_name, "PercentageFull") == 0)
-		return g_variant_new_double(self->percentage);
+		return g_variant_new_double(fu_daemon_get_percentage(FU_DAEMON(self)));
 
 	if (g_strcmp0(property_name, FWUPD_RESULT_KEY_BATTERY_LEVEL) == 0)
 		return g_variant_new_uint32(fu_context_get_battery_level(ctx));
@@ -3282,11 +3209,43 @@ fu_dbus_daemon_setup(FuDaemon *daemon,
 }
 
 static void
+fu_dbus_daemon_status_notify_cb(FuDaemon *daemon, GParamSpec *pspec, gpointer user_data)
+{
+	FuDbusDaemon *self = FU_DBUS_DAEMON(daemon);
+	FwupdStatus status = fu_daemon_get_status(daemon);
+	g_debug("emitting PropertyChanged('Status'='%s')", fwupd_status_to_string(status));
+	fu_dbus_daemon_emit_property_changed(self, "Status", g_variant_new_uint32(status));
+}
+
+static void
+fu_dbus_daemon_percentage_notify_cb(FuDaemon *daemon, GParamSpec *pspec, gpointer user_data)
+{
+	FuDbusDaemon *self = FU_DBUS_DAEMON(daemon);
+	gdouble percentage = fu_daemon_get_percentage(daemon);
+
+	g_debug("emitting PropertyChanged('Percentage'='%.1f%%')", percentage);
+	fu_dbus_daemon_emit_property_changed(
+	    self,
+	    "Percentage",
+	    g_variant_new_uint32(fwupd_percentage_is_valid(percentage) ? (guint32)percentage : 0));
+	fu_dbus_daemon_emit_property_changed(self,
+					     "PercentageFull",
+					     g_variant_new_double(percentage));
+}
+
+static void
 fu_dbus_daemon_init(FuDbusDaemon *self)
 {
-	self->status = FWUPD_STATUS_IDLE;
 	self->system_inhibits =
 	    g_ptr_array_new_with_free_func((GDestroyNotify)fu_dbus_daemon_system_inhibit_free);
+	g_signal_connect(FU_DAEMON(self),
+			 "notify::status",
+			 G_CALLBACK(fu_dbus_daemon_status_notify_cb),
+			 NULL);
+	g_signal_connect(FU_DAEMON(self),
+			 "notify::percentage",
+			 G_CALLBACK(fu_dbus_daemon_percentage_notify_cb),
+			 NULL);
 }
 
 static void
@@ -3295,8 +3254,6 @@ fu_dbus_daemon_finalize(GObject *obj)
 	FuDbusDaemon *self = FU_DBUS_DAEMON(obj);
 
 	g_ptr_array_unref(self->system_inhibits);
-	if (self->set_status_id != 0)
-		g_source_remove(self->set_status_id);
 	if (self->client_list != NULL)
 		g_object_unref(self->client_list);
 	if (self->owner_id > 0)


### PR DESCRIPTION
We need to do all the same logic in FuBinderDaemon and it makes no sense to duplicate it.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
