### PR TITLE
dell-dock: always test dock type when connected

### DIFF
--- a/plugins/dell-dock/fu-dell-dock-ec.c
+++ b/plugins/dell-dock/fu-dell-dock-ec.c
@@ -982,9 +982,8 @@ fu_dell_dock_ec_open(FuDevice *device, GError **error)
 		return FALSE;
 	if (!fu_device_open(proxy, error))
 		return FALSE;
-	if (self->st_data != NULL && !fu_struct_dell_dock_data_get_dock_type(self->st_data))
-		return fu_dell_dock_ec_is_valid_dock(self, error);
-	return TRUE;
+
+	return fu_dell_dock_ec_is_valid_dock(self, error);
 }
 
 static gboolean


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

This is a fix for the following warning message:

> 16:08:10.554 FuEngine             failed to add device /sys/devices/pci0000:00/0000:00:14.0/usb3/3-1/3-1.3/3-1.3.4/3-1.3.4.3: failed to add device using on dell_dock: failed to setup: Failed to query dock info: Invalid result data: 190 expected 103


The `dell-dock` plugin should drop this device (e.g., WD25) earlier according to `dock data` exposed `dock_type`.
