### PR TITLE
modem-manager: Free the FDL write helper GBytes with g_bytes_unref

### DIFF
--- a/plugins/modem-manager/fu-mm-fdl-device.c
+++ b/plugins/modem-manager/fu-mm-fdl-device.c
@@ -139,9 +139,9 @@ static void
 fu_mm_fdl_device_write_helper_free(FuMmFdlDeviceWriteHelper *helper)
 {
 	if (helper->size_bytes)
-		g_object_unref(helper->size_bytes);
+		g_bytes_unref(helper->size_bytes);
 	if (helper->chunk_bytes)
-		g_object_unref(helper->chunk_bytes);
+		g_bytes_unref(helper->chunk_bytes);
 	g_free(helper);
 }
 


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

**Wrong deallocator for the write-helper GBytes**

`FuMmFdlDeviceWriteHelper` keeps the size and chunk buffers as `GBytes`, both created by `fu_bytes_new_offset()`, but the cleanup releases them with `g_object_unref()`. A `GBytes` is a boxed type rather than a `GObject`, so `g_object_unref()` reinterprets the buffer's `data` pointer as a `GTypeClass` and the reference is never dropped, leaking each chunk on every Cinterion FDL write. Both are now released with `g_bytes_unref()`.
