### PR TITLE
policy: Fix fwupd-refresh.service polkit auth errors

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -289,7 +289,6 @@ cd -
     -Dhsi=disabled \
 %endif
     -Dman=true \
-    -Dsystemd_unit_user="" \
     -Dbluez=enabled
 
 %meson_build
@@ -391,6 +390,7 @@ systemctl --no-reload preset fwupd-refresh.timer &>/dev/null || :
 %{_unitdir}/fwupd.service
 %{_unitdir}/fwupd-refresh.service
 %{_unitdir}/fwupd-refresh.timer
+/usr/lib/sysusers.d/fwupd.conf
 %dir %{_localstatedir}/lib/fwupd
 %dir %{_localstatedir}/cache/fwupd
 %dir %{_datadir}/fwupd/quirks.d

--- a/policy/org.freedesktop.fwupd.rules
+++ b/policy/org.freedesktop.fwupd.rules
@@ -5,3 +5,12 @@ polkit.addRule(function(action, subject) {
             return polkit.Result.YES;
     }
 });
+
+// Always allow the fwupd-refresh service user to refresh metadata.
+polkit.addRule(function(action, subject) {
+    if ((action.id == "org.freedesktop.fwupd.get-remotes" ||
+            action.id == "org.freedesktop.fwupd.refresh-remote") &&
+        subject.user == "fwupd-refresh") {
+        return polkit.Result.YES;
+    }
+});


### PR DESCRIPTION
The fwupd-refresh service is currently failing on CoreOS with polkit authorization errors (even after aaf4a1e). See [1].

Add a polkit rule following what was done in [2] to grant the fwupd-refresh service user permissions to refresh metadata. Also remove the -Dsystemd_unit_user="" override and include the sysusers.d file in the spec file so that the user is actually created, giving polkit a stable username to match against.

[1]: https://github.com/coreos/fedora-coreos-tracker/issues/2176
[2]: https://github.com/NixOS/nixpkgs/pull/526476

Closes: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1139344

---

Disclaimer: this is my first time working with polkit stuff, but see https://github.com/coreos/fedora-coreos-tracker/issues/2176#issuecomment-4935479109 for my understanding of the problem. The changes in this patch do seem to fix the issue on CoreOS though. I'm unsure of the reasoning behind that line in the spec file so if this isn't the way to go that's just let me know. Happy to make any changes.

---

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
