### PR TITLE
sunwinon-hid: avoid guint32 overflow in the firmware size check

### DIFF
--- a/plugins/sunwinon-hid/fu-sunwinon-hid-firmware.c
+++ b/plugins/sunwinon-hid/fu-sunwinon-hid-firmware.c
@@ -93,7 +93,7 @@ fu_sunwinon_hid_firmware_parse(FuFirmware *firmware,
 	self->bin_size = fu_struct_sunwinon_dfu_image_info_get_bin_size(st);
 
 	/* check fw sign pattern to see if it is signed */
-	if (streamsz >= self->bin_size + FU_STRUCT_SUNWINON_DFU_IMAGE_INFO_SIZE +
+	if (streamsz >= (gsize)self->bin_size + FU_STRUCT_SUNWINON_DFU_IMAGE_INFO_SIZE +
 			    FU_SUNWINON_HID_DFU_SIGN_LEN) {
 		guint32 fw_pattern_deadbeef = 0;
 		guint32 fw_pattern_sign = 0;
@@ -120,7 +120,8 @@ fu_sunwinon_hid_firmware_parse(FuFirmware *firmware,
 	}
 
 	/* check if the fw is correctly packed */
-	if (streamsz != self->bin_size + FU_STRUCT_SUNWINON_DFU_IMAGE_INFO_SIZE + tail_size) {
+	if (streamsz !=
+	    (gsize)self->bin_size + FU_STRUCT_SUNWINON_DFU_IMAGE_INFO_SIZE + tail_size) {
 		g_set_error(
 		    error,
 		    FWUPD_ERROR,


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

**Wrapped size check in the sunwinon-hid firmware parser**

`bin_size` is read as a `u32le` from the image trailer and added to the info-struct and signature lengths as `guint32`, so a value near `0xFFFFFFFF` wraps the sum and a truncated image slips past both the sign-pattern gate and the final packing check (and can be mis-tagged as signed). `streamsz` is already a `gsize`, so I have widened the two comparisons to match; well-formed images parse exactly as before.
