### PR TITLE
Wrap the GLib input stream types into our own types

### DIFF
--- a/contrib/ci/check-source.py
+++ b/contrib/ci/check-source.py
@@ -851,6 +851,20 @@ class Checker:
                 self.add_failure(
                     f"contains blocked token {token.data}: {msg}", linecnt=token.linecnt
                 )
+        # only enforce FuInputStream/FuMemoryInputStream outside of libfwupd
+        if not self._current_fn or not self._current_fn.startswith("libfwupd/"):
+            for token, msg in {
+                "~g_memory_input_stream_new*": "Use fu_memory_input_stream_new*() instead",
+                "g_file_read": "Use fu_file_input_stream_from_file() instead",
+                "~g_file_input_stream_*": "Use fu_file_input_stream_*() instead",
+            }.items():
+                idx = node.tokens.find_fuzzy([token, "("])
+                if idx != -1:
+                    token = node.tokens[idx]
+                    self.add_failure(
+                        f"contains blocked token {token.data}: {msg}",
+                        linecnt=token.linecnt,
+                    )
 
         idx = node.tokens.find_fuzzy(["|=", "~1*", "<", "<"])
         if idx != -1:
@@ -885,6 +899,20 @@ class Checker:
                         f"contains blocked token {token.data}: {msg}",
                         linecnt=token.linecnt,
                     )
+
+        # only enforce FuInputStream/FuMemoryInputStream outside of libfwupd
+        if not self._current_fn or not self._current_fn.startswith("libfwupd/"):
+            for search, msg in {
+                "GInputStream": "Use FuInputStream instead",
+                "GMemoryInputStream": "Use FuMemoryInputStream instead",
+                "GFileInputStream": "Use FuFileInputStream instead",
+            }.items():
+                for token in node.tokens:
+                    if token.data == search:
+                        self.add_failure(
+                            f"contains blocked token {token.data}: {msg}",
+                            linecnt=token.linecnt,
+                        )
 
     def _test_magic_numbers_defined(self, nodes: List[Node]) -> None:
         cnt: int = 0

--- a/contrib/ci/qt5-thread-test/qt-thread-test.cpp
+++ b/contrib/ci/qt5-thread-test/qt-thread-test.cpp
@@ -7,24 +7,24 @@
 #include <fwupd.h>
 
 #include <QCoreApplication>
-#include <QtConcurrentRun>
 #include <QFutureWatcher>
+#include <QtConcurrentRun>
 
-int main(int argc, char** argv)
+int
+main(int argc, char **argv)
 {
-    QCoreApplication app(argc, argv);
+	QCoreApplication app(argc, argv);
 
-    auto client = fwupd_client_new();
-    auto cancellable = g_cancellable_new();
-    g_autoptr(GError) error = nullptr;
+	auto client = fwupd_client_new();
+	auto cancellable = g_cancellable_new();
+	g_autoptr(GError) error = nullptr;
 
-    auto fw = new QFutureWatcher<GPtrArray*>(&app);
-    QObject::connect(fw, &QFutureWatcher<GPtrArray*>::finished, [fw]() {
-        QCoreApplication::exit(0);
-    });
-    fw->setFuture(QtConcurrent::run([&] {
-        return fwupd_client_get_devices(client, cancellable, &error);
-    }));
+	auto fw = new QFutureWatcher<GPtrArray *>(&app);
+	QObject::connect(fw, &QFutureWatcher<GPtrArray *>::finished, [fw]() {
+		QCoreApplication::exit(0);
+	});
+	fw->setFuture(QtConcurrent::run(
+	    [&] { return fwupd_client_get_devices(client, cancellable, &error); }));
 
-    return app.exec();
+	return app.exec();
 }

--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -89,7 +89,7 @@ typedef struct {
 	GStrv hwid_keys;
 	GStrv hwid_values;
 	GMutex download_items_mutex; /* for @download_items */
-	GPtrArray *download_items; /* element-type FwupdClientDownloadItem */
+	GPtrArray *download_items;   /* element-type FwupdClientDownloadItem */
 } FwupdClientPrivate;
 
 typedef struct {

--- a/libfwupdplugin/fu-acpi-table.c
+++ b/libfwupdplugin/fu-acpi-table.c
@@ -27,7 +27,7 @@ typedef struct {
 	gchar *oem_id;
 	gchar *oem_table_id;
 	guint32 oem_revision;
-	GInputStream *payload;
+	FuInputStream *payload;
 } FuAcpiTablePrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE(FuAcpiTable, fu_acpi_table, FU_TYPE_FIRMWARE)
@@ -123,11 +123,11 @@ fu_acpi_table_get_oem_revision(FuAcpiTable *self)
  *
  * Gets the payload after the ACPI header. This function will fail if there is no payload.
  *
- * Returns: (transfer full): a #GInputStream, or %NULL on error
+ * Returns: (transfer full): a #FuInputStream, or %NULL on error
  *
  * Since: 2.1.3
  **/
-GInputStream *
+FuInputStream *
 fu_acpi_table_get_payload(FuAcpiTable *self, GError **error)
 {
 	FuAcpiTablePrivate *priv = GET_PRIVATE(self);
@@ -142,7 +142,7 @@ fu_acpi_table_get_payload(FuAcpiTable *self, GError **error)
 
 static gboolean
 fu_acpi_table_parse(FuFirmware *firmware,
-		    GInputStream *stream,
+		    FuInputStream *stream,
 		    FuFirmwareParseFlags flags,
 		    GError **error)
 {

--- a/libfwupdplugin/fu-acpi-table.h
+++ b/libfwupdplugin/fu-acpi-table.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "fu-firmware.h"
+#include "fu-input-stream.h"
 
 #define FU_TYPE_ACPI_TABLE (fu_acpi_table_get_type())
 G_DECLARE_DERIVABLE_TYPE(FuAcpiTable, fu_acpi_table, FU, ACPI_TABLE, FuFirmware)
@@ -25,5 +26,5 @@ const gchar *
 fu_acpi_table_get_oem_table_id(FuAcpiTable *self) G_GNUC_NON_NULL(1);
 guint32
 fu_acpi_table_get_oem_revision(FuAcpiTable *self) G_GNUC_NON_NULL(1);
-GInputStream *
+FuInputStream *
 fu_acpi_table_get_payload(FuAcpiTable *self, GError **error) G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-bios-settings.c
+++ b/libfwupdplugin/fu-bios-settings.c
@@ -10,6 +10,7 @@
 
 #include <glib/gi18n.h>
 
+#include "fwupd-bios-setting-struct.h"
 #include "fwupd-error.h"
 
 #include "fu-bios-setting.h"
@@ -19,8 +20,6 @@
 #include "fu-path.h"
 #include "fu-quirks.h"
 #include "fu-string.h"
-
-#include "fwupd-bios-setting-struct.h"
 
 #define LENOVO_READ_ONLY_NEEDLE "[Status:ShowOnly]"
 
@@ -363,7 +362,9 @@ static const struct {
 	const gchar *icon;
 } fu_bios_settings_appstream[] = {
     {"org.fwupd.bios.secure-boot", N_("Secure Boot"), "application-certificate"},
-    {"org.fwupd.bios.firmware-update-opt-in", N_("Firmware Update Opt-in"), "system-software-update"},
+    {"org.fwupd.bios.firmware-update-opt-in",
+     N_("Firmware Update Opt-in"),
+     "system-software-update"},
     {"org.fwupd.bios.wake-on-lan", N_("Wake on LAN"), "network-wired"},
     {"org.fwupd.bios.num-lock", N_("Num Lock"), "input-keyboard"},
     {"org.fwupd.bios.memory-encryption", N_("Memory Encryption"), "security-high"},

--- a/libfwupdplugin/fu-cab-firmware.c
+++ b/libfwupdplugin/fu-cab-firmware.c
@@ -72,7 +72,7 @@ fu_cab_firmware_set_compressed(FuCabFirmware *self, gboolean compressed)
 }
 
 typedef struct {
-	GInputStream *stream;
+	FuInputStream *stream;
 	FuFirmwareParseFlags parse_flags;
 	gsize rsvd_folder;
 	gsize rsvd_block;
@@ -166,7 +166,7 @@ static gboolean
 fu_cab_firmware_parse_data(FuCabFirmware *self,
 			   FuCabFirmwareParseHelper *helper,
 			   gsize *offset,
-			   GInputStream *folder_data,
+			   FuInputStream *folder_data,
 			   GError **error)
 {
 	gsize blob_comp;
@@ -175,7 +175,7 @@ fu_cab_firmware_parse_data(FuCabFirmware *self,
 	gsize payload_offset = *offset;
 	gsize size_max = fu_firmware_get_size_max(FU_FIRMWARE(self));
 	g_autoptr(FuStructCabData) st = NULL;
-	g_autoptr(GInputStream) partial_stream = NULL;
+	g_autoptr(FuInputStream) partial_stream = NULL;
 
 	/* parse header */
 	st = fu_struct_cab_data_parse_stream(helper->stream, *offset, error);
@@ -413,7 +413,7 @@ fu_cab_firmware_parse_folder(FuCabFirmware *self,
 			     FuCabFirmwareParseHelper *helper,
 			     guint idx,
 			     gsize offset,
-			     GInputStream *folder_data,
+			     FuInputStream *folder_data,
 			     GError **error)
 {
 	FuCabFirmwarePrivate *priv = GET_PRIVATE(self);
@@ -470,14 +470,14 @@ fu_cab_firmware_parse_file(FuCabFirmware *self,
 			   FuFirmwareParseFlags flags,
 			   GError **error)
 {
-	GInputStream *folder_data;
+	FuInputStream *folder_data;
 	guint16 date;
 	guint16 index;
 	guint16 time;
 	g_autoptr(FuCabImage) img = fu_cab_image_new();
 	g_autoptr(FuStructCabFile) st = NULL;
 	g_autoptr(GDateTime) created = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(GString) filename = g_string_new(NULL);
 	g_autoptr(GTimeZone) tz_utc = g_time_zone_new_utc();
 
@@ -571,13 +571,13 @@ fu_cab_firmware_parse_file(FuCabFirmware *self,
 }
 
 static gboolean
-fu_cab_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize offset, GError **error)
+fu_cab_firmware_validate(FuFirmware *firmware, FuInputStream *stream, gsize offset, GError **error)
 {
 	return fu_struct_cab_header_validate_stream(stream, offset, error);
 }
 
 static FuCabFirmwareParseHelper *
-fu_cab_firmware_parse_helper_new(GInputStream *stream, FuFirmwareParseFlags flags, GError **error)
+fu_cab_firmware_parse_helper_new(FuInputStream *stream, FuFirmwareParseFlags flags, GError **error)
 {
 	int zret;
 	g_autoptr(FuCabFirmwareParseHelper) helper = g_new0(FuCabFirmwareParseHelper, 1);
@@ -604,7 +604,7 @@ fu_cab_firmware_parse_helper_new(GInputStream *stream, FuFirmwareParseFlags flag
 
 static gboolean
 fu_cab_firmware_parse(FuFirmware *firmware,
-		      GInputStream *stream,
+		      FuInputStream *stream,
 		      FuFirmwareParseFlags flags,
 		      GError **error)
 {
@@ -729,7 +729,7 @@ fu_cab_firmware_parse(FuFirmware *firmware,
 
 	/* parse CFFOLDER */
 	for (guint i = 0; i < fu_struct_cab_header_get_nr_folders(st); i++) {
-		g_autoptr(GInputStream) folder_data = fu_composite_input_stream_new();
+		g_autoptr(FuInputStream) folder_data = fu_composite_input_stream_new();
 		if (!fu_cab_firmware_parse_folder(self, helper, i, offset, folder_data, error))
 			return FALSE;
 		if (!fu_input_stream_size(folder_data, &streamsz, error))

--- a/libfwupdplugin/fu-cbor-common.c
+++ b/libfwupdplugin/fu-cbor-common.c
@@ -17,7 +17,7 @@ typedef struct {
 	guint max_depth;
 	guint max_items;
 	guint max_length;
-	GInputStream *stream; /* no ref */
+	FuInputStream *stream; /* no ref */
 	gsize offset;
 } FuCborParseHelper;
 
@@ -276,7 +276,7 @@ fu_cbor_parse_item(FuCborParseHelper *helper, guint current_depth, GError **erro
 
 /**
  * fu_cbor_parse: (skip):
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @offset: (inout) (nullable): stream position
  * @max_depth: maximum depth, or 0 for no limit
  * @max_items: maximum number of items, or 0 for no limit
@@ -290,7 +290,7 @@ fu_cbor_parse_item(FuCborParseHelper *helper, guint current_depth, GError **erro
  * Since: 2.1.2
  **/
 FuCborItem *
-fu_cbor_parse(GInputStream *stream,
+fu_cbor_parse(FuInputStream *stream,
 	      gsize *offset,
 	      guint max_depth,
 	      guint max_items,
@@ -305,7 +305,7 @@ fu_cbor_parse(GInputStream *stream,
 	    .max_length = max_length,
 	};
 
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), NULL);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
 	if (offset != NULL)

--- a/libfwupdplugin/fu-cbor-common.h
+++ b/libfwupdplugin/fu-cbor-common.h
@@ -7,9 +7,10 @@
 #pragma once
 
 #include "fu-cbor-item.h"
+#include "fu-input-stream.h"
 
 FuCborItem *
-fu_cbor_parse(GInputStream *stream,
+fu_cbor_parse(FuInputStream *stream,
 	      gsize *offset,
 	      guint max_depth,
 	      guint max_items,

--- a/libfwupdplugin/fu-cbor-test.c
+++ b/libfwupdplugin/fu-cbor-test.c
@@ -7,6 +7,7 @@
 #include "config.h"
 
 #include "fu-cbor-common.h"
+#include "fu-input-stream.h"
 
 /* nocheck:magic-inlines=200 */
 
@@ -20,7 +21,7 @@ fu_cbor_item_depth_func(void)
 	g_autoptr(FuCborItem) item3 = fu_cbor_item_new_array();
 	g_autoptr(GByteArray) buf = NULL;
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	ret = fu_cbor_item_array_append(item1, item2, &error);
 	g_assert_no_error(error);
@@ -51,7 +52,7 @@ fu_cbor_item_items_func(void)
 	g_autoptr(FuCborItem) item3 = fu_cbor_item_new_integer(2);
 	g_autoptr(GByteArray) buf = NULL;
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	ret = fu_cbor_item_map_append(item1, item2, item3, &error);
 	g_assert_no_error(error);
@@ -112,7 +113,7 @@ fu_cbor_item_integer_func(void)
 	g_autoptr(FuCborItem) item3 = fu_cbor_item_new_integer(G_MAXINT64);
 	g_autoptr(GByteArray) buf = NULL;
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	ret = fu_cbor_item_map_append(item1, item2, item3, &error);
 	g_assert_no_error(error);
@@ -144,7 +145,7 @@ fu_cbor_item_string_func(void)
 	g_autoptr(FuCborItem) item2 = fu_cbor_item_new_string(NULL);
 	g_autoptr(GByteArray) buf = NULL;
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	ret = fu_cbor_item_array_append(item1, item2, &error);
 	g_assert_no_error(error);
@@ -180,7 +181,7 @@ fu_cbor_item_bytes_func(void)
 	g_autoptr(FuCborItem) item2 = fu_cbor_item_new_bytes(blob);
 	g_autoptr(GByteArray) buf = NULL;
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	ret = fu_cbor_item_array_append(item1, item2, &error);
 	g_assert_no_error(error);
@@ -214,7 +215,7 @@ fu_cbor_item_func(void)
 	g_autofree gchar *str = NULL;
 	g_autoptr(FuCborItem) item = NULL;
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	const guint8 buf[] = {
 	    0xa7, 0x0f, 0x65, 0x65, 0x6e, 0x2d, 0x55, 0x53, 0x00, 0x64, 0x64, 0x61, 0x76, 0x65,
 	    0x08, 0xf5, 0x01, 0x6c, 0x66, 0x69, 0x72, 0x6d, 0x77, 0x61, 0x72, 0x65, 0x2e, 0x62,

--- a/libfwupdplugin/fu-cbor-test.c
+++ b/libfwupdplugin/fu-cbor-test.c
@@ -7,7 +7,7 @@
 #include "config.h"
 
 #include "fu-cbor-common.h"
-#include "fu-input-stream.h"
+#include "fu-memory-input-stream.h"
 
 /* nocheck:magic-inlines=200 */
 
@@ -35,7 +35,7 @@ fu_cbor_item_depth_func(void)
 	g_assert_nonnull(buf);
 	g_assert_cmpint(buf->len, ==, 3);
 
-	stream = g_memory_input_stream_new_from_data(buf->data, buf->len, NULL);
+	stream = fu_memory_input_stream_new_from_data(buf->data, buf->len, NULL);
 	g_assert_nonnull(stream);
 	item = fu_cbor_parse(stream, NULL, 2, 0, 0, &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
@@ -66,7 +66,7 @@ fu_cbor_item_items_func(void)
 	g_assert_nonnull(buf);
 	g_assert_cmpint(buf->len, ==, 5);
 
-	stream = g_memory_input_stream_new_from_data(buf->data, buf->len, NULL);
+	stream = fu_memory_input_stream_new_from_data(buf->data, buf->len, NULL);
 	g_assert_nonnull(stream);
 	item = fu_cbor_parse(stream, NULL, 0, 1, 0, &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
@@ -127,7 +127,7 @@ fu_cbor_item_integer_func(void)
 	g_assert_nonnull(buf);
 	g_assert_cmpint(buf->len, ==, 29);
 
-	stream = g_memory_input_stream_new_from_data(buf->data, buf->len, NULL);
+	stream = fu_memory_input_stream_new_from_data(buf->data, buf->len, NULL);
 	g_assert_nonnull(stream);
 	item = fu_cbor_parse(stream, NULL, 0, 0, 0, &error);
 	g_assert_no_error(error);
@@ -155,7 +155,7 @@ fu_cbor_item_string_func(void)
 	g_assert_nonnull(buf);
 	g_assert_cmpint(buf->len, ==, 2);
 
-	stream = g_memory_input_stream_new_from_data(buf->data, buf->len, NULL);
+	stream = fu_memory_input_stream_new_from_data(buf->data, buf->len, NULL);
 	g_assert_nonnull(stream);
 	item = fu_cbor_parse(stream, NULL, 0, 0, 0, &error);
 	g_assert_no_error(error);
@@ -191,7 +191,7 @@ fu_cbor_item_bytes_func(void)
 	g_assert_nonnull(buf);
 	g_assert_cmpint(buf->len, ==, 5);
 
-	stream = g_memory_input_stream_new_from_data(buf->data, buf->len, NULL);
+	stream = fu_memory_input_stream_new_from_data(buf->data, buf->len, NULL);
 	g_assert_nonnull(stream);
 	item = fu_cbor_parse(stream, NULL, 0, 0, 0, &error);
 	g_assert_no_error(error);
@@ -232,7 +232,7 @@ fu_cbor_item_func(void)
 	 * "uSWID", "54": "def", "52": "Dave", "45": "acb"}, "2": {"31": "Hughski Ltd", "32":
 	 * "hughsie.com", "33": [1, 2, 3, 4, 5, 6]}}
 	 */
-	stream = g_memory_input_stream_new_from_data(buf, sizeof(buf), NULL);
+	stream = fu_memory_input_stream_new_from_data(buf, sizeof(buf), NULL);
 	g_assert_nonnull(stream);
 
 	item = fu_cbor_parse(stream, NULL, 0, 0, 0, &error);

--- a/libfwupdplugin/fu-cfu-offer.c
+++ b/libfwupdplugin/fu-cfu-offer.c
@@ -11,6 +11,7 @@
 #include "fu-cfu-firmware-struct.h"
 #include "fu-cfu-offer.h"
 #include "fu-common.h"
+#include "fu-input-stream.h"
 #include "fu-string.h"
 #include "fu-version-common.h"
 
@@ -417,7 +418,7 @@ fu_cfu_offer_set_product_id(FuCfuOffer *self, guint16 product_id)
 
 static gboolean
 fu_cfu_offer_parse(FuFirmware *firmware,
-		   GInputStream *stream,
+		   FuInputStream *stream,
 		   FuFirmwareParseFlags flags,
 		   GError **error)
 {

--- a/libfwupdplugin/fu-cfu-payload.c
+++ b/libfwupdplugin/fu-cfu-payload.c
@@ -30,7 +30,7 @@ G_DEFINE_TYPE(FuCfuPayload, fu_cfu_payload, FU_TYPE_FIRMWARE)
 
 static gboolean
 fu_cfu_payload_parse(FuFirmware *firmware,
-		     GInputStream *stream,
+		     FuInputStream *stream,
 		     FuFirmwareParseFlags flags,
 		     GError **error)
 {

--- a/libfwupdplugin/fu-chunk-array.c
+++ b/libfwupdplugin/fu-chunk-array.c
@@ -22,7 +22,7 @@
 struct _FuChunkArray {
 	GObject parent_instance;
 	GBytes *blob;
-	GInputStream *stream;
+	FuInputStream *stream;
 	gsize addr_offset;
 	gsize page_sz;
 	gsize packet_sz;
@@ -232,7 +232,7 @@ fu_chunk_array_new_virtual(gsize bufsz, gsize addr_offset, gsize page_sz, gsize 
 
 /**
  * fu_chunk_array_new_from_stream:
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @addr_offset: the hardware address offset, or %FU_CHUNK_ADDR_OFFSET_NONE
  * @page_sz: the hardware page size, typically %FU_CHUNK_PAGESZ_NONE
  * @packet_sz: the packet size, or 0x0
@@ -246,7 +246,7 @@ fu_chunk_array_new_virtual(gsize bufsz, gsize addr_offset, gsize page_sz, gsize 
  * Since: 2.0.2
  **/
 FuChunkArray *
-fu_chunk_array_new_from_stream(GInputStream *stream,
+fu_chunk_array_new_from_stream(FuInputStream *stream,
 			       gsize addr_offset,
 			       gsize page_sz,
 			       gsize packet_sz,
@@ -254,7 +254,7 @@ fu_chunk_array_new_from_stream(GInputStream *stream,
 {
 	g_autoptr(FuChunkArray) self = g_object_new(FU_TYPE_CHUNK_ARRAY, NULL);
 
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), NULL);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 	g_return_val_if_fail(page_sz == 0 || page_sz >= packet_sz, NULL);
 

--- a/libfwupdplugin/fu-chunk-array.h
+++ b/libfwupdplugin/fu-chunk-array.h
@@ -9,6 +9,7 @@
 #include <fwupd.h>
 
 #include "fu-chunk.h"
+#include "fu-input-stream.h"
 
 #define FU_TYPE_CHUNK_ARRAY (fu_chunk_array_get_type())
 
@@ -20,7 +21,7 @@ FuChunkArray *
 fu_chunk_array_new_from_bytes(GBytes *blob, gsize addr_offset, gsize page_sz, gsize packet_sz)
     G_GNUC_NON_NULL(1);
 FuChunkArray *
-fu_chunk_array_new_from_stream(GInputStream *stream,
+fu_chunk_array_new_from_stream(FuInputStream *stream,
 			       gsize addr_offset,
 			       gsize page_sz,
 			       gsize packet_sz,

--- a/libfwupdplugin/fu-composite-input-stream-test.c
+++ b/libfwupdplugin/fu-composite-input-stream-test.c
@@ -114,7 +114,7 @@ fu_composite_input_stream_func(void)
 	ret = g_seekable_seek(G_SEEKABLE(composite_stream), 0x1, G_SEEK_SET, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	rc = g_input_stream_read(composite_stream, buf, 2, NULL, &error);
+	rc = g_input_stream_read(G_INPUT_STREAM(composite_stream), buf, 2, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 1);
 	g_assert_cmpint(buf[0], ==, 'b');
@@ -124,7 +124,7 @@ fu_composite_input_stream_func(void)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(composite_stream)), ==, 0x7);
-	rc = g_input_stream_read(composite_stream, buf, sizeof(buf), NULL, &error);
+	rc = g_input_stream_read(G_INPUT_STREAM(composite_stream), buf, sizeof(buf), NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 
@@ -133,7 +133,7 @@ fu_composite_input_stream_func(void)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(composite_stream)), ==, 0x7);
-	rc = g_input_stream_read(composite_stream, buf, sizeof(buf), NULL, &error);
+	rc = g_input_stream_read(G_INPUT_STREAM(composite_stream), buf, sizeof(buf), NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 
@@ -142,7 +142,7 @@ fu_composite_input_stream_func(void)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(composite_stream)), ==, 0x6);
-	rc = g_input_stream_read(composite_stream, buf, sizeof(buf), NULL, &error);
+	rc = g_input_stream_read(G_INPUT_STREAM(composite_stream), buf, sizeof(buf), NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 1);
 	g_assert_cmpint(buf[0], ==, 'g');

--- a/libfwupdplugin/fu-composite-input-stream-test.c
+++ b/libfwupdplugin/fu-composite-input-stream-test.c
@@ -20,9 +20,9 @@ fu_composite_input_stream_func(void)
 	g_autoptr(GBytes) blob1 = g_bytes_new_static("ab", 2);
 	g_autoptr(GBytes) blob2 = g_bytes_new_static("cde", 3);
 	g_autoptr(GBytes) blob3 = g_bytes_new_static("xxxfgyyy", 8);
-	g_autoptr(GInputStream) composite_stream = fu_composite_input_stream_new();
-	g_autoptr(GInputStream) stream3 = g_memory_input_stream_new_from_bytes(blob3);
-	g_autoptr(GInputStream) stream4 = NULL;
+	g_autoptr(FuInputStream) composite_stream = fu_composite_input_stream_new();
+	g_autoptr(FuInputStream) stream3 = g_memory_input_stream_new_from_bytes(blob3);
+	g_autoptr(FuInputStream) stream4 = NULL;
 
 	/* empty */
 	ret = fu_input_stream_size(composite_stream, &streamsz, &error);

--- a/libfwupdplugin/fu-composite-input-stream-test.c
+++ b/libfwupdplugin/fu-composite-input-stream-test.c
@@ -21,7 +21,7 @@ fu_composite_input_stream_func(void)
 	g_autoptr(GBytes) blob2 = g_bytes_new_static("cde", 3);
 	g_autoptr(GBytes) blob3 = g_bytes_new_static("xxxfgyyy", 8);
 	g_autoptr(FuInputStream) composite_stream = fu_composite_input_stream_new();
-	g_autoptr(FuInputStream) stream3 = g_memory_input_stream_new_from_bytes(blob3);
+	g_autoptr(FuInputStream) stream3 = fu_memory_input_stream_new_from_bytes(blob3);
 	g_autoptr(FuInputStream) stream4 = NULL;
 
 	/* empty */

--- a/libfwupdplugin/fu-composite-input-stream.c
+++ b/libfwupdplugin/fu-composite-input-stream.c
@@ -12,6 +12,7 @@
 
 #include "fu-common.h"
 #include "fu-composite-input-stream.h"
+#include "fu-input-stream.h"
 #include "fu-partial-input-stream-private.h"
 
 /**
@@ -38,7 +39,7 @@ typedef struct {
 } FuCompositeInputStreamItem;
 
 struct _FuCompositeInputStream {
-	GInputStream parent_instance;
+	FuInputStream parent_instance;
 	GPtrArray *items;		       /* of FuCompositeInputStreamItem */
 	FuCompositeInputStreamItem *last_item; /* no-ref */
 	goffset pos;
@@ -53,7 +54,7 @@ fu_composite_input_stream_codec_iface_init(FwupdCodecInterface *iface);
 
 G_DEFINE_TYPE_WITH_CODE(FuCompositeInputStream,
 			fu_composite_input_stream,
-			G_TYPE_INPUT_STREAM,
+			FU_TYPE_INPUT_STREAM,
 			G_IMPLEMENT_INTERFACE(G_TYPE_SEEKABLE,
 					      fu_composite_input_stream_seekable_iface_init)
 			    G_IMPLEMENT_INTERFACE(FWUPD_TYPE_CODEC,
@@ -103,8 +104,8 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuCompositeInputStreamItem, fu_composite_input_str
 gboolean
 fu_composite_input_stream_add_bytes(FuCompositeInputStream *self, GBytes *bytes, GError **error)
 {
-	g_autoptr(GInputStream) stream = NULL;
-	g_autoptr(GInputStream) partial_stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
+	g_autoptr(FuInputStream) partial_stream = NULL;
 
 	g_return_val_if_fail(FU_IS_COMPOSITE_INPUT_STREAM(self), FALSE);
 	g_return_val_if_fail(bytes != NULL, FALSE);
@@ -141,7 +142,7 @@ fu_composite_input_stream_add_partial_stream(FuCompositeInputStream *self,
 
 	g_return_val_if_fail(FU_IS_COMPOSITE_INPUT_STREAM(self), FALSE);
 	g_return_val_if_fail(FU_IS_PARTIAL_INPUT_STREAM(partial_stream), FALSE);
-	g_return_val_if_fail(G_INPUT_STREAM(self) != G_INPUT_STREAM(partial_stream), FALSE);
+	g_return_val_if_fail(FU_INPUT_STREAM(self) != FU_INPUT_STREAM(partial_stream), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	/* get the last-added item */
@@ -184,7 +185,7 @@ fu_composite_input_stream_add_partial_stream(FuCompositeInputStream *self,
 /**
  * fu_composite_input_stream_add_stream:
  * @self: a #FuCompositeInputStream
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @error: (nullable): optional return location for an error
  *
  * Adds a input stream object, which has to be seekable.
@@ -195,17 +196,17 @@ fu_composite_input_stream_add_partial_stream(FuCompositeInputStream *self,
  **/
 gboolean
 fu_composite_input_stream_add_stream(FuCompositeInputStream *self,
-				     GInputStream *stream,
+				     FuInputStream *stream,
 				     GError **error)
 {
-	g_autoptr(GInputStream) partial_stream = NULL;
+	g_autoptr(FuInputStream) partial_stream = NULL;
 
 	g_return_val_if_fail(FU_IS_COMPOSITE_INPUT_STREAM(self), FALSE);
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
-	g_return_val_if_fail(G_INPUT_STREAM(self) != stream, FALSE);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(FU_INPUT_STREAM(self) != stream, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	/* create a partial stream that is actually the size of the entire GInputStream */
+	/* create a partial stream that is actually the size of the entire FuInputStream */
 	partial_stream = fu_partial_input_stream_new(stream, 0x0, G_MAXSIZE, error);
 	if (partial_stream == NULL) {
 		g_prefix_error_literal(error, "failed to add input stream: ");
@@ -315,10 +316,10 @@ fu_composite_input_stream_seekable_iface_init(GSeekableIface *iface)
  *
  * Since: 2.0.0
  **/
-GInputStream *
+FuInputStream *
 fu_composite_input_stream_new(void)
 {
-	return G_INPUT_STREAM(g_object_new(FU_TYPE_COMPOSITE_INPUT_STREAM, NULL));
+	return FU_INPUT_STREAM(g_object_new(FU_TYPE_COMPOSITE_INPUT_STREAM, NULL));
 }
 
 static gssize

--- a/libfwupdplugin/fu-composite-input-stream.c
+++ b/libfwupdplugin/fu-composite-input-stream.c
@@ -13,6 +13,7 @@
 #include "fu-common.h"
 #include "fu-composite-input-stream.h"
 #include "fu-input-stream.h"
+#include "fu-memory-input-stream.h"
 #include "fu-partial-input-stream-private.h"
 
 /**
@@ -111,7 +112,7 @@ fu_composite_input_stream_add_bytes(FuCompositeInputStream *self, GBytes *bytes,
 	g_return_val_if_fail(bytes != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	stream = g_memory_input_stream_new_from_bytes(bytes);
+	stream = fu_memory_input_stream_new_from_bytes(bytes);
 	partial_stream = fu_partial_input_stream_new(stream, 0x0, g_bytes_get_size(bytes), error);
 	if (partial_stream == NULL)
 		return FALSE;

--- a/libfwupdplugin/fu-composite-input-stream.h
+++ b/libfwupdplugin/fu-composite-input-stream.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "fu-input-stream.h"
 #include "fu-partial-input-stream.h"
 
 #define FU_TYPE_COMPOSITE_INPUT_STREAM (fu_composite_input_stream_get_type())
@@ -14,9 +15,9 @@ G_DECLARE_FINAL_TYPE(FuCompositeInputStream,
 		     fu_composite_input_stream,
 		     FU,
 		     COMPOSITE_INPUT_STREAM,
-		     GInputStream)
+		     FuInputStream)
 
-GInputStream *
+FuInputStream *
 fu_composite_input_stream_new(void);
 gboolean
 fu_composite_input_stream_add_bytes(FuCompositeInputStream *self, GBytes *bytes, GError **error)
@@ -27,5 +28,5 @@ fu_composite_input_stream_add_partial_stream(FuCompositeInputStream *self,
 					     GError **error) G_GNUC_NON_NULL(1, 2);
 gboolean
 fu_composite_input_stream_add_stream(FuCompositeInputStream *self,
-				     GInputStream *stream,
+				     FuInputStream *stream,
 				     GError **error) G_GNUC_NON_NULL(1, 2);

--- a/libfwupdplugin/fu-coswid-firmware.c
+++ b/libfwupdplugin/fu-coswid-firmware.c
@@ -624,7 +624,7 @@ fu_coswid_firmware_parse_entity(FuCborItem *item, gpointer user_data, GError **e
 
 static gboolean
 fu_coswid_firmware_parse(FuFirmware *firmware,
-			 GInputStream *stream,
+			 FuInputStream *stream,
 			 FuFirmwareParseFlags flags,
 			 GError **error)
 {

--- a/libfwupdplugin/fu-csv-entry.c
+++ b/libfwupdplugin/fu-csv-entry.c
@@ -9,6 +9,7 @@
 #include "fu-common.h"
 #include "fu-csv-entry.h"
 #include "fu-csv-firmware-private.h"
+#include "fu-input-stream.h"
 #include "fu-string.h"
 
 /**
@@ -203,7 +204,7 @@ fu_csv_entry_parse_token_cb(GString *token, guint token_idx, gpointer user_data,
 
 static gboolean
 fu_csv_entry_parse(FuFirmware *firmware,
-		   GInputStream *stream,
+		   FuInputStream *stream,
 		   FuFirmwareParseFlags flags,
 		   GError **error)
 {

--- a/libfwupdplugin/fu-csv-firmware.c
+++ b/libfwupdplugin/fu-csv-firmware.c
@@ -10,6 +10,7 @@
 #include "fu-common.h"
 #include "fu-csv-entry.h"
 #include "fu-csv-firmware-private.h"
+#include "fu-input-stream.h"
 #include "fu-string.h"
 
 /**
@@ -176,7 +177,7 @@ fu_csv_firmware_parse_line_cb(GString *token, guint token_idx, gpointer user_dat
 
 static gboolean
 fu_csv_firmware_parse(FuFirmware *firmware,
-		      GInputStream *stream,
+		      FuInputStream *stream,
 		      FuFirmwareParseFlags flags,
 		      GError **error)
 {

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -22,6 +22,7 @@
 #include "fu-device-poll-locker.h"
 #include "fu-device-private.h"
 #include "fu-input-stream.h"
+#include "fu-memory-input-stream.h"
 #include "fu-output-stream.h"
 #include "fu-quirks.h"
 #include "fu-security-attr.h"
@@ -923,7 +924,7 @@ fu_device_set_contents_bytes(FuDevice *self,
 	g_return_val_if_fail(progress == NULL || FU_IS_PROGRESS(progress), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	stream = g_memory_input_stream_new_from_bytes(blob);
+	stream = fu_memory_input_stream_new_from_bytes(blob);
 	return fu_device_set_contents(self, filename, stream, progress, error);
 }
 

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -806,7 +806,7 @@ fu_device_sleep_full(FuDevice *self, guint delay_ms, FuProgress *progress)
 gboolean
 fu_device_set_contents(FuDevice *self,
 		       const gchar *filename,
-		       GInputStream *stream,
+		       FuInputStream *stream,
 		       FuProgress *progress,
 		       GError **error)
 {
@@ -819,7 +819,7 @@ fu_device_set_contents(FuDevice *self,
 
 	g_return_val_if_fail(FU_IS_DEVICE(self), FALSE);
 	g_return_val_if_fail(filename != NULL, FALSE);
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(FU_IS_PROGRESS(progress), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
@@ -915,7 +915,7 @@ fu_device_set_contents_bytes(FuDevice *self,
 			     FuProgress *progress,
 			     GError **error)
 {
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	g_return_val_if_fail(FU_IS_DEVICE(self), FALSE);
 	g_return_val_if_fail(filename != NULL, FALSE);
@@ -951,7 +951,7 @@ fu_device_get_contents_bytes(FuDevice *self,
 	FuDeviceEvent *event = NULL;
 	g_autofree gchar *event_id = NULL;
 	g_autoptr(GBytes) blob = NULL;
-	g_autoptr(GInputStream) istr = NULL;
+	g_autoptr(FuInputStream) istr = NULL;
 
 	g_return_val_if_fail(FU_IS_DEVICE(self), NULL);
 	g_return_val_if_fail(filename != NULL, NULL);
@@ -1018,7 +1018,7 @@ fu_device_get_contents(FuDevice *self,
 	g_autofree gchar *event_id = NULL;
 	g_autofree gchar *str = NULL;
 	g_autoptr(GBytes) blob = NULL;
-	g_autoptr(GInputStream) istr = NULL;
+	g_autoptr(FuInputStream) istr = NULL;
 
 	g_return_val_if_fail(FU_IS_DEVICE(self), NULL);
 	g_return_val_if_fail(filename != NULL, NULL);
@@ -5733,7 +5733,7 @@ fu_device_write_firmware(FuDevice *self,
 /**
  * fu_device_prepare_firmware:
  * @self: a #FuDevice
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @flags: #FuFirmwareParseFlags, e.g. %FWUPD_INSTALL_FLAG_FORCE
  * @error: (nullable): optional return location for an error
  *
@@ -5751,7 +5751,7 @@ fu_device_write_firmware(FuDevice *self,
  **/
 FuFirmware *
 fu_device_prepare_firmware(FuDevice *self,
-			   GInputStream *stream,
+			   FuInputStream *stream,
 			   FuProgress *progress,
 			   FuFirmwareParseFlags flags,
 			   GError **error)
@@ -5762,7 +5762,7 @@ fu_device_prepare_firmware(FuDevice *self,
 	gsize fw_size;
 
 	g_return_val_if_fail(FU_IS_DEVICE(self), NULL);
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), NULL);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), NULL);
 	g_return_val_if_fail(FU_IS_PROGRESS(progress), NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -96,7 +96,7 @@ typedef struct {
 	GPtrArray *instance_ids;     /* (nullable) (element-type FuDeviceInstanceIdItem) */
 	GPtrArray *retry_recs;	     /* (nullable) (element-type FuDeviceRetryRecovery) */
 	guint retry_delay;
-	GArray *private_flags;		  /* (nullable) (element-type GQuark) */
+	GArray *private_flags; /* (nullable) (element-type GQuark) */
 	gchar *custom_flags;
 	gulong notify_flags_proxy_id;
 	GHashTable *instance_hash; /* (nullable) */

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -12,6 +12,7 @@
 #include "fu-device-event.h"
 #include "fu-device-struct.h"
 #include "fu-firmware.h"
+#include "fu-input-stream.h"
 #include "fu-progress.h"
 #include "fu-security-attrs.h"
 #include "fu-version-common.h"
@@ -42,7 +43,7 @@ struct _FuDeviceClass {
 	gboolean (*probe)(FuDevice *self, GError **error) G_GNUC_WARN_UNUSED_RESULT;
 	gboolean (*rescan)(FuDevice *self, GError **error) G_GNUC_WARN_UNUSED_RESULT;
 	FuFirmware *(*prepare_firmware)(FuDevice *self,
-					GInputStream *stream,
+					FuInputStream *stream,
 					FuProgress *progress,
 					FuFirmwareParseFlags flags,
 					GError **error)G_GNUC_WARN_UNUSED_RESULT;
@@ -1205,7 +1206,7 @@ fu_device_write_firmware(FuDevice *self,
 			 GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2, 3);
 FuFirmware *
 fu_device_prepare_firmware(FuDevice *self,
-			   GInputStream *stream,
+			   FuInputStream *stream,
 			   FuProgress *progress,
 			   FuFirmwareParseFlags flags,
 			   GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2, 3);
@@ -1316,7 +1317,7 @@ fu_device_security_attr_new(FuDevice *self, const gchar *appstream_id) G_GNUC_NO
 gboolean
 fu_device_set_contents(FuDevice *self,
 		       const gchar *filename,
-		       GInputStream *stream,
+		       FuInputStream *stream,
 		       FuProgress *progress,
 		       GError **error) G_GNUC_NON_NULL(1, 2, 3);
 gboolean

--- a/libfwupdplugin/fu-dfu-firmware-private.h
+++ b/libfwupdplugin/fu-dfu-firmware-private.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "fu-dfu-firmware.h"
+#include "fu-input-stream.h"
 
 guint8
 fu_dfu_firmware_get_footer_len(FuDfuFirmware *self) G_GNUC_NON_NULL(1);
@@ -15,6 +16,6 @@ fu_dfu_firmware_append_footer(FuDfuFirmware *self, GBytes *contents, GError **er
     G_GNUC_NON_NULL(1, 2);
 gboolean
 fu_dfu_firmware_parse_footer(FuDfuFirmware *self,
-			     GInputStream *stream,
+			     FuInputStream *stream,
 			     FuFirmwareParseFlags flags,
 			     GError **error) G_GNUC_NON_NULL(1, 2);

--- a/libfwupdplugin/fu-dfu-firmware.c
+++ b/libfwupdplugin/fu-dfu-firmware.c
@@ -197,7 +197,7 @@ fu_dfu_firmware_set_version(FuDfuFirmware *self, guint16 version)
 }
 
 static gboolean
-fu_dfu_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize offset, GError **error)
+fu_dfu_firmware_validate(FuFirmware *firmware, FuInputStream *stream, gsize offset, GError **error)
 {
 	gsize streamsz = 0;
 	if (!fu_input_stream_size(stream, &streamsz, error))
@@ -214,7 +214,7 @@ fu_dfu_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize offse
 
 gboolean
 fu_dfu_firmware_parse_footer(FuDfuFirmware *self,
-			     GInputStream *stream,
+			     FuInputStream *stream,
 			     FuFirmwareParseFlags flags,
 			     GError **error)
 {
@@ -300,7 +300,7 @@ fu_dfu_firmware_parse_footer(FuDfuFirmware *self,
 
 static gboolean
 fu_dfu_firmware_parse(FuFirmware *firmware,
-		      GInputStream *stream,
+		      FuInputStream *stream,
 		      FuFirmwareParseFlags flags,
 		      GError **error)
 {

--- a/libfwupdplugin/fu-dfuse-firmware.c
+++ b/libfwupdplugin/fu-dfuse-firmware.c
@@ -29,7 +29,7 @@ G_DEFINE_TYPE(FuDfuseFirmware, fu_dfuse_firmware, FU_TYPE_DFU_FIRMWARE)
 
 static FuChunk *
 fu_dfuse_firmware_image_chunk_parse(FuDfuseFirmware *self,
-				    GInputStream *stream,
+				    FuInputStream *stream,
 				    gsize *offset,
 				    GError **error)
 {
@@ -64,7 +64,7 @@ fu_dfuse_firmware_image_chunk_parse(FuDfuseFirmware *self,
 
 static FuFirmware *
 fu_dfuse_firmware_image_parse_stream(FuDfuseFirmware *self,
-				     GInputStream *stream,
+				     FuInputStream *stream,
 				     gsize *offset,
 				     GError **error)
 {
@@ -121,14 +121,17 @@ fu_dfuse_firmware_image_parse_stream(FuDfuseFirmware *self,
 }
 
 static gboolean
-fu_dfuse_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize offset, GError **error)
+fu_dfuse_firmware_validate(FuFirmware *firmware,
+			   FuInputStream *stream,
+			   gsize offset,
+			   GError **error)
 {
 	return fu_struct_dfuse_hdr_validate_stream(stream, offset, error);
 }
 
 static gboolean
 fu_dfuse_firmware_parse(FuFirmware *firmware,
-			GInputStream *stream,
+			FuInputStream *stream,
 			FuFirmwareParseFlags flags,
 			GError **error)
 {

--- a/libfwupdplugin/fu-edid.c
+++ b/libfwupdplugin/fu-edid.c
@@ -11,6 +11,7 @@
 #include "fu-common.h"
 #include "fu-edid-struct.h"
 #include "fu-edid.h"
+#include "fu-input-stream.h"
 #include "fu-string.h"
 
 struct _FuEdid {
@@ -218,7 +219,7 @@ fu_edid_strsafe(const guint8 *buf, gsize bufsz)
 }
 
 static gboolean
-fu_edid_parse_descriptor(FuEdid *self, GInputStream *stream, gsize offset, GError **error)
+fu_edid_parse_descriptor(FuEdid *self, FuInputStream *stream, gsize offset, GError **error)
 {
 	gsize buf2sz = 0;
 	const guint8 *buf2;
@@ -253,7 +254,7 @@ fu_edid_parse_descriptor(FuEdid *self, GInputStream *stream, gsize offset, GErro
 
 static gboolean
 fu_edid_parse(FuFirmware *firmware,
-	      GInputStream *stream,
+	      FuInputStream *stream,
 	      FuFirmwareParseFlags flags,
 	      GError **error)
 {

--- a/libfwupdplugin/fu-efi-common.c
+++ b/libfwupdplugin/fu-efi-common.c
@@ -69,7 +69,7 @@ fu_efi_guid_to_name(const gchar *guid)
 /**
  * fu_efi_parse_sections:
  * @firmware: #FuFirmware
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @flags: #FuFirmwareParseFlags
  * @error: (nullable): optional return location for an error
  *
@@ -81,7 +81,7 @@ fu_efi_guid_to_name(const gchar *guid)
  **/
 gboolean
 fu_efi_parse_sections(FuFirmware *firmware,
-		      GInputStream *stream,
+		      FuInputStream *stream,
 		      gsize offset,
 		      FuFirmwareParseFlags flags,
 		      GError **error)
@@ -92,7 +92,7 @@ fu_efi_parse_sections(FuFirmware *firmware,
 		return FALSE;
 	while (offset < streamsz) {
 		g_autoptr(FuFirmware) img = fu_efi_section_new();
-		g_autoptr(GInputStream) partial_stream = NULL;
+		g_autoptr(FuInputStream) partial_stream = NULL;
 
 		/* parse maximum payload */
 		partial_stream =

--- a/libfwupdplugin/fu-efi-common.h
+++ b/libfwupdplugin/fu-efi-common.h
@@ -8,6 +8,7 @@
 
 #include "fu-efi-struct.h"
 #include "fu-firmware.h"
+#include "fu-input-stream.h"
 
 #define FU_EFI_VOLUME_GUID_FFS1	       "7a9354d9-0468-444a-81ce-0bf617d890df"
 #define FU_EFI_VOLUME_GUID_FFS2	       "8c8ce578-8a3d-4f1c-9935-896185c32dd3"
@@ -41,7 +42,7 @@ const gchar *
 fu_efi_guid_to_name(const gchar *guid);
 gboolean
 fu_efi_parse_sections(FuFirmware *firmware,
-		      GInputStream *stream,
+		      FuInputStream *stream,
 		      gsize offset,
 		      FuFirmwareParseFlags flags,
 		      GError **error) G_GNUC_NON_NULL(1, 2);

--- a/libfwupdplugin/fu-efi-device-path-list.c
+++ b/libfwupdplugin/fu-efi-device-path-list.c
@@ -69,7 +69,7 @@ fu_efi_device_path_list_add_json(FwupdCodec *codec,
 
 static gboolean
 fu_efi_device_path_list_parse(FuFirmware *firmware,
-			      GInputStream *stream,
+			      FuInputStream *stream,
 			      FuFirmwareParseFlags flags,
 			      GError **error)
 {

--- a/libfwupdplugin/fu-efi-device-path.c
+++ b/libfwupdplugin/fu-efi-device-path.c
@@ -89,7 +89,7 @@ fu_efi_device_path_set_subtype(FuEfiDevicePath *self, guint8 subtype)
 
 static gboolean
 fu_efi_device_path_parse(FuFirmware *firmware,
-			 GInputStream *stream,
+			 FuInputStream *stream,
 			 FuFirmwareParseFlags flags,
 			 GError **error)
 {

--- a/libfwupdplugin/fu-efi-file.c
+++ b/libfwupdplugin/fu-efi-file.c
@@ -70,7 +70,7 @@ fu_efi_file_hdr_checksum8(GBytes *blob)
 
 static gboolean
 fu_efi_file_parse(FuFirmware *firmware,
-		  GInputStream *stream,
+		  FuInputStream *stream,
 		  FuFirmwareParseFlags flags,
 		  GError **error)
 {
@@ -79,7 +79,7 @@ fu_efi_file_parse(FuFirmware *firmware,
 	guint32 size = 0x0;
 	g_autofree gchar *guid_str = NULL;
 	g_autoptr(FuStructEfiFile) st = NULL;
-	g_autoptr(GInputStream) partial_stream = NULL;
+	g_autoptr(FuInputStream) partial_stream = NULL;
 
 	/* parse */
 	st = fu_struct_efi_file_parse_stream(stream, 0x0, error);

--- a/libfwupdplugin/fu-efi-filesystem.c
+++ b/libfwupdplugin/fu-efi-filesystem.c
@@ -28,7 +28,7 @@ G_DEFINE_TYPE(FuEfiFilesystem, fu_efi_filesystem, FU_TYPE_FIRMWARE)
 
 static gboolean
 fu_efi_filesystem_parse(FuFirmware *firmware,
-			GInputStream *stream,
+			FuInputStream *stream,
 			FuFirmwareParseFlags flags,
 			GError **error)
 {
@@ -38,7 +38,7 @@ fu_efi_filesystem_parse(FuFirmware *firmware,
 		return FALSE;
 	while (offset < streamsz) {
 		g_autoptr(FuFirmware) img = fu_efi_file_new();
-		g_autoptr(GInputStream) stream_tmp = NULL;
+		g_autoptr(FuInputStream) stream_tmp = NULL;
 		gboolean is_freespace = TRUE;
 
 		/* ignore free space */

--- a/libfwupdplugin/fu-efi-ftw-store.c
+++ b/libfwupdplugin/fu-efi-ftw-store.c
@@ -12,6 +12,7 @@
 #include "fu-common.h"
 #include "fu-efi-ftw-store.h"
 #include "fu-efi-struct.h"
+#include "fu-input-stream.h"
 
 /**
  * FuEfiFtwStore:
@@ -39,7 +40,7 @@ fu_efi_ftw_store_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBui
 }
 
 static gboolean
-fu_efi_ftw_store_validate(FuFirmware *firmware, GInputStream *stream, gsize offset, GError **error)
+fu_efi_ftw_store_validate(FuFirmware *firmware, FuInputStream *stream, gsize offset, GError **error)
 {
 	return fu_struct_efi_fault_tolerant_working_block_header64_validate_stream(stream,
 										   offset,
@@ -48,7 +49,7 @@ fu_efi_ftw_store_validate(FuFirmware *firmware, GInputStream *stream, gsize offs
 
 static gboolean
 fu_efi_ftw_store_parse(FuFirmware *firmware,
-		       GInputStream *stream,
+		       FuInputStream *stream,
 		       FuFirmwareParseFlags flags,
 		       GError **error)
 {

--- a/libfwupdplugin/fu-efi-hard-drive-device-path.c
+++ b/libfwupdplugin/fu-efi-hard-drive-device-path.c
@@ -12,6 +12,7 @@
 #include "fu-efi-hard-drive-device-path.h"
 #include "fu-efi-struct.h"
 #include "fu-firmware-common.h"
+#include "fu-input-stream.h"
 #include "fu-mem.h"
 #include "fu-string.h"
 
@@ -91,7 +92,7 @@ fu_efi_hard_drive_device_path_add_json(FwupdCodec *codec,
 
 static gboolean
 fu_efi_hard_drive_device_path_parse(FuFirmware *firmware,
-				    GInputStream *stream,
+				    FuInputStream *stream,
 				    FuFirmwareParseFlags flags,
 				    GError **error)
 {

--- a/libfwupdplugin/fu-efi-load-option.c
+++ b/libfwupdplugin/fu-efi-load-option.c
@@ -152,7 +152,7 @@ fu_efi_load_option_set_metadata(FuEfiLoadOption *self, const gchar *key, const g
 
 static gboolean
 fu_efi_load_option_parse_optional_hive(FuEfiLoadOption *self,
-				       GInputStream *stream,
+				       FuInputStream *stream,
 				       gsize offset,
 				       GError **error)
 {
@@ -247,7 +247,7 @@ fu_efi_load_option_parse_optional_path(FuEfiLoadOption *self, GBytes *opt_blob, 
 
 static gboolean
 fu_efi_load_option_parse_optional(FuEfiLoadOption *self,
-				  GInputStream *stream,
+				  FuInputStream *stream,
 				  gsize offset,
 				  GError **error)
 {
@@ -289,7 +289,7 @@ fu_efi_load_option_parse_optional(FuEfiLoadOption *self,
 
 static gboolean
 fu_efi_load_option_parse(FuFirmware *firmware,
-			 GInputStream *stream,
+			 FuInputStream *stream,
 			 FuFirmwareParseFlags flags,
 			 GError **error)
 {

--- a/libfwupdplugin/fu-efi-lz77-decompressor.c
+++ b/libfwupdplugin/fu-efi-lz77-decompressor.c
@@ -52,8 +52,8 @@ G_DEFINE_TYPE(FuEfiLz77Decompressor, fu_efi_lz77_decompressor, FU_TYPE_FIRMWARE)
 #endif
 
 typedef struct {
-	GInputStream *stream; /* no-ref */
-	GByteArray *dst;      /* no-ref */
+	FuInputStream *stream; /* no-ref */
+	GByteArray *dst;       /* no-ref */
 
 	guint16 bit_count;
 	guint32 bit_buf;
@@ -613,7 +613,7 @@ fu_efi_lz77_decompressor_internal(FuEfiLz77DecompressHelper *helper,
 
 static gboolean
 fu_efi_lz77_decompressor_parse(FuFirmware *firmware,
-			       GInputStream *stream,
+			       FuInputStream *stream,
 			       FuFirmwareParseFlags flags,
 			       GError **error)
 {

--- a/libfwupdplugin/fu-efi-lz77-decompressor.c
+++ b/libfwupdplugin/fu-efi-lz77-decompressor.c
@@ -96,7 +96,7 @@ fu_efi_lz77_decompressor_read_source_bits(FuEfiLz77DecompressHelper *helper,
 		helper->bit_buf |= (guint32)(((guint64)helper->sub_bit_buf) << number_of_bits);
 
 		/* get 1 byte into sub_bit_buf */
-		rc = g_input_stream_read(helper->stream,
+		rc = g_input_stream_read(G_INPUT_STREAM(helper->stream),
 					 &sub_bit_buf,
 					 sizeof(sub_bit_buf),
 					 NULL,

--- a/libfwupdplugin/fu-efi-section.c
+++ b/libfwupdplugin/fu-efi-section.c
@@ -57,7 +57,7 @@ fu_efi_section_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuild
 
 static gboolean
 fu_efi_section_parse_volume_image(FuEfiSection *self,
-				  GInputStream *stream,
+				  FuInputStream *stream,
 				  FuFirmwareParseFlags flags,
 				  GError **error)
 {
@@ -74,13 +74,13 @@ fu_efi_section_parse_volume_image(FuEfiSection *self,
 
 static gboolean
 fu_efi_section_parse_lzma_sections(FuEfiSection *self,
-				   GInputStream *stream,
+				   FuInputStream *stream,
 				   FuFirmwareParseFlags flags,
 				   GError **error)
 {
 	g_autoptr(GBytes) blob = NULL;
 	g_autoptr(GBytes) blob_uncomp = NULL;
-	g_autoptr(GInputStream) stream_uncomp = NULL;
+	g_autoptr(FuInputStream) stream_uncomp = NULL;
 
 	/* parse all sections */
 	blob = fu_input_stream_read_bytes(stream, 0, G_MAXSIZE, NULL, error);
@@ -101,7 +101,7 @@ fu_efi_section_parse_lzma_sections(FuEfiSection *self,
 
 static gboolean
 fu_efi_section_parse_user_interface(FuEfiSection *self,
-				    GInputStream *stream,
+				    FuInputStream *stream,
 				    FuFirmwareParseFlags flags,
 				    GError **error)
 {
@@ -127,7 +127,7 @@ fu_efi_section_parse_user_interface(FuEfiSection *self,
 
 static gboolean
 fu_efi_section_parse_version(FuEfiSection *self,
-			     GInputStream *stream,
+			     FuInputStream *stream,
 			     FuFirmwareParseFlags flags,
 			     GError **error)
 {
@@ -156,7 +156,7 @@ fu_efi_section_parse_version(FuEfiSection *self,
 
 static gboolean
 fu_efi_section_parse_compression_sections(FuEfiSection *self,
-					  GInputStream *stream,
+					  FuInputStream *stream,
 					  FuFirmwareParseFlags flags,
 					  GError **error)
 {
@@ -172,7 +172,7 @@ fu_efi_section_parse_compression_sections(FuEfiSection *self,
 		}
 	} else {
 		g_autoptr(FuFirmware) lz77_decompressor = fu_efi_lz77_decompressor_new();
-		g_autoptr(GInputStream) lz77_stream = NULL;
+		g_autoptr(FuInputStream) lz77_stream = NULL;
 		if (!fu_firmware_parse_stream(lz77_decompressor,
 					      stream,
 					      st->buf->len,
@@ -222,7 +222,7 @@ fu_efi_section_freeform_subtype_guid_to_string(const gchar *guid)
 
 static gboolean
 fu_efi_section_parse_freeform_subtype_guid(FuEfiSection *self,
-					   GInputStream *stream,
+					   FuInputStream *stream,
 					   FuFirmwareParseFlags flags,
 					   GError **error)
 {
@@ -248,7 +248,7 @@ fu_efi_section_parse_freeform_subtype_guid(FuEfiSection *self,
 
 static gboolean
 fu_efi_section_parse(FuFirmware *firmware,
-		     GInputStream *stream,
+		     FuInputStream *stream,
 		     FuFirmwareParseFlags flags,
 		     GError **error)
 {
@@ -259,7 +259,7 @@ fu_efi_section_parse(FuFirmware *firmware,
 	gsize stlen = 0;
 	guint32 size;
 	g_autoptr(FuStructEfiSection) st = NULL;
-	g_autoptr(GInputStream) partial_stream = NULL;
+	g_autoptr(FuInputStream) partial_stream = NULL;
 
 	/* parse */
 	st = fu_struct_efi_section_parse_stream(stream, offset, error);

--- a/libfwupdplugin/fu-efi-section.c
+++ b/libfwupdplugin/fu-efi-section.c
@@ -17,6 +17,7 @@
 #include "fu-efi-volume.h"
 #include "fu-input-stream.h"
 #include "fu-lzma-common.h"
+#include "fu-memory-input-stream.h"
 #include "fu-partial-input-stream.h"
 #include "fu-string.h"
 
@@ -91,7 +92,7 @@ fu_efi_section_parse_lzma_sections(FuEfiSection *self,
 		g_prefix_error_literal(error, "failed to decompress: ");
 		return FALSE;
 	}
-	stream_uncomp = g_memory_input_stream_new_from_bytes(blob_uncomp);
+	stream_uncomp = fu_memory_input_stream_new_from_bytes(blob_uncomp);
 	if (!fu_efi_parse_sections(FU_FIRMWARE(self), stream_uncomp, 0, flags, error)) {
 		g_prefix_error_literal(error, "failed to parse sections: ");
 		return FALSE;

--- a/libfwupdplugin/fu-efi-signature-list.c
+++ b/libfwupdplugin/fu-efi-signature-list.c
@@ -117,7 +117,7 @@ fu_efi_signature_list_get_newest(FuEfiSignatureList *self)
 
 static gboolean
 fu_efi_signature_list_parse_list(FuEfiSignatureList *self,
-				 GInputStream *stream,
+				 FuInputStream *stream,
 				 gsize *offset,
 				 FuFirmwareParseFlags flags,
 				 GError **error)
@@ -221,7 +221,7 @@ fu_efi_signature_list_parse_list(FuEfiSignatureList *self,
 
 static gboolean
 fu_efi_signature_list_validate(FuFirmware *firmware,
-			       GInputStream *stream,
+			       FuInputStream *stream,
 			       gsize offset,
 			       GError **error)
 {
@@ -255,7 +255,7 @@ fu_efi_signature_list_validate(FuFirmware *firmware,
 
 static gboolean
 fu_efi_signature_list_parse(FuFirmware *firmware,
-			    GInputStream *stream,
+			    FuInputStream *stream,
 			    FuFirmwareParseFlags flags,
 			    GError **error)
 {

--- a/libfwupdplugin/fu-efi-signature.c
+++ b/libfwupdplugin/fu-efi-signature.c
@@ -11,6 +11,7 @@
 #include "fu-common.h"
 #include "fu-efi-common.h"
 #include "fu-efi-signature-private.h"
+#include "fu-input-stream.h"
 
 /**
  * FuEfiSignature:
@@ -126,7 +127,7 @@ fu_efi_signature_get_owner(FuEfiSignature *self)
 
 static gboolean
 fu_efi_signature_parse(FuFirmware *firmware,
-		       GInputStream *stream,
+		       FuInputStream *stream,
 		       FuFirmwareParseFlags flags,
 		       GError **error)
 {

--- a/libfwupdplugin/fu-efi-variable-authentication2.c
+++ b/libfwupdplugin/fu-efi-variable-authentication2.c
@@ -12,6 +12,7 @@
 #include "fu-common.h"
 #include "fu-efi-struct.h"
 #include "fu-efi-variable-authentication2.h"
+#include "fu-input-stream.h"
 #include "fu-mem.h"
 #include "fu-partial-input-stream.h"
 #include "fu-pkcs7.h"
@@ -69,7 +70,7 @@ fu_efi_variable_authentication2_export(FuFirmware *firmware,
 
 static gboolean
 fu_efi_variable_authentication2_validate(FuFirmware *firmware,
-					 GInputStream *stream,
+					 FuInputStream *stream,
 					 gsize offset,
 					 GError **error)
 {
@@ -172,7 +173,7 @@ fu_efi_variable_authentication2_parse_pkcs7_certs(FuEfiVariableAuthentication2 *
 
 static gboolean
 fu_efi_variable_authentication2_parse(FuFirmware *firmware,
-				      GInputStream *stream,
+				      FuInputStream *stream,
 				      FuFirmwareParseFlags flags,
 				      GError **error)
 {
@@ -180,7 +181,7 @@ fu_efi_variable_authentication2_parse(FuFirmware *firmware,
 	gsize offset = FU_STRUCT_EFI_TIME_SIZE;
 	g_autoptr(FuStructEfiVariableAuthentication2) st = NULL;
 	g_autoptr(FuStructEfiWinCertificate) st_wincert = NULL;
-	g_autoptr(GInputStream) partial_stream = NULL;
+	g_autoptr(FuInputStream) partial_stream = NULL;
 	gboolean offset_tmp = 0;
 
 	st = fu_struct_efi_variable_authentication2_parse_stream(stream, 0x0, error);

--- a/libfwupdplugin/fu-efi-volume.c
+++ b/libfwupdplugin/fu-efi-volume.c
@@ -51,14 +51,14 @@ fu_efi_volume_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuilde
 }
 
 static gboolean
-fu_efi_volume_validate(FuFirmware *firmware, GInputStream *stream, gsize offset, GError **error)
+fu_efi_volume_validate(FuFirmware *firmware, FuInputStream *stream, gsize offset, GError **error)
 {
 	return fu_struct_efi_volume_validate_stream(stream, offset, error);
 }
 
 static gboolean
 fu_efi_volume_parse_nvram_evsa(FuEfiVolume *self,
-			       GInputStream *stream,
+			       FuInputStream *stream,
 			       gsize offset,
 			       FuFirmwareParseFlags flags,
 			       GError **error)
@@ -141,7 +141,7 @@ fu_efi_volume_parse_nvram_evsa(FuEfiVolume *self,
 
 static gboolean
 fu_efi_volume_parse(FuFirmware *firmware,
-		    GInputStream *stream,
+		    FuInputStream *stream,
 		    FuFirmwareParseFlags flags,
 		    GError **error)
 {
@@ -156,7 +156,7 @@ fu_efi_volume_parse(FuFirmware *firmware,
 	guint8 alignment;
 	g_autofree gchar *guid_str = NULL;
 	g_autoptr(FuStructEfiVolume) st_hdr = NULL;
-	g_autoptr(GInputStream) partial_stream = NULL;
+	g_autoptr(FuInputStream) partial_stream = NULL;
 
 	/* parse */
 	st_hdr = fu_struct_efi_volume_parse_stream(stream, 0x0, error);

--- a/libfwupdplugin/fu-efi-vss-auth-variable.c
+++ b/libfwupdplugin/fu-efi-vss-auth-variable.c
@@ -15,6 +15,7 @@
 #include "fu-efi-struct.h"
 #include "fu-efi-vss-auth-variable.h"
 #include "fu-efivars.h"
+#include "fu-input-stream.h"
 #include "fu-partial-input-stream.h"
 #include "fu-string.h"
 
@@ -97,7 +98,7 @@ fu_efi_vss_auth_variable_lookup_image_gtype(FuEfiVssAuthVariable *self)
 
 static gboolean
 fu_efi_vss_auth_variable_parse(FuFirmware *firmware,
-			       GInputStream *stream,
+			       FuInputStream *stream,
 			       FuFirmwareParseFlags flags,
 			       GError **error)
 {
@@ -164,7 +165,7 @@ fu_efi_vss_auth_variable_parse(FuFirmware *firmware,
 	img_gtype = fu_efi_vss_auth_variable_lookup_image_gtype(self);
 	if (img_gtype != G_TYPE_INVALID) {
 		g_autoptr(FuFirmware) img = g_object_new(img_gtype, NULL);
-		g_autoptr(GInputStream) partial_stream = NULL;
+		g_autoptr(FuInputStream) partial_stream = NULL;
 		partial_stream = fu_partial_input_stream_new(
 		    stream,
 		    offset,

--- a/libfwupdplugin/fu-efi-vss2-variable-store.c
+++ b/libfwupdplugin/fu-efi-vss2-variable-store.c
@@ -13,6 +13,7 @@
 #include "fu-efi-struct.h"
 #include "fu-efi-vss-auth-variable.h"
 #include "fu-efi-vss2-variable-store.h"
+#include "fu-input-stream.h"
 #include "fu-string.h"
 
 /**
@@ -31,7 +32,7 @@ G_DEFINE_TYPE(FuEfiVss2VariableStore, fu_efi_vss2_variable_store, FU_TYPE_FIRMWA
 
 static gboolean
 fu_efi_vss2_variable_store_validate(FuFirmware *firmware,
-				    GInputStream *stream,
+				    FuInputStream *stream,
 				    gsize offset,
 				    GError **error)
 {
@@ -40,7 +41,7 @@ fu_efi_vss2_variable_store_validate(FuFirmware *firmware,
 
 static gboolean
 fu_efi_vss2_variable_store_parse(FuFirmware *firmware,
-				 GInputStream *stream,
+				 FuInputStream *stream,
 				 FuFirmwareParseFlags flags,
 				 GError **error)
 {

--- a/libfwupdplugin/fu-efi-x509-device.c
+++ b/libfwupdplugin/fu-efi-x509-device.c
@@ -10,6 +10,7 @@
 
 #include "fu-efi-variable-authentication2.h"
 #include "fu-efi-x509-device.h"
+#include "fu-input-stream.h"
 #include "fu-version-common.h"
 #include "fu-zip-firmware.h"
 
@@ -84,7 +85,7 @@ fu_efi_x509_device_convert_version(FuDevice *device, guint64 version_raw)
 
 static FuFirmware *
 fu_efi_x509_device_prepare_firmware(FuDevice *device,
-				    GInputStream *stream,
+				    FuInputStream *stream,
 				    FuProgress *progress,
 				    FuFirmwareParseFlags flags,
 				    GError **error)

--- a/libfwupdplugin/fu-efi-x509-signature.c
+++ b/libfwupdplugin/fu-efi-x509-signature.c
@@ -14,6 +14,7 @@
 #include "fu-common.h"
 #include "fu-efi-signature-private.h"
 #include "fu-efi-x509-signature-private.h"
+#include "fu-input-stream.h"
 #include "fu-string.h"
 #include "fu-version-common.h"
 #include "fu-x509-certificate.h"
@@ -222,7 +223,7 @@ fu_efi_x509_signature_get_subject_vendor(FuEfiX509Signature *self)
 
 static gboolean
 fu_efi_x509_signature_parse(FuFirmware *firmware,
-			    GInputStream *stream,
+			    FuInputStream *stream,
 			    FuFirmwareParseFlags flags,
 			    GError **error)
 {

--- a/libfwupdplugin/fu-elf-firmware.c
+++ b/libfwupdplugin/fu-elf-firmware.c
@@ -32,14 +32,14 @@ G_DEFINE_TYPE(FuElfFirmware, fu_elf_firmware, FU_TYPE_FIRMWARE)
 #define FU_ELF_FIRMWARE_MAX_SECTIONS 10000
 
 static gboolean
-fu_elf_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize offset, GError **error)
+fu_elf_firmware_validate(FuFirmware *firmware, FuInputStream *stream, gsize offset, GError **error)
 {
 	return fu_struct_elf_file_header64le_validate_stream(stream, offset, error);
 }
 
 static gboolean
 fu_elf_firmware_parse(FuFirmware *firmware,
-		      GInputStream *stream,
+		      FuInputStream *stream,
 		      FuFirmwareParseFlags flags,
 		      GError **error)
 {
@@ -150,7 +150,7 @@ fu_elf_firmware_parse(FuFirmware *firmware,
 			FU_ELF_SECTION_HEADER_TYPE_STRTAB)
 			continue;
 		if (sect_size_safe > 0) {
-			g_autoptr(GInputStream) img_stream =
+			g_autoptr(FuInputStream) img_stream =
 			    fu_partial_input_stream_new(stream,
 							sect_offset_safe,
 							sect_size_safe,

--- a/libfwupdplugin/fu-fdt-firmware.c
+++ b/libfwupdplugin/fu-fdt-firmware.c
@@ -283,7 +283,7 @@ fu_fdt_firmware_parse_dt_struct(FuFdtFirmware *self, GBytes *fw, GByteArray *str
 
 static gboolean
 fu_fdt_firmware_parse_mem_rsvmap(FuFdtFirmware *self,
-				 GInputStream *stream,
+				 FuInputStream *stream,
 				 gsize offset,
 				 GError **error)
 {
@@ -319,14 +319,14 @@ fu_fdt_firmware_parse_mem_rsvmap(FuFdtFirmware *self,
 }
 
 static gboolean
-fu_fdt_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize offset, GError **error)
+fu_fdt_firmware_validate(FuFirmware *firmware, FuInputStream *stream, gsize offset, GError **error)
 {
 	return fu_struct_fdt_validate_stream(stream, offset, error);
 }
 
 static gboolean
 fu_fdt_firmware_parse(FuFirmware *firmware,
-		      GInputStream *stream,
+		      FuInputStream *stream,
 		      FuFirmwareParseFlags flags,
 		      GError **error)
 {

--- a/libfwupdplugin/fu-file-input-stream.c
+++ b/libfwupdplugin/fu-file-input-stream.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#define G_LOG_DOMAIN "FuFileInputStream"
+
+#include "config.h"
+
+#include "fu-file-input-stream.h"
+
+/**
+ * fu_file_input_stream_from_file:
+ * @file: a #GFile
+ * @cancellable: (nullable): optional #GCancellable
+ * @error: (nullable): optional return location for an error
+ *
+ * Opens a #GFile for reading and returns a #FuFileInputStream. Use
+ * this instead of g_file_read().
+ *
+ * Returns: (transfer full): a #FuFileInputStream, or %NULL on error
+ *
+ * Since: 2.1.7
+ **/
+FuFileInputStream *
+fu_file_input_stream_from_file(GFile *file, GCancellable *cancellable, GError **error)
+{
+	g_return_val_if_fail(G_IS_FILE(file), NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+	return g_file_read(file, cancellable, error); /* nocheck:blocked */
+}
+
+/**
+ * fu_file_input_stream_query_info:
+ * @stream: a #FuFileInputStream
+ * @attributes: a file attribute query string
+ * @cancellable: (nullable): optional #GCancellable
+ * @error: (nullable): optional return location for an error
+ *
+ * Queries a file input stream for the given @attributes.
+ *
+ * Returns: (transfer full): a #GFileInfo, or %NULL on error
+ *
+ * Since: 2.1.7
+ **/
+GFileInfo *
+fu_file_input_stream_query_info(FuFileInputStream *stream,
+				const gchar *attributes,
+				GCancellable *cancellable,
+				GError **error)
+{
+	g_return_val_if_fail(FU_IS_FILE_INPUT_STREAM(stream), NULL);
+	g_return_val_if_fail(attributes != NULL, NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+	return g_file_input_stream_query_info(G_FILE_INPUT_STREAM(stream), /* nocheck:blocked */
+					      attributes,
+					      cancellable,
+					      error);
+}

--- a/libfwupdplugin/fu-file-input-stream.h
+++ b/libfwupdplugin/fu-file-input-stream.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include "fu-input-stream.h"
+
+typedef GFileInputStream FuFileInputStream;	      /* nocheck:blocked */
+typedef GFileInputStreamClass FuFileInputStreamClass; /* nocheck:blocked */
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuFileInputStream, g_object_unref)   /* nocheck:blocked */
+#define FU_FILE_INPUT_STREAM(o)	      G_FILE_INPUT_STREAM(o)	   /* nocheck:blocked */
+#define FU_TYPE_FILE_INPUT_STREAM     G_TYPE_FILE_INPUT_STREAM	   /* nocheck:blocked */
+#define FU_IS_FILE_INPUT_STREAM(o)    G_IS_FILE_INPUT_STREAM(o)	   /* nocheck:blocked */
+#define FU_FILE_INPUT_STREAM_CLASS(o) G_FILE_INPUT_STREAM_CLASS(o) /* nocheck:blocked */
+
+FuFileInputStream *
+fu_file_input_stream_from_file(GFile *file,
+			       GCancellable *cancellable,
+			       GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1);
+GFileInfo *
+fu_file_input_stream_query_info(FuFileInputStream *stream,
+				const gchar *attributes,
+				GCancellable *cancellable,
+				GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);

--- a/libfwupdplugin/fu-firmware-test.c
+++ b/libfwupdplugin/fu-firmware-test.c
@@ -371,7 +371,7 @@ fu_firmware_new_from_gtypes_func(void)
 	g_autoptr(FuFirmware) firmware2 = NULL;
 	g_autoptr(FuFirmware) firmware3 = NULL;
 	g_autoptr(GBytes) fw = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(GError) error = NULL;
 
 	filename = g_test_build_filename(G_TEST_DIST, "tests", "dfu.builder.xml", NULL);

--- a/libfwupdplugin/fu-firmware-test.c
+++ b/libfwupdplugin/fu-firmware-test.c
@@ -381,7 +381,7 @@ fu_firmware_new_from_gtypes_func(void)
 	fw = fu_firmware_write(firmware, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(fw);
-	stream = g_memory_input_stream_new_from_bytes(fw);
+	stream = fu_memory_input_stream_new_from_bytes(fw);
 	g_assert_no_error(error);
 	g_assert_nonnull(stream);
 

--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -12,6 +12,7 @@
 #include "fu-bytes.h"
 #include "fu-chunk-private.h"
 #include "fu-common.h"
+#include "fu-file-input-stream.h"
 #include "fu-firmware-private.h"
 #include "fu-fuzzer.h"
 #include "fu-input-stream.h"
@@ -1648,13 +1649,13 @@ fu_firmware_new_from_filename(const gchar *filename, GError **error)
 gboolean
 fu_firmware_parse_file(FuFirmware *self, GFile *file, FuFirmwareParseFlags flags, GError **error)
 {
-	g_autoptr(GFileInputStream) stream = NULL;
+	g_autoptr(FuFileInputStream) stream = NULL;
 
 	g_return_val_if_fail(FU_IS_FIRMWARE(self), FALSE);
 	g_return_val_if_fail(G_IS_FILE(file), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	stream = g_file_read(file, NULL, error);
+	stream = fu_file_input_stream_from_file(file, NULL, error);
 	if (stream == NULL) {
 		fwupd_error_convert(error);
 		return FALSE;

--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -36,7 +36,7 @@ typedef struct {
 	guint64 version_raw;
 	FwupdVersionFormat version_format;
 	GBytes *bytes;
-	GInputStream *stream;
+	FuInputStream *stream;
 	gsize streamsz;
 	FuFirmwareAlignment alignment;
 	gchar *id;
@@ -711,11 +711,11 @@ fu_firmware_set_alignment(FuFirmware *self, FuFirmwareAlignment alignment)
  *
  * Gets the input stream which was used to parse the firmware.
  *
- * Returns: (transfer full): a #GInputStream, or %NULL if the payload has never been set
+ * Returns: (transfer full): a #FuInputStream, or %NULL if the payload has never been set
  *
  * Since: 2.0.0
  **/
-GInputStream *
+FuInputStream *
 fu_firmware_get_stream(FuFirmware *self, GError **error)
 {
 	FuFirmwarePrivate *priv = GET_PRIVATE(self);
@@ -731,7 +731,7 @@ fu_firmware_get_stream(FuFirmware *self, GError **error)
 /**
  * fu_firmware_set_stream:
  * @self: a #FuPlugin
- * @stream: (nullable): #GInputStream
+ * @stream: (nullable): #FuInputStream
  * @error: (nullable): optional return location for an error
  *
  * Sets the input stream.
@@ -741,11 +741,11 @@ fu_firmware_get_stream(FuFirmware *self, GError **error)
  * Since: 2.0.0
  **/
 gboolean
-fu_firmware_set_stream(FuFirmware *self, GInputStream *stream, GError **error)
+fu_firmware_set_stream(FuFirmware *self, FuInputStream *stream, GError **error)
 {
 	FuFirmwarePrivate *priv = GET_PRIVATE(self);
 	g_return_val_if_fail(FU_IS_FIRMWARE(self), FALSE);
-	g_return_val_if_fail(stream == NULL || G_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(stream == NULL || FU_IS_INPUT_STREAM(stream), FALSE);
 	if (stream != NULL) {
 		if (!fu_input_stream_size(stream, &priv->streamsz, error))
 			return FALSE;
@@ -928,7 +928,7 @@ fu_firmware_get_checksum(FuFirmware *self, GChecksumType csum_kind, GError **err
 /**
  * fu_firmware_tokenize:
  * @self: a #FuFirmware
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @flags: #FuFirmwareParseFlags, e.g. %FWUPD_INSTALL_FLAG_FORCE
  * @error: (nullable): optional return location for an error
  *
@@ -943,14 +943,14 @@ fu_firmware_get_checksum(FuFirmware *self, GChecksumType csum_kind, GError **err
  **/
 gboolean
 fu_firmware_tokenize(FuFirmware *self,
-		     GInputStream *stream,
+		     FuInputStream *stream,
 		     FuFirmwareParseFlags flags,
 		     GError **error)
 {
 	FuFirmwareClass *klass = FU_FIRMWARE_GET_CLASS(self);
 
 	g_return_val_if_fail(FU_IS_FIRMWARE(self), FALSE);
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	/* optionally subclassed */
@@ -992,7 +992,7 @@ fu_firmware_check_compatible(FuFirmware *self,
 
 static gboolean
 fu_firmware_validate_with_magic(FuFirmware *self,
-				GInputStream *stream,
+				FuInputStream *stream,
 				gsize offset,
 				gsize *offset_found,
 				GError **error)
@@ -1049,7 +1049,7 @@ fu_firmware_validate_with_magic(FuFirmware *self,
 
 static gboolean
 fu_firmware_validate_for_offset(FuFirmware *self,
-				GInputStream *stream,
+				FuInputStream *stream,
 				gsize offset,
 				gsize *offset_found,
 				FuFirmwareParseFlags flags,
@@ -1105,7 +1105,7 @@ fu_firmware_validate_for_offset(FuFirmware *self,
  **/
 gboolean
 fu_firmware_parse_stream(FuFirmware *self,
-			 GInputStream *stream,
+			 FuInputStream *stream,
 			 gsize offset,
 			 FuFirmwareParseFlags flags,
 			 GError **error)
@@ -1113,12 +1113,12 @@ fu_firmware_parse_stream(FuFirmware *self,
 	FuFirmwareClass *klass = FU_FIRMWARE_GET_CLASS(self);
 	FuFirmwarePrivate *priv = GET_PRIVATE(self);
 	gsize streamsz = 0;
-	g_autoptr(GInputStream) partial_stream = NULL;
-	g_autoptr(GInputStream) seekable_stream = NULL;
+	g_autoptr(FuInputStream) partial_stream = NULL;
+	g_autoptr(FuInputStream) seekable_stream = NULL;
 	g_autoptr(GBytes) blob = NULL;
 
 	g_return_val_if_fail(FU_IS_FIRMWARE(self), FALSE);
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	/* sanity check */
@@ -1291,7 +1291,7 @@ fu_firmware_parse_bytes(FuFirmware *self,
 			FuFirmwareParseFlags flags,
 			GError **error)
 {
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	g_return_val_if_fail(FU_IS_FIRMWARE(self), FALSE);
 	g_return_val_if_fail(fw != NULL, FALSE);
@@ -1658,7 +1658,7 @@ fu_firmware_parse_file(FuFirmware *self, GFile *file, FuFirmwareParseFlags flags
 		fwupd_error_convert(error);
 		return FALSE;
 	}
-	return fu_firmware_parse_stream(self, G_INPUT_STREAM(stream), 0, flags, error);
+	return fu_firmware_parse_stream(self, FU_INPUT_STREAM(stream), 0, flags, error);
 }
 
 /**
@@ -2274,11 +2274,11 @@ fu_firmware_get_image_by_id_bytes(FuFirmware *self, const gchar *id, GError **er
  *
  * Gets the firmware image stream using the image ID.
  *
- * Returns: (transfer full): a #GInputStream of a #FuFirmware, or %NULL if the image is not found
+ * Returns: (transfer full): a #FuInputStream of a #FuFirmware, or %NULL if the image is not found
  *
  * Since: 2.0.0
  **/
-GInputStream *
+FuInputStream *
 fu_firmware_get_image_by_id_stream(FuFirmware *self, const gchar *id, GError **error)
 {
 	g_autoptr(FuFirmware) img = fu_firmware_get_image_by_id(self, id, error);
@@ -2393,11 +2393,11 @@ fu_firmware_get_image_by_idx_bytes(FuFirmware *self, guint64 idx, GError **error
  *
  * Gets the firmware image stream using the image index.
  *
- * Returns: (transfer full): a #GInputStream of a #FuFirmware, or %NULL if the image is not found
+ * Returns: (transfer full): a #FuInputStream of a #FuFirmware, or %NULL if the image is not found
  *
  * Since: 2.0.0
  **/
-GInputStream *
+FuInputStream *
 fu_firmware_get_image_by_idx_stream(FuFirmware *self, guint64 idx, GError **error)
 {
 	g_autoptr(FuFirmware) img = fu_firmware_get_image_by_idx(self, idx, error);
@@ -2573,7 +2573,7 @@ fu_firmware_export(FuFirmware *self, FuFirmwareExportFlags flags, XbBuilderNode 
 					    "data",
 					    datastr,
 					    "type",
-					    "GInputStream",
+					    "FuInputStream",
 					    "size",
 					    dataszstr,
 					    NULL);
@@ -2840,7 +2840,7 @@ fu_firmware_new_from_bytes(GBytes *fw)
 
 /**
  * fu_firmware_new_from_gtypes:
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @offset: start offset, useful for ignoring a bootloader
  * @flags: install flags, e.g. %FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM
  * @error: (nullable): optional return location for an error
@@ -2853,7 +2853,7 @@ fu_firmware_new_from_bytes(GBytes *fw)
  * Since: 1.5.6
  **/
 FuFirmware *
-fu_firmware_new_from_gtypes(GInputStream *stream,
+fu_firmware_new_from_gtypes(FuInputStream *stream,
 			    gsize offset,
 			    FuFirmwareParseFlags flags,
 			    GError **error,
@@ -2863,7 +2863,7 @@ fu_firmware_new_from_gtypes(GInputStream *stream,
 	g_autoptr(GArray) gtypes = g_array_new(FALSE, FALSE, sizeof(GType));
 	g_autoptr(GError) error_all = NULL;
 
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), NULL);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
 	/* create array of GTypes */

--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -16,6 +16,7 @@
 #include "fu-fuzzer.h"
 #include "fu-input-stream.h"
 #include "fu-mem.h"
+#include "fu-memory-input-stream.h"
 #include "fu-partial-input-stream.h"
 #include "fu-ptr-array.h"
 #include "fu-string.h"
@@ -723,7 +724,7 @@ fu_firmware_get_stream(FuFirmware *self, GError **error)
 	if (priv->stream != NULL)
 		return g_object_ref(priv->stream);
 	if (priv->bytes != NULL)
-		return g_memory_input_stream_new_from_bytes(priv->bytes);
+		return fu_memory_input_stream_new_from_bytes(priv->bytes);
 	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND, "no stream or bytes set");
 	return NULL;
 }
@@ -1135,7 +1136,7 @@ fu_firmware_parse_stream(FuFirmware *self,
 		blob = fu_input_stream_read_bytes(stream, offset, G_MAXUINT32, NULL, error);
 		if (blob == NULL)
 			return FALSE;
-		seekable_stream = g_memory_input_stream_new_from_bytes(blob);
+		seekable_stream = fu_memory_input_stream_new_from_bytes(blob);
 	} else {
 		seekable_stream = g_object_ref(stream);
 	}
@@ -1297,7 +1298,7 @@ fu_firmware_parse_bytes(FuFirmware *self,
 	g_return_val_if_fail(fw != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	stream = g_memory_input_stream_new_from_bytes(fw);
+	stream = fu_memory_input_stream_new_from_bytes(fw);
 	return fu_firmware_parse_stream(self, stream, offset, flags, error);
 }
 

--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -11,6 +11,7 @@
 
 #include "fu-chunk.h"
 #include "fu-firmware-struct.h"
+#include "fu-input-stream.h"
 
 #define FU_TYPE_FIRMWARE (fu_firmware_get_type())
 G_DECLARE_DERIVABLE_TYPE(FuFirmware, fu_firmware, FU, FIRMWARE, GObject)
@@ -24,25 +25,25 @@ G_DECLARE_DERIVABLE_TYPE(FuFirmware, fu_firmware, FU, FIRMWARE, GObject)
 struct _FuFirmwareClass {
 	GObjectClass parent_class;
 	gboolean (*parse)(FuFirmware *self,
-			  GInputStream *stream,
+			  FuInputStream *stream,
 			  FuFirmwareParseFlags flags,
 			  GError **error) G_GNUC_WARN_UNUSED_RESULT;
 	gboolean (*parse_full)(FuFirmware *self,
-			       GInputStream *stream,
+			       FuInputStream *stream,
 			       gsize offset,
 			       FuFirmwareParseFlags flags,
 			       GError **error) G_GNUC_WARN_UNUSED_RESULT;
 	GByteArray *(*write)(FuFirmware *self, GError **error)G_GNUC_WARN_UNUSED_RESULT;
 	void (*export)(FuFirmware *self, FuFirmwareExportFlags flags, XbBuilderNode *bn);
 	gboolean (*tokenize)(FuFirmware *self,
-			     GInputStream *stream,
+			     FuInputStream *stream,
 			     FuFirmwareParseFlags flags,
 			     GError **error) G_GNUC_WARN_UNUSED_RESULT;
 	gboolean (*build)(FuFirmware *self, XbNode *n, GError **error) G_GNUC_WARN_UNUSED_RESULT;
 	gchar *(*get_checksum)(FuFirmware *self,
 			       GChecksumType csum_kind,
 			       GError **error)G_GNUC_WARN_UNUSED_RESULT;
-	gboolean (*validate)(FuFirmware *self, GInputStream *stream, gsize offset, GError **error);
+	gboolean (*validate)(FuFirmware *self, FuInputStream *stream, gsize offset, GError **error);
 	gboolean (*check_compatible)(FuFirmware *self,
 				     FuFirmware *other,
 				     FuFirmwareParseFlags flags,
@@ -89,7 +90,7 @@ FuFirmware *
 fu_firmware_new_from_filename(const gchar *filename, GError **error) G_GNUC_WARN_UNUSED_RESULT
     G_GNUC_NON_NULL(1);
 FuFirmware *
-fu_firmware_new_from_gtypes(GInputStream *stream,
+fu_firmware_new_from_gtypes(FuInputStream *stream,
 			    gsize offset,
 			    FuFirmwareParseFlags flags,
 			    GError **error,
@@ -161,8 +162,8 @@ fu_firmware_get_bytes_with_patches(FuFirmware *self, GError **error) G_GNUC_NON_
 void
 fu_firmware_set_bytes(FuFirmware *self, GBytes *bytes) G_GNUC_NON_NULL(1);
 gboolean
-fu_firmware_set_stream(FuFirmware *self, GInputStream *stream, GError **error) G_GNUC_NON_NULL(1);
-GInputStream *
+fu_firmware_set_stream(FuFirmware *self, FuInputStream *stream, GError **error) G_GNUC_NON_NULL(1);
+FuInputStream *
 fu_firmware_get_stream(FuFirmware *self, GError **error) G_GNUC_NON_NULL(1);
 FuFirmwareAlignment
 fu_firmware_get_alignment(FuFirmware *self) G_GNUC_NON_NULL(1);
@@ -182,7 +183,7 @@ fu_firmware_set_parent(FuFirmware *self, FuFirmware *parent) G_GNUC_NON_NULL(1);
 
 gboolean
 fu_firmware_tokenize(FuFirmware *self,
-		     GInputStream *stream,
+		     FuInputStream *stream,
 		     FuFirmwareParseFlags flags,
 		     GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
 gboolean
@@ -200,7 +201,7 @@ fu_firmware_roundtrip_from_filename(const gchar *builder_fn,
 				    GError **error) G_GNUC_NON_NULL(1);
 gboolean
 fu_firmware_parse_stream(FuFirmware *self,
-			 GInputStream *stream,
+			 FuInputStream *stream,
 			 gsize offset,
 			 FuFirmwareParseFlags flags,
 			 GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
@@ -248,7 +249,7 @@ fu_firmware_get_image_by_id(FuFirmware *self, const gchar *id, GError **error) G
 GBytes *
 fu_firmware_get_image_by_id_bytes(FuFirmware *self, const gchar *id, GError **error)
     G_GNUC_NON_NULL(1);
-GInputStream *
+FuInputStream *
 fu_firmware_get_image_by_id_stream(FuFirmware *self, const gchar *id, GError **error)
     G_GNUC_NON_NULL(1);
 FuFirmware *
@@ -256,7 +257,7 @@ fu_firmware_get_image_by_idx(FuFirmware *self, guint64 idx, GError **error) G_GN
 GBytes *
 fu_firmware_get_image_by_idx_bytes(FuFirmware *self, guint64 idx, GError **error)
     G_GNUC_NON_NULL(1);
-GInputStream *
+FuInputStream *
 fu_firmware_get_image_by_idx_stream(FuFirmware *self, guint64 idx, GError **error)
     G_GNUC_NON_NULL(1);
 FuFirmware *

--- a/libfwupdplugin/fu-fit-firmware.c
+++ b/libfwupdplugin/fu-fit-firmware.c
@@ -212,7 +212,7 @@ fu_fit_firmware_verify_hash(FuFitFirmware *self,
 
 static gboolean
 fu_fit_firmware_verify_image(FuFitFirmware *self,
-			     GInputStream *stream,
+			     FuInputStream *stream,
 			     FuFirmware *img,
 			     FuFirmwareParseFlags flags,
 			     GError **error)
@@ -290,7 +290,7 @@ fu_fit_firmware_verify_configuration(FuFitFirmware *self,
 
 static gboolean
 fu_fit_firmware_parse(FuFirmware *firmware,
-		      GInputStream *stream,
+		      FuInputStream *stream,
 		      FuFirmwareParseFlags flags,
 		      GError **error)
 {

--- a/libfwupdplugin/fu-fmap-firmware.c
+++ b/libfwupdplugin/fu-fmap-firmware.c
@@ -82,14 +82,14 @@ fu_fmap_firmware_build(FuFirmware *firmware, XbNode *n, GError **error)
 }
 
 static gboolean
-fu_fmap_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize offset, GError **error)
+fu_fmap_firmware_validate(FuFirmware *firmware, FuInputStream *stream, gsize offset, GError **error)
 {
 	return fu_struct_fmap_validate_stream(stream, offset, error);
 }
 
 static gboolean
 fu_fmap_firmware_parse(FuFirmware *firmware,
-		       GInputStream *stream,
+		       FuInputStream *stream,
 		       gsize offset,
 		       FuFirmwareParseFlags flags,
 		       GError **error)
@@ -146,7 +146,7 @@ fu_fmap_firmware_parse(FuFirmware *firmware,
 		g_autofree gchar *area_name = NULL;
 		g_autoptr(FuFirmware) img = NULL;
 		g_autoptr(FuStructFmapArea) st_area = NULL;
-		g_autoptr(GInputStream) img_stream = NULL;
+		g_autoptr(FuInputStream) img_stream = NULL;
 
 		/* load area */
 		st_area = fu_struct_fmap_area_parse_stream(stream, offset, error);

--- a/libfwupdplugin/fu-hid-descriptor.c
+++ b/libfwupdplugin/fu-hid-descriptor.c
@@ -51,7 +51,7 @@ fu_hid_descriptor_count_table_dupes(GPtrArray *table, FuHidReportItem *item)
 
 static gboolean
 fu_hid_descriptor_parse(FuFirmware *firmware,
-			GInputStream *stream,
+			FuInputStream *stream,
 			FuFirmwareParseFlags flags,
 			GError **error)
 {

--- a/libfwupdplugin/fu-hid-report-item.c
+++ b/libfwupdplugin/fu-hid-report-item.c
@@ -54,7 +54,7 @@ fu_hid_report_item_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbB
 
 static gboolean
 fu_hid_report_item_parse(FuFirmware *firmware,
-			 GInputStream *stream,
+			 FuInputStream *stream,
 			 FuFirmwareParseFlags flags,
 			 GError **error)
 {
@@ -85,7 +85,7 @@ fu_hid_report_item_parse(FuFirmware *firmware,
 		if (!fu_input_stream_read_u8(stream, 1, &data_size, error))
 			return FALSE;
 	} else {
-		g_autoptr(GInputStream) partial_stream = NULL;
+		g_autoptr(FuInputStream) partial_stream = NULL;
 		if (data_size == 1) {
 			guint8 value = 0;
 			if (!fu_input_stream_read_u8(stream, 1, &value, error))

--- a/libfwupdplugin/fu-ifd-bios.c
+++ b/libfwupdplugin/fu-ifd-bios.c
@@ -27,7 +27,7 @@ G_DEFINE_TYPE(FuIfdBios, fu_ifd_bios, FU_TYPE_IFD_IMAGE)
 
 static gboolean
 fu_ifd_bios_parse(FuFirmware *firmware,
-		  GInputStream *stream,
+		  FuInputStream *stream,
 		  FuFirmwareParseFlags flags,
 		  GError **error)
 {

--- a/libfwupdplugin/fu-ifd-firmware.c
+++ b/libfwupdplugin/fu-ifd-firmware.c
@@ -94,18 +94,18 @@ fu_ifd_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuil
 }
 
 static gboolean
-fu_ifd_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize offset, GError **error)
+fu_ifd_firmware_validate(FuFirmware *firmware, FuInputStream *stream, gsize offset, GError **error)
 {
 	return fu_struct_ifd_fdbar_validate_stream(stream, offset, error);
 }
 
-static GInputStream *
-fu_ifd_firmware_fixup_stream(GInputStream *stream, GError **error)
+static FuInputStream *
+fu_ifd_firmware_fixup_stream(FuInputStream *stream, GError **error)
 {
 	const guint8 buf[] = {0xFF};
 	gsize streamsz = 0;
 	g_autoptr(GBytes) blob = g_bytes_new(buf, sizeof(buf));
-	g_autoptr(GInputStream) stream2 = fu_composite_input_stream_new();
+	g_autoptr(FuInputStream) stream2 = fu_composite_input_stream_new();
 
 	/* already aligned */
 	if (!fu_input_stream_size(stream, &streamsz, error))
@@ -173,7 +173,7 @@ fu_ifd_firmware_region_to_access(FuIfdRegion region, guint32 flash_master, gbool
 
 static gboolean
 fu_ifd_firmware_parse(FuFirmware *firmware,
-		      GInputStream *stream,
+		      FuInputStream *stream,
 		      FuFirmwareParseFlags flags,
 		      GError **error)
 {
@@ -182,7 +182,7 @@ fu_ifd_firmware_parse(FuFirmware *firmware,
 	gsize streamsz = 0;
 	g_autoptr(FuStructIfdFcba) st_fcba = NULL;
 	g_autoptr(FuStructIfdFdbar) st_fdbar = NULL;
-	g_autoptr(GInputStream) stream2 = NULL;
+	g_autoptr(FuInputStream) stream2 = NULL;
 
 	/* check size */
 	if (!fu_input_stream_size(stream, &streamsz, error))
@@ -269,7 +269,7 @@ fu_ifd_firmware_parse(FuFirmware *firmware,
 		guint32 freg_limt = FU_IFD_FREG_LIMIT(priv->flash_descriptor_regs[i]);
 		guint32 freg_size;
 		g_autoptr(FuFirmware) img = NULL;
-		g_autoptr(GInputStream) partial_stream = NULL;
+		g_autoptr(FuInputStream) partial_stream = NULL;
 
 		/* invalid - check before subtraction */
 		if (freg_base > freg_limt)

--- a/libfwupdplugin/fu-ifwi-cpd-firmware.c
+++ b/libfwupdplugin/fu-ifwi-cpd-firmware.c
@@ -53,7 +53,7 @@ fu_ifwi_cpd_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, X
 static gboolean
 fu_ifwi_cpd_firmware_parse_manifest(FuIfwiCpdFirmware *self,
 				    FuFirmware *firmware,
-				    GInputStream *stream,
+				    FuInputStream *stream,
 				    FuFirmwareParseFlags flags,
 				    GError **error)
 {
@@ -109,7 +109,7 @@ fu_ifwi_cpd_firmware_parse_manifest(FuIfwiCpdFirmware *self,
 		guint32 extension_length = 0;
 		g_autoptr(FuFirmware) img = fu_firmware_new();
 		g_autoptr(FuStructIfwiCpdManifestExt) st_mex = NULL;
-		g_autoptr(GInputStream) partial_stream = NULL;
+		g_autoptr(FuInputStream) partial_stream = NULL;
 
 		/* set the extension type as the index */
 		st_mex = fu_struct_ifwi_cpd_manifest_ext_parse_stream(stream, offset, error);
@@ -157,7 +157,7 @@ fu_ifwi_cpd_firmware_parse_manifest(FuIfwiCpdFirmware *self,
 
 static gboolean
 fu_ifwi_cpd_firmware_validate(FuFirmware *firmware,
-			      GInputStream *stream,
+			      FuInputStream *stream,
 			      gsize offset,
 			      GError **error)
 {
@@ -166,7 +166,7 @@ fu_ifwi_cpd_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_ifwi_cpd_firmware_parse(FuFirmware *firmware,
-			   GInputStream *stream,
+			   FuInputStream *stream,
 			   FuFirmwareParseFlags flags,
 			   GError **error)
 {
@@ -202,7 +202,7 @@ fu_ifwi_cpd_firmware_parse(FuFirmware *firmware,
 		g_autofree gchar *id = NULL;
 		g_autoptr(FuFirmware) img = fu_ifwi_cpd_image_new();
 		g_autoptr(FuStructIfwiCpdEntry) st_ent = NULL;
-		g_autoptr(GInputStream) partial_stream = NULL;
+		g_autoptr(FuInputStream) partial_stream = NULL;
 
 		/* the IDX is the position in the file */
 		fu_firmware_set_idx(img, i);

--- a/libfwupdplugin/fu-ifwi-fpt-firmware.c
+++ b/libfwupdplugin/fu-ifwi-fpt-firmware.c
@@ -15,6 +15,7 @@
 #include "fu-common.h"
 #include "fu-ifwi-fpt-firmware.h"
 #include "fu-ifwi-struct.h"
+#include "fu-input-stream.h"
 #include "fu-partial-input-stream.h"
 #include "fu-string.h"
 
@@ -36,7 +37,7 @@ G_DEFINE_TYPE(FuIfwiFptFirmware, fu_ifwi_fpt_firmware, FU_TYPE_FIRMWARE)
 
 static gboolean
 fu_ifwi_fpt_firmware_validate(FuFirmware *firmware,
-			      GInputStream *stream,
+			      FuInputStream *stream,
 			      gsize offset,
 			      GError **error)
 {
@@ -45,7 +46,7 @@ fu_ifwi_fpt_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_ifwi_fpt_firmware_parse(FuFirmware *firmware,
-			   GInputStream *stream,
+			   FuInputStream *stream,
 			   FuFirmwareParseFlags flags,
 			   GError **error)
 {
@@ -104,7 +105,7 @@ fu_ifwi_fpt_firmware_parse(FuFirmware *firmware,
 		data_length = fu_struct_ifwi_fpt_entry_get_length(st_ent);
 		if (data_length != 0x0) {
 			guint32 data_offset = fu_struct_ifwi_fpt_entry_get_offset(st_ent);
-			g_autoptr(GInputStream) partial_stream = NULL;
+			g_autoptr(FuInputStream) partial_stream = NULL;
 			partial_stream =
 			    fu_partial_input_stream_new(stream, data_offset, data_length, error);
 			if (partial_stream == NULL) {

--- a/libfwupdplugin/fu-ihex-firmware.c
+++ b/libfwupdplugin/fu-ihex-firmware.c
@@ -14,6 +14,7 @@
 #include "fu-common.h"
 #include "fu-firmware-common.h"
 #include "fu-ihex-firmware.h"
+#include "fu-input-stream.h"
 #include "fu-mem.h"
 #include "fu-string.h"
 #include "fu-sum.h"
@@ -211,7 +212,7 @@ fu_ihex_firmware_tokenize_cb(GString *token, guint token_idx, gpointer user_data
 
 static gboolean
 fu_ihex_firmware_tokenize(FuFirmware *firmware,
-			  GInputStream *stream,
+			  FuInputStream *stream,
 			  FuFirmwareParseFlags flags,
 			  GError **error)
 {
@@ -222,7 +223,7 @@ fu_ihex_firmware_tokenize(FuFirmware *firmware,
 
 static gboolean
 fu_ihex_firmware_parse(FuFirmware *firmware,
-		       GInputStream *stream,
+		       FuInputStream *stream,
 		       FuFirmwareParseFlags flags,
 		       GError **error)
 {

--- a/libfwupdplugin/fu-input-stream-test.c
+++ b/libfwupdplugin/fu-input-stream-test.c
@@ -20,7 +20,7 @@ fu_input_stream_find_func(void)
 	g_autoptr(FuInputStream) stream = NULL;
 
 	stream =
-	    g_memory_input_stream_new_from_data((const guint8 *)haystack, strlen(haystack), NULL);
+	    fu_memory_input_stream_new_from_data((const guint8 *)haystack, strlen(haystack), NULL);
 	ret = fu_input_stream_find(stream,
 				   (const guint8 *)needle1,
 				   strlen(needle1),
@@ -60,7 +60,7 @@ fu_input_stream_sum_overflow_func(void)
 	guint32 sum32 = 0;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(FuInputStream) stream =
-	    g_memory_input_stream_new_from_data(buf, sizeof(buf), NULL);
+	    fu_memory_input_stream_new_from_data(buf, sizeof(buf), NULL);
 
 	ret = fu_input_stream_compute_sum32(stream, &sum32, &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_READ);
@@ -84,7 +84,7 @@ fu_input_stream_chunkify_func(void)
 	for (guint i = 0; i < 0x80000; i++)
 		fu_byte_array_append_uint8(buf, i);
 	blob = g_bytes_new(buf->data, buf->len);
-	stream = g_memory_input_stream_new_from_bytes(blob);
+	stream = fu_memory_input_stream_new_from_bytes(blob);
 
 	ret = fu_input_stream_compute_sum8(stream, &sum8, &error);
 	g_assert_no_error(error);

--- a/libfwupdplugin/fu-input-stream-test.c
+++ b/libfwupdplugin/fu-input-stream-test.c
@@ -127,7 +127,6 @@ fu_input_stream_func(void)
 	g_autofree guint8 *buf2 = NULL;
 	g_autofree guint8 *buf = NULL;
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GFile) file = NULL;
 	g_autoptr(FuInputStream) stream = NULL;
 
 	fn = g_test_build_filename(G_TEST_DIST, "tests", "dfu.builder.xml", NULL);
@@ -138,8 +137,7 @@ fu_input_stream_func(void)
 	fu_dump_raw(G_LOG_DOMAIN, "src", buf, bufsz);
 	csum = g_compute_checksum_for_data(G_CHECKSUM_MD5, (const guchar *)buf, bufsz);
 
-	file = g_file_new_for_path(fn);
-	stream = FU_INPUT_STREAM(g_file_read(file, NULL, &error));
+	stream = fu_input_stream_from_path(fn, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(stream);
 

--- a/libfwupdplugin/fu-input-stream-test.c
+++ b/libfwupdplugin/fu-input-stream-test.c
@@ -17,7 +17,7 @@ fu_input_stream_find_func(void)
 	gboolean ret;
 	gsize offset = 0;
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	stream =
 	    g_memory_input_stream_new_from_data((const guint8 *)haystack, strlen(haystack), NULL);
@@ -59,7 +59,7 @@ fu_input_stream_sum_overflow_func(void)
 	gboolean ret;
 	guint32 sum32 = 0;
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream =
+	g_autoptr(FuInputStream) stream =
 	    g_memory_input_stream_new_from_data(buf, sizeof(buf), NULL);
 
 	ret = fu_input_stream_compute_sum32(stream, &sum32, &error);
@@ -75,7 +75,7 @@ fu_input_stream_chunkify_func(void)
 	guint16 crc16 = 0x0;
 	guint32 crc32 = 0xffffffff;
 	g_autoptr(GByteArray) buf = g_byte_array_new();
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GBytes) blob = NULL;
 	g_autofree gchar *checksum = NULL;
@@ -128,7 +128,7 @@ fu_input_stream_func(void)
 	g_autofree guint8 *buf = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GFile) file = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	fn = g_test_build_filename(G_TEST_DIST, "tests", "dfu.builder.xml", NULL);
 	g_assert_nonnull(fn);
@@ -139,7 +139,7 @@ fu_input_stream_func(void)
 	csum = g_compute_checksum_for_data(G_CHECKSUM_MD5, (const guchar *)buf, bufsz);
 
 	file = g_file_new_for_path(fn);
-	stream = G_INPUT_STREAM(g_file_read(file, NULL, &error));
+	stream = FU_INPUT_STREAM(g_file_read(file, NULL, &error));
 	g_assert_no_error(error);
 	g_assert_nonnull(stream);
 

--- a/libfwupdplugin/fu-input-stream.c
+++ b/libfwupdplugin/fu-input-stream.c
@@ -10,6 +10,7 @@
 
 #include "fu-chunk-array.h"
 #include "fu-crc-private.h"
+#include "fu-file-input-stream.h"
 #include "fu-input-stream.h"
 #include "fu-mem-private.h"
 #include "fu-sum.h"
@@ -29,13 +30,13 @@ FuInputStream *
 fu_input_stream_from_path(const gchar *path, GError **error)
 {
 	g_autoptr(GFile) file = NULL;
-	g_autoptr(GFileInputStream) stream = NULL;
+	g_autoptr(FuFileInputStream) stream = NULL;
 
 	g_return_val_if_fail(path != NULL, NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
 	file = g_file_new_for_path(path);
-	stream = g_file_read(file, NULL, error);
+	stream = fu_file_input_stream_from_file(file, NULL, error);
 	if (stream == NULL) {
 		fwupd_error_convert(error);
 		return NULL;

--- a/libfwupdplugin/fu-input-stream.c
+++ b/libfwupdplugin/fu-input-stream.c
@@ -21,11 +21,11 @@
  *
  * Opens the file as n input stream.
  *
- * Returns: (transfer full): a #GInputStream, or %NULL on error
+ * Returns: (transfer full): a #FuInputStream, or %NULL on error
  *
  * Since: 2.0.0
  **/
-GInputStream *
+FuInputStream *
 fu_input_stream_from_path(const gchar *path, GError **error)
 {
 	g_autoptr(GFile) file = NULL;
@@ -40,12 +40,12 @@ fu_input_stream_from_path(const gchar *path, GError **error)
 		fwupd_error_convert(error);
 		return NULL;
 	}
-	return G_INPUT_STREAM(g_steal_pointer(&stream));
+	return FU_INPUT_STREAM(g_steal_pointer(&stream));
 }
 
 /**
  * fu_input_stream_read_safe:
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @buf (not nullable): a buffer to read data into
  * @bufsz: size of @buf
  * @offset: offset in bytes into @buf to copy from
@@ -60,7 +60,7 @@ fu_input_stream_from_path(const gchar *path, GError **error)
  * Since: 2.0.0
  **/
 gboolean
-fu_input_stream_read_safe(GInputStream *stream,
+fu_input_stream_read_safe(FuInputStream *stream,
 			  guint8 *buf,
 			  gsize bufsz,
 			  gsize offset,
@@ -70,7 +70,7 @@ fu_input_stream_read_safe(GInputStream *stream,
 {
 	gssize rc;
 
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(buf != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
@@ -99,7 +99,7 @@ fu_input_stream_read_safe(GInputStream *stream,
 
 /**
  * fu_input_stream_read_u8:
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @offset: offset in bytes into @stream to copy from
  * @value: (out) (not nullable): the parsed value
  * @error: (nullable): optional return location for an error
@@ -111,10 +111,10 @@ fu_input_stream_read_safe(GInputStream *stream,
  * Since: 2.0.0
  **/
 gboolean
-fu_input_stream_read_u8(GInputStream *stream, gsize offset, guint8 *value, GError **error)
+fu_input_stream_read_u8(FuInputStream *stream, gsize offset, guint8 *value, GError **error)
 {
 	guint8 buf = 0;
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(value != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 	if (!fu_input_stream_read_safe(stream, &buf, sizeof(buf), 0x0, offset, sizeof(buf), error))
@@ -125,7 +125,7 @@ fu_input_stream_read_u8(GInputStream *stream, gsize offset, guint8 *value, GErro
 
 /**
  * fu_input_stream_read_u16:
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @offset: offset in bytes into @stream to copy from
  * @value: (out) (not nullable): the parsed value
  * @endian: an endian type, e.g. %G_LITTLE_ENDIAN
@@ -138,14 +138,14 @@ fu_input_stream_read_u8(GInputStream *stream, gsize offset, guint8 *value, GErro
  * Since: 2.0.0
  **/
 gboolean
-fu_input_stream_read_u16(GInputStream *stream,
+fu_input_stream_read_u16(FuInputStream *stream,
 			 gsize offset,
 			 guint16 *value,
 			 FuEndianType endian,
 			 GError **error)
 {
 	guint8 buf[2] = {0};
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(value != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 	if (!fu_input_stream_read_safe(stream, buf, sizeof(buf), 0x0, offset, sizeof(buf), error))
@@ -156,7 +156,7 @@ fu_input_stream_read_u16(GInputStream *stream,
 
 /**
  * fu_input_stream_read_u24:
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @offset: offset in bytes into @stream to copy from
  * @value: (out) (not nullable): the parsed value
  * @endian: an endian type, e.g. %G_LITTLE_ENDIAN
@@ -169,14 +169,14 @@ fu_input_stream_read_u16(GInputStream *stream,
  * Since: 2.0.0
  **/
 gboolean
-fu_input_stream_read_u24(GInputStream *stream,
+fu_input_stream_read_u24(FuInputStream *stream,
 			 gsize offset,
 			 guint32 *value,
 			 FuEndianType endian,
 			 GError **error)
 {
 	guint8 buf[3] = {0};
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(value != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 	if (!fu_input_stream_read_safe(stream, buf, sizeof(buf), 0x0, offset, sizeof(buf), error))
@@ -187,7 +187,7 @@ fu_input_stream_read_u24(GInputStream *stream,
 
 /**
  * fu_input_stream_read_u32:
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @offset: offset in bytes into @stream to copy from
  * @value: (out) (not nullable): the parsed value
  * @endian: an endian type, e.g. %G_LITTLE_ENDIAN
@@ -200,14 +200,14 @@ fu_input_stream_read_u24(GInputStream *stream,
  * Since: 2.0.0
  **/
 gboolean
-fu_input_stream_read_u32(GInputStream *stream,
+fu_input_stream_read_u32(FuInputStream *stream,
 			 gsize offset,
 			 guint32 *value,
 			 FuEndianType endian,
 			 GError **error)
 {
 	guint8 buf[4] = {0};
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(value != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 	if (!fu_input_stream_read_safe(stream, buf, sizeof(buf), 0x0, offset, sizeof(buf), error))
@@ -218,7 +218,7 @@ fu_input_stream_read_u32(GInputStream *stream,
 
 /**
  * fu_input_stream_read_u64:
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @offset: offset in bytes into @stream to copy from
  * @value: (out) (not nullable): the parsed value
  * @endian: an endian type, e.g. %G_LITTLE_ENDIAN
@@ -231,14 +231,14 @@ fu_input_stream_read_u32(GInputStream *stream,
  * Since: 2.0.0
  **/
 gboolean
-fu_input_stream_read_u64(GInputStream *stream,
+fu_input_stream_read_u64(FuInputStream *stream,
 			 gsize offset,
 			 guint64 *value,
 			 FuEndianType endian,
 			 GError **error)
 {
 	guint8 buf[8] = {0};
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(value != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 	if (!fu_input_stream_read_safe(stream, buf, sizeof(buf), 0x0, offset, sizeof(buf), error))
@@ -249,7 +249,7 @@ fu_input_stream_read_u64(GInputStream *stream,
 
 /**
  * fu_input_stream_read_byte_array:
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @offset: offset in bytes into @stream to copy from
  * @count: maximum number of bytes to read
  * @progress: (nullable): an optional #FuProgress
@@ -264,7 +264,7 @@ fu_input_stream_read_u64(GInputStream *stream,
  * Since: 2.0.0
  **/
 GByteArray *
-fu_input_stream_read_byte_array(GInputStream *stream,
+fu_input_stream_read_byte_array(FuInputStream *stream,
 				gsize offset,
 				gsize count,
 				FuProgress *progress,
@@ -274,7 +274,7 @@ fu_input_stream_read_byte_array(GInputStream *stream,
 	g_autoptr(GByteArray) buf = g_byte_array_new();
 	g_autoptr(GError) error_local = NULL;
 
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), NULL);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), NULL);
 	g_return_val_if_fail(progress == NULL || FU_IS_PROGRESS(progress), NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
@@ -335,7 +335,7 @@ fu_input_stream_read_byte_array(GInputStream *stream,
 
 /**
  * fu_input_stream_read_bytes:
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @offset: offset in bytes into @stream to copy from
  * @count: maximum number of bytes to read
  * @progress: (nullable): an optional #FuProgress
@@ -350,14 +350,14 @@ fu_input_stream_read_byte_array(GInputStream *stream,
  * Since: 2.0.0
  **/
 GBytes *
-fu_input_stream_read_bytes(GInputStream *stream,
+fu_input_stream_read_bytes(FuInputStream *stream,
 			   gsize offset,
 			   gsize count,
 			   FuProgress *progress,
 			   GError **error)
 {
 	g_autoptr(GByteArray) buf = NULL;
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), NULL);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), NULL);
 	g_return_val_if_fail(progress == NULL || FU_IS_PROGRESS(progress), NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 	buf = fu_input_stream_read_byte_array(stream, offset, count, progress, error);
@@ -368,7 +368,7 @@ fu_input_stream_read_bytes(GInputStream *stream,
 
 /**
  * fu_input_stream_read_string:
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @offset: offset in bytes into @stream to copy from
  * @count: maximum number of bytes to read
  * @error: (nullable): optional return location for an error
@@ -380,11 +380,11 @@ fu_input_stream_read_bytes(GInputStream *stream,
  * Since: 2.0.0
  **/
 gchar *
-fu_input_stream_read_string(GInputStream *stream, gsize offset, gsize count, GError **error)
+fu_input_stream_read_string(FuInputStream *stream, gsize offset, gsize count, GError **error)
 {
 	g_autoptr(GByteArray) buf = NULL;
 
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), NULL);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
 	buf = fu_input_stream_read_byte_array(stream, offset, count, NULL, error);
@@ -402,7 +402,7 @@ fu_input_stream_read_string(GInputStream *stream, gsize offset, gsize count, GEr
 
 /**
  * fu_input_stream_size:
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @val: (out): size in bytes
  * @error: (nullable): optional return location for an error
  *
@@ -415,9 +415,9 @@ fu_input_stream_read_string(GInputStream *stream, gsize offset, gsize count, GEr
  * Since: 2.0.0
  **/
 gboolean
-fu_input_stream_size(GInputStream *stream, gsize *val, GError **error)
+fu_input_stream_size(FuInputStream *stream, gsize *val, GError **error)
 {
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	/* streaming from unseekable stream */
@@ -451,7 +451,7 @@ fu_input_stream_compute_checksum_cb(const guint8 *buf,
 
 /**
  * fu_input_stream_compute_checksum:
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @checksum_type: a #GChecksumType
  * @error: (nullable): optional return location for an error
  *
@@ -462,11 +462,11 @@ fu_input_stream_compute_checksum_cb(const guint8 *buf,
  * Since: 2.0.0
  **/
 gchar *
-fu_input_stream_compute_checksum(GInputStream *stream, GChecksumType checksum_type, GError **error)
+fu_input_stream_compute_checksum(FuInputStream *stream, GChecksumType checksum_type, GError **error)
 {
 	g_autoptr(GChecksum) csum = g_checksum_new(checksum_type);
 
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), NULL);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
 	if (!fu_input_stream_chunkify(stream, fu_input_stream_compute_checksum_cb, csum, error))
@@ -484,7 +484,7 @@ fu_input_stream_compute_sum8_cb(const guint8 *buf, gsize bufsz, gpointer user_da
 
 /**
  * fu_input_stream_compute_sum8:
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @value: (out): value
  * @error: (nullable): optional return location for an error
  *
@@ -495,9 +495,9 @@ fu_input_stream_compute_sum8_cb(const guint8 *buf, gsize bufsz, gpointer user_da
  * Since: 2.0.0
  **/
 gboolean
-fu_input_stream_compute_sum8(GInputStream *stream, guint8 *value, GError **error)
+fu_input_stream_compute_sum8(FuInputStream *stream, guint8 *value, GError **error)
 {
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(value != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 	return fu_input_stream_chunkify(stream, fu_input_stream_compute_sum8_cb, value, error);
@@ -522,7 +522,7 @@ fu_input_stream_compute_sum16_cb(const guint8 *buf, gsize bufsz, gpointer user_d
 
 /**
  * fu_input_stream_compute_sum16:
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @value: (out): value
  * @error: (nullable): optional return location for an error
  *
@@ -533,9 +533,9 @@ fu_input_stream_compute_sum16_cb(const guint8 *buf, gsize bufsz, gpointer user_d
  * Since: 2.0.0
  **/
 gboolean
-fu_input_stream_compute_sum16(GInputStream *stream, guint16 *value, GError **error)
+fu_input_stream_compute_sum16(FuInputStream *stream, guint16 *value, GError **error)
 {
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(value != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 	return fu_input_stream_chunkify(stream, fu_input_stream_compute_sum16_cb, value, error);
@@ -560,7 +560,7 @@ fu_input_stream_compute_sum32_cb(const guint8 *buf, gsize bufsz, gpointer user_d
 
 /**
  * fu_input_stream_compute_sum32:
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @value: (out): value
  * @error: (nullable): optional return location for an error
  *
@@ -571,9 +571,9 @@ fu_input_stream_compute_sum32_cb(const guint8 *buf, gsize bufsz, gpointer user_d
  * Since: 2.0.1
  **/
 gboolean
-fu_input_stream_compute_sum32(GInputStream *stream, guint32 *value, GError **error)
+fu_input_stream_compute_sum32(FuInputStream *stream, guint32 *value, GError **error)
 {
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(value != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 	return fu_input_stream_chunkify(stream, fu_input_stream_compute_sum32_cb, value, error);
@@ -605,7 +605,7 @@ fu_input_stream_compute_crc32_fast_cb(const guint8 *buf,
 
 /**
  * fu_input_stream_compute_crc32:
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @kind: a #FuCrcKind, typically %FU_CRC_KIND_B32_STANDARD
  * @crc: (inout): initial and final CRC value
  * @error: (nullable): optional return location for an error
@@ -620,10 +620,10 @@ fu_input_stream_compute_crc32_fast_cb(const guint8 *buf,
  * Since: 2.0.0
  **/
 gboolean
-fu_input_stream_compute_crc32(GInputStream *stream, FuCrcKind kind, guint32 *crc, GError **error)
+fu_input_stream_compute_crc32(FuInputStream *stream, FuCrcKind kind, guint32 *crc, GError **error)
 {
 	FuInputStreamComputeCrc32Helper helper = {.crc = *crc, .kind = kind};
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(crc != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
@@ -656,7 +656,7 @@ fu_input_stream_compute_crc16_cb(const guint8 *buf, gsize bufsz, gpointer user_d
 
 /**
  * fu_input_stream_compute_crc16:
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @kind: a #FuCrcKind, typically %FU_CRC_KIND_B16_XMODEM
  * @crc: (inout): initial and final CRC value
  * @error: (nullable): optional return location for an error
@@ -671,10 +671,10 @@ fu_input_stream_compute_crc16_cb(const guint8 *buf, gsize bufsz, gpointer user_d
  * Since: 2.0.0
  **/
 gboolean
-fu_input_stream_compute_crc16(GInputStream *stream, FuCrcKind kind, guint16 *crc, GError **error)
+fu_input_stream_compute_crc16(FuInputStream *stream, FuCrcKind kind, guint16 *crc, GError **error)
 {
 	FuInputStreamComputeCrc16Helper helper = {.crc = *crc, .kind = kind};
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(crc != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 	if (!fu_input_stream_chunkify(stream, fu_input_stream_compute_crc16_cb, &helper, error))
@@ -685,7 +685,7 @@ fu_input_stream_compute_crc16(GInputStream *stream, FuCrcKind kind, guint16 *crc
 
 /**
  * fu_input_stream_chunkify:
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @func_cb: (scope async): function to call with chunks
  * @user_data: user data to pass to @func_cb
  * @error: (nullable): optional return location for an error
@@ -697,14 +697,14 @@ fu_input_stream_compute_crc16(GInputStream *stream, FuCrcKind kind, guint16 *crc
  * Since: 2.0.0
  **/
 gboolean
-fu_input_stream_chunkify(GInputStream *stream,
+fu_input_stream_chunkify(FuInputStream *stream,
 			 FuInputStreamChunkifyFunc func_cb,
 			 gpointer user_data,
 			 GError **error)
 {
 	g_autoptr(FuChunkArray) chunks = NULL;
 
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(func_cb != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
@@ -728,7 +728,7 @@ fu_input_stream_chunkify(GInputStream *stream,
 
 /**
  * fu_input_stream_find:
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @buf: input buffer to look for
  * @bufsz: size of @buf
  * @offset: starting offset, typically 0x0
@@ -742,7 +742,7 @@ fu_input_stream_chunkify(GInputStream *stream,
  * Since: 2.0.18
  **/
 gboolean
-fu_input_stream_find(GInputStream *stream,
+fu_input_stream_find(FuInputStream *stream,
 		     const guint8 *buf,
 		     gsize bufsz,
 		     gsize offset,
@@ -754,7 +754,7 @@ fu_input_stream_find(GInputStream *stream,
 	gsize offset_add = 0;
 	gsize offset_cur = offset;
 
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(buf != NULL, FALSE);
 	g_return_val_if_fail(bufsz != 0, FALSE);
 	g_return_val_if_fail(bufsz < blocksz, FALSE);

--- a/libfwupdplugin/fu-input-stream.c
+++ b/libfwupdplugin/fu-input-stream.c
@@ -80,7 +80,11 @@ fu_input_stream_read_safe(FuInputStream *stream,
 		g_prefix_error(error, "seek to 0x%x: ", (guint)seek_set);
 		return FALSE;
 	}
-	rc = g_input_stream_read(stream, buf + offset, count, NULL, error);
+	rc = g_input_stream_read(G_INPUT_STREAM(stream),
+				 buf + offset,
+				 count,
+				 NULL,
+				 error); /* nocheck:blocked */
 	if (rc == -1) {
 		g_prefix_error(error, "failed read of 0x%x: ", (guint)count);
 		return FALSE;
@@ -296,7 +300,7 @@ fu_input_stream_read_byte_array(FuInputStream *stream,
 	/* read from stream in 32kB chunks */
 	while (TRUE) {
 		gssize sz;
-		sz = g_input_stream_read(stream,
+		sz = g_input_stream_read(G_INPUT_STREAM(stream), /* nocheck:blocked */
 					 tmp,
 					 MIN(count - buf->len, sizeof(tmp)),
 					 NULL,

--- a/libfwupdplugin/fu-input-stream.h
+++ b/libfwupdplugin/fu-input-stream.h
@@ -21,13 +21,13 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuInputStream, g_object_unref) /* nocheck:blocked 
 #define FU_IS_INPUT_STREAM    G_IS_INPUT_STREAM		     /* nocheck:blocked */
 #define FU_INPUT_STREAM_CLASS G_INPUT_STREAM_CLASS	     /* nocheck:blocked */
 
-GInputStream *
+FuInputStream *
 fu_input_stream_from_path(const gchar *path, GError **error) G_GNUC_WARN_UNUSED_RESULT
     G_GNUC_NON_NULL(1);
 gboolean
-fu_input_stream_size(GInputStream *stream, gsize *val, GError **error) G_GNUC_NON_NULL(1);
+fu_input_stream_size(FuInputStream *stream, gsize *val, GError **error) G_GNUC_NON_NULL(1);
 gboolean
-fu_input_stream_read_safe(GInputStream *stream,
+fu_input_stream_read_safe(FuInputStream *stream,
 			  guint8 *buf,
 			  gsize bufsz,
 			  gsize offset,
@@ -35,46 +35,46 @@ fu_input_stream_read_safe(GInputStream *stream,
 			  gsize count,
 			  GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
 gboolean
-fu_input_stream_read_u8(GInputStream *stream, gsize offset, guint8 *value, GError **error)
+fu_input_stream_read_u8(FuInputStream *stream, gsize offset, guint8 *value, GError **error)
     G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 3);
 gboolean
-fu_input_stream_read_u16(GInputStream *stream,
+fu_input_stream_read_u16(FuInputStream *stream,
 			 gsize offset,
 			 guint16 *value,
 			 FuEndianType endian,
 			 GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 3);
 gboolean
-fu_input_stream_read_u24(GInputStream *stream,
+fu_input_stream_read_u24(FuInputStream *stream,
 			 gsize offset,
 			 guint32 *value,
 			 FuEndianType endian,
 			 GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 3);
 gboolean
-fu_input_stream_read_u32(GInputStream *stream,
+fu_input_stream_read_u32(FuInputStream *stream,
 			 gsize offset,
 			 guint32 *value,
 			 FuEndianType endian,
 			 GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 3);
 gboolean
-fu_input_stream_read_u64(GInputStream *stream,
+fu_input_stream_read_u64(FuInputStream *stream,
 			 gsize offset,
 			 guint64 *value,
 			 FuEndianType endian,
 			 GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 3);
 GByteArray *
-fu_input_stream_read_byte_array(GInputStream *stream,
+fu_input_stream_read_byte_array(FuInputStream *stream,
 				gsize offset,
 				gsize count,
 				FuProgress *progress,
 				GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1);
 GBytes *
-fu_input_stream_read_bytes(GInputStream *stream,
+fu_input_stream_read_bytes(FuInputStream *stream,
 			   gsize offset,
 			   gsize count,
 			   FuProgress *progress,
 			   GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1);
 gchar *
-fu_input_stream_read_string(GInputStream *stream, gsize offset, gsize count, GError **error)
+fu_input_stream_read_string(FuInputStream *stream, gsize offset, gsize count, GError **error)
     G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1);
 
 typedef gboolean (*FuInputStreamChunkifyFunc)(const guint8 *buf,
@@ -82,35 +82,35 @@ typedef gboolean (*FuInputStreamChunkifyFunc)(const guint8 *buf,
 					      gpointer user_data,
 					      GError **error) G_GNUC_WARN_UNUSED_RESULT;
 gboolean
-fu_input_stream_chunkify(GInputStream *stream,
+fu_input_stream_chunkify(FuInputStream *stream,
 			 FuInputStreamChunkifyFunc func_cb,
 			 gpointer user_data,
 			 GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
 
 gboolean
-fu_input_stream_compute_sum8(GInputStream *stream,
+fu_input_stream_compute_sum8(FuInputStream *stream,
 			     guint8 *value,
 			     GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
 gboolean
-fu_input_stream_compute_sum16(GInputStream *stream,
+fu_input_stream_compute_sum16(FuInputStream *stream,
 			      guint16 *value,
 			      GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
 gboolean
-fu_input_stream_compute_sum32(GInputStream *stream,
+fu_input_stream_compute_sum32(FuInputStream *stream,
 			      guint32 *value,
 			      GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
 gboolean
-fu_input_stream_compute_crc16(GInputStream *stream, FuCrcKind kind, guint16 *crc, GError **error)
+fu_input_stream_compute_crc16(FuInputStream *stream, FuCrcKind kind, guint16 *crc, GError **error)
     G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 3);
 gboolean
-fu_input_stream_compute_crc32(GInputStream *stream, FuCrcKind kind, guint32 *crc, GError **error)
+fu_input_stream_compute_crc32(FuInputStream *stream, FuCrcKind kind, guint32 *crc, GError **error)
     G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 3);
 gchar *
-fu_input_stream_compute_checksum(GInputStream *stream,
+fu_input_stream_compute_checksum(FuInputStream *stream,
 				 GChecksumType checksum_type,
 				 GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1);
 gboolean
-fu_input_stream_find(GInputStream *stream,
+fu_input_stream_find(FuInputStream *stream,
 		     const guint8 *buf,
 		     gsize bufsz,
 		     gsize offset,

--- a/libfwupdplugin/fu-input-stream.h
+++ b/libfwupdplugin/fu-input-stream.h
@@ -12,6 +12,15 @@
 #include "fu-endian.h"
 #include "fu-progress.h"
 
+typedef GInputStream FuInputStream;	      /* nocheck:blocked */
+typedef GInputStreamClass FuInputStreamClass; /* nocheck:blocked */
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuInputStream, g_object_unref) /* nocheck:blocked */
+#define FU_INPUT_STREAM	      G_INPUT_STREAM		     /* nocheck:blocked */
+#define FU_TYPE_INPUT_STREAM  G_TYPE_INPUT_STREAM	     /* nocheck:blocked */
+#define FU_IS_INPUT_STREAM    G_IS_INPUT_STREAM		     /* nocheck:blocked */
+#define FU_INPUT_STREAM_CLASS G_INPUT_STREAM_CLASS	     /* nocheck:blocked */
+
 GInputStream *
 fu_input_stream_from_path(const gchar *path, GError **error) G_GNUC_WARN_UNUSED_RESULT
     G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-intel-thunderbolt-firmware.c
+++ b/libfwupdplugin/fu-intel-thunderbolt-firmware.c
@@ -38,14 +38,14 @@ fu_intel_thunderbolt_firmware_nvm_valid_farb_pointer(guint32 pointer)
 
 static gboolean
 fu_intel_thunderbolt_firmware_parse(FuFirmware *firmware,
-				    GInputStream *stream,
+				    FuInputStream *stream,
 				    FuFirmwareParseFlags flags,
 				    GError **error)
 {
 	const guint32 farb_offsets[] = {0x0, 0x1000};
 	gboolean valid = FALSE;
 	guint32 farb_pointer = 0x0;
-	g_autoptr(GInputStream) partial_stream = NULL;
+	g_autoptr(FuInputStream) partial_stream = NULL;
 
 	/* get header offset */
 	for (guint i = 0; i < G_N_ELEMENTS(farb_offsets); i++) {

--- a/libfwupdplugin/fu-intel-thunderbolt-nvm.c
+++ b/libfwupdplugin/fu-intel-thunderbolt-nvm.c
@@ -223,7 +223,7 @@ fu_intel_thunderbolt_nvm_valid_pd_pointer(guint32 pointer)
  */
 static gboolean
 fu_intel_thunderbolt_nvm_read_ucode_section_len(FuIntelThunderboltNvm *self,
-						GInputStream *stream,
+						FuInputStream *stream,
 						guint32 offset,
 						gsize *value,
 						GError **error)
@@ -249,7 +249,7 @@ fu_intel_thunderbolt_nvm_read_ucode_section_len(FuIntelThunderboltNvm *self,
 /* assumes sections[FU_INTEL_THUNDERBOLT_NVM_SECTION_DIGITAL].offset is already set */
 static gboolean
 fu_intel_thunderbolt_nvm_read_sections(FuIntelThunderboltNvm *self,
-				       GInputStream *stream,
+				       FuInputStream *stream,
 				       GError **error)
 {
 	FuIntelThunderboltNvmPrivate *priv = GET_PRIVATE(self);
@@ -363,7 +363,7 @@ fu_intel_thunderbolt_nvm_missing_needed_drom(FuIntelThunderboltNvm *self)
 
 static gboolean
 fu_intel_thunderbolt_nvm_parse(FuFirmware *firmware,
-			       GInputStream *stream,
+			       FuInputStream *stream,
 			       FuFirmwareParseFlags flags,
 			       GError **error)
 {

--- a/libfwupdplugin/fu-io-channel.c
+++ b/libfwupdplugin/fu-io-channel.c
@@ -188,7 +188,7 @@ fu_io_channel_write_stream_cb(const guint8 *buf, gsize bufsz, gpointer user_data
 /**
  * fu_io_channel_write_stream:
  * @self: a #FuIOChannel
- * @stream: #GInputStream to write
+ * @stream: #FuInputStream to write
  * @timeout_ms: timeout in ms
  * @flags: channel flags, e.g. %FU_IO_CHANNEL_FLAG_SINGLE_SHOT
  * @error: (nullable): optional return location for an error
@@ -201,7 +201,7 @@ fu_io_channel_write_stream_cb(const guint8 *buf, gsize bufsz, gpointer user_data
  **/
 gboolean
 fu_io_channel_write_stream(FuIOChannel *self,
-			   GInputStream *stream,
+			   FuInputStream *stream,
 			   guint timeout_ms,
 			   FuIoChannelFlags flags,
 			   GError **error)
@@ -210,7 +210,7 @@ fu_io_channel_write_stream(FuIOChannel *self,
 					       .timeout_ms = timeout_ms,
 					       .flags = flags};
 	g_return_val_if_fail(FU_IS_IO_CHANNEL(self), FALSE);
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 	return fu_input_stream_chunkify(stream, fu_io_channel_write_stream_cb, &helper, error);
 }

--- a/libfwupdplugin/fu-io-channel.h
+++ b/libfwupdplugin/fu-io-channel.h
@@ -8,6 +8,7 @@
 
 #include <fwupd.h>
 
+#include "fu-input-stream.h"
 #include "fu-io-channel-struct.h"
 
 #define FU_TYPE_IO_CHANNEL (fu_io_channel_get_type())
@@ -55,7 +56,7 @@ fu_io_channel_write_bytes(FuIOChannel *self,
 			  GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
 gboolean
 fu_io_channel_write_stream(FuIOChannel *self,
-			   GInputStream *stream,
+			   FuInputStream *stream,
 			   guint timeout_ms,
 			   FuIoChannelFlags flags,
 			   GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);

--- a/libfwupdplugin/fu-json-firmware.c
+++ b/libfwupdplugin/fu-json-firmware.c
@@ -9,6 +9,7 @@
 #include "config.h"
 
 #include "fu-common.h"
+#include "fu-input-stream.h"
 #include "fu-json-firmware.h"
 
 /**
@@ -26,7 +27,7 @@ G_DEFINE_TYPE_WITH_PRIVATE(FuJsonFirmware, fu_json_firmware, FU_TYPE_FIRMWARE)
 
 static gboolean
 fu_json_firmware_parse(FuFirmware *firmware,
-		       GInputStream *stream,
+		       FuInputStream *stream,
 		       FuFirmwareParseFlags flags,
 		       GError **error)
 {

--- a/libfwupdplugin/fu-json-firmware.c
+++ b/libfwupdplugin/fu-json-firmware.c
@@ -48,7 +48,7 @@ fu_json_firmware_parse(FuFirmware *firmware,
 
 	/* just load into memory, no extraction performed */
 	priv->json_node = fwupd_json_parser_load_from_stream(json_parser,
-							     stream,
+							     G_INPUT_STREAM(stream),
 							     FWUPD_JSON_LOAD_FLAG_NONE,
 							     error);
 	if (priv->json_node == NULL)

--- a/libfwupdplugin/fu-kernel.c
+++ b/libfwupdplugin/fu-kernel.c
@@ -243,10 +243,10 @@ fu_kernel_get_config(FuPathStore *pstore, GError **error)
 		g_autoptr(GBytes) payload = NULL;
 		g_autoptr(GConverter) conv = NULL;
 		g_autoptr(GFile) file = g_file_new_for_path(config_fngz);
-		g_autoptr(GInputStream) istream1 = NULL;
-		g_autoptr(GInputStream) istream2 = NULL;
+		g_autoptr(FuInputStream) istream1 = NULL;
+		g_autoptr(FuInputStream) istream2 = NULL;
 
-		istream1 = G_INPUT_STREAM(g_file_read(file, NULL, error));
+		istream1 = FU_INPUT_STREAM(g_file_read(file, NULL, error));
 		if (istream1 == NULL)
 			return NULL;
 		conv = G_CONVERTER(g_zlib_decompressor_new(G_ZLIB_COMPRESSOR_FORMAT_GZIP));

--- a/libfwupdplugin/fu-kernel.c
+++ b/libfwupdplugin/fu-kernel.c
@@ -250,7 +250,7 @@ fu_kernel_get_config(FuPathStore *pstore, GError **error)
 		if (istream1 == NULL)
 			return NULL;
 		conv = G_CONVERTER(g_zlib_decompressor_new(G_ZLIB_COMPRESSOR_FORMAT_GZIP));
-		istream2 = g_converter_input_stream_new(istream1, conv);
+		istream2 = g_converter_input_stream_new(G_INPUT_STREAM(istream1), conv);
 		payload = fu_input_stream_read_bytes(istream2, 0, G_MAXSIZE, NULL, error);
 		if (payload == NULL)
 			return NULL;

--- a/libfwupdplugin/fu-kernel.c
+++ b/libfwupdplugin/fu-kernel.c
@@ -242,11 +242,10 @@ fu_kernel_get_config(FuPathStore *pstore, GError **error)
 	if (config_fngz != NULL && g_file_test(config_fngz, G_FILE_TEST_EXISTS)) {
 		g_autoptr(GBytes) payload = NULL;
 		g_autoptr(GConverter) conv = NULL;
-		g_autoptr(GFile) file = g_file_new_for_path(config_fngz);
 		g_autoptr(FuInputStream) istream1 = NULL;
 		g_autoptr(FuInputStream) istream2 = NULL;
 
-		istream1 = FU_INPUT_STREAM(g_file_read(file, NULL, error));
+		istream1 = fu_input_stream_from_path(config_fngz, error);
 		if (istream1 == NULL)
 			return NULL;
 		conv = G_CONVERTER(g_zlib_decompressor_new(G_ZLIB_COMPRESSOR_FORMAT_GZIP));

--- a/libfwupdplugin/fu-linear-firmware.c
+++ b/libfwupdplugin/fu-linear-firmware.c
@@ -87,7 +87,7 @@ fu_linear_firmware_build(FuFirmware *firmware, XbNode *n, GError **error)
 
 static gboolean
 fu_linear_firmware_parse(FuFirmware *firmware,
-			 GInputStream *stream,
+			 FuInputStream *stream,
 			 FuFirmwareParseFlags flags,
 			 GError **error)
 {
@@ -100,7 +100,7 @@ fu_linear_firmware_parse(FuFirmware *firmware,
 		return FALSE;
 	while (offset < streamsz) {
 		g_autoptr(FuFirmware) img = g_object_new(priv->image_gtype, NULL);
-		g_autoptr(GInputStream) stream_tmp = NULL;
+		g_autoptr(FuInputStream) stream_tmp = NULL;
 
 		stream_tmp = fu_partial_input_stream_new(stream, offset, streamsz - offset, error);
 		if (stream_tmp == NULL) {

--- a/libfwupdplugin/fu-linux-efivars.c
+++ b/libfwupdplugin/fu-linux-efivars.c
@@ -25,6 +25,7 @@
 #include "fwupd-error.h"
 
 #include "fu-efivars-private.h"
+#include "fu-file-input-stream.h"
 #include "fu-input-stream.h"
 #include "fu-linux-efivars.h"
 #include "fu-path.h"
@@ -254,7 +255,6 @@ fu_linux_efivars_get_data(FuEfivars *efivars,
 	FuEfiVariableAttrs attr_tmp;
 	guint64 sz;
 	g_autofree gchar *fn = NULL;
-	g_autoptr(GFile) file = NULL;
 	g_autoptr(GFileInfo) info = NULL;
 	g_autoptr(FuInputStream) istr = NULL;
 
@@ -262,16 +262,15 @@ fu_linux_efivars_get_data(FuEfivars *efivars,
 	fn = fu_linux_efivars_get_filename(efivars, guid, name, error);
 	if (fn == NULL)
 		return FALSE;
-	file = g_file_new_for_path(fn);
-	istr = FU_INPUT_STREAM(g_file_read(file, NULL, error));
+	istr = fu_input_stream_from_path(fn, error);
 	if (istr == NULL) {
 		fwupd_error_convert(error);
 		return FALSE;
 	}
-	info = g_file_input_stream_query_info(G_FILE_INPUT_STREAM(istr),
-					      G_FILE_ATTRIBUTE_STANDARD_SIZE,
-					      NULL,
-					      error);
+	info = fu_file_input_stream_query_info(FU_FILE_INPUT_STREAM(istr),
+					       G_FILE_ATTRIBUTE_STANDARD_SIZE,
+					       NULL,
+					       error);
 	if (info == NULL) {
 		g_prefix_error_literal(error, "failed to get stream info: ");
 		fwupd_error_convert(error);

--- a/libfwupdplugin/fu-linux-efivars.c
+++ b/libfwupdplugin/fu-linux-efivars.c
@@ -290,7 +290,8 @@ fu_linux_efivars_get_data(FuEfivars *efivars,
 	}
 
 	/* read out the attributes */
-	attr_sz = g_input_stream_read(istr, &attr_tmp, sizeof(attr_tmp), NULL, error);
+	attr_sz =
+	    g_input_stream_read(G_INPUT_STREAM(istr), &attr_tmp, sizeof(attr_tmp), NULL, error);
 	if (attr_sz == -1) {
 		g_prefix_error_literal(error, "failed to read attr: ");
 		fwupd_error_convert(error);
@@ -312,7 +313,12 @@ fu_linux_efivars_get_data(FuEfivars *efivars,
 		*data_sz = data_sz_tmp;
 	if (data != NULL) {
 		g_autofree guint8 *data_tmp = g_malloc0(data_sz_tmp);
-		if (!g_input_stream_read_all(istr, data_tmp, data_sz_tmp, NULL, NULL, error)) {
+		if (!g_input_stream_read_all(G_INPUT_STREAM(istr),
+					     data_tmp,
+					     data_sz_tmp,
+					     NULL,
+					     NULL,
+					     error)) {
 			g_prefix_error_literal(error, "failed to read data: ");
 			return FALSE;
 		}

--- a/libfwupdplugin/fu-linux-efivars.c
+++ b/libfwupdplugin/fu-linux-efivars.c
@@ -25,6 +25,7 @@
 #include "fwupd-error.h"
 
 #include "fu-efivars-private.h"
+#include "fu-input-stream.h"
 #include "fu-linux-efivars.h"
 #include "fu-path.h"
 
@@ -255,14 +256,14 @@ fu_linux_efivars_get_data(FuEfivars *efivars,
 	g_autofree gchar *fn = NULL;
 	g_autoptr(GFile) file = NULL;
 	g_autoptr(GFileInfo) info = NULL;
-	g_autoptr(GInputStream) istr = NULL;
+	g_autoptr(FuInputStream) istr = NULL;
 
 	/* open file as stream */
 	fn = fu_linux_efivars_get_filename(efivars, guid, name, error);
 	if (fn == NULL)
 		return FALSE;
 	file = g_file_new_for_path(fn);
-	istr = G_INPUT_STREAM(g_file_read(file, NULL, error));
+	istr = FU_INPUT_STREAM(g_file_read(file, NULL, error));
 	if (istr == NULL) {
 		fwupd_error_convert(error);
 		return FALSE;

--- a/libfwupdplugin/fu-memory-input-stream.c
+++ b/libfwupdplugin/fu-memory-input-stream.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#define G_LOG_DOMAIN "FuMemoryInputStream"
+
+#include "config.h"
+
+#include "fu-memory-input-stream.h"
+
+/**
+ * fu_memory_input_stream_new:
+ *
+ * Creates a new empty memory-backed input stream.
+ *
+ * Returns: (transfer full): a #FuInputStream
+ *
+ * Since: 2.1.7
+ **/
+FuInputStream *
+fu_memory_input_stream_new(void)
+{
+	return g_memory_input_stream_new(); /* nocheck:blocked */
+}
+
+/**
+ * fu_memory_input_stream_new_from_bytes:
+ * @bytes: a #GBytes
+ *
+ * Creates a new memory-backed input stream from @bytes.
+ *
+ * Returns: (transfer full): a #FuInputStream
+ *
+ * Since: 2.1.7
+ **/
+FuInputStream *
+fu_memory_input_stream_new_from_bytes(GBytes *bytes)
+{
+	g_return_val_if_fail(bytes != NULL, NULL);
+	return g_memory_input_stream_new_from_bytes(bytes); /* nocheck:blocked */
+}
+
+/**
+ * fu_memory_input_stream_new_from_data:
+ * @data: (array length=len) (element-type guint8): input data
+ * @len: length of the data, or -1 if @data is a nul-terminated string
+ * @destroy: (nullable): function that is called to free @data, or %NULL
+ *
+ * Creates a new memory-backed input stream from @data.
+ *
+ * Returns: (transfer full): a #FuInputStream
+ *
+ * Since: 2.1.7
+ **/
+FuInputStream *
+fu_memory_input_stream_new_from_data(const void *data, gssize len, GDestroyNotify destroy)
+{
+	g_return_val_if_fail(data != NULL, NULL);
+	return g_memory_input_stream_new_from_data(data, len, destroy); /* nocheck:blocked */
+}

--- a/libfwupdplugin/fu-memory-input-stream.h
+++ b/libfwupdplugin/fu-memory-input-stream.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include "fu-input-stream.h"
+
+typedef GMemoryInputStream FuMemoryInputStream;		  /* nocheck:blocked */
+typedef GMemoryInputStreamClass FuMemoryInputStreamClass; /* nocheck:blocked */
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuMemoryInputStream, g_object_unref)     /* nocheck:blocked */
+#define FU_MEMORY_INPUT_STREAM(o)	G_MEMORY_INPUT_STREAM(o)       /* nocheck:blocked */
+#define FU_TYPE_MEMORY_INPUT_STREAM	G_TYPE_MEMORY_INPUT_STREAM     /* nocheck:blocked */
+#define FU_IS_MEMORY_INPUT_STREAM(o)	G_IS_MEMORY_INPUT_STREAM(o)    /* nocheck:blocked */
+#define FU_MEMORY_INPUT_STREAM_CLASS(o) G_MEMORY_INPUT_STREAM_CLASS(o) /* nocheck:blocked */
+
+FuInputStream *
+fu_memory_input_stream_new(void) G_GNUC_WARN_UNUSED_RESULT;
+FuInputStream *
+fu_memory_input_stream_new_from_bytes(GBytes *bytes) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1);
+FuInputStream *
+fu_memory_input_stream_new_from_data(const void *data,
+				     gssize len,
+				     GDestroyNotify destroy) G_GNUC_WARN_UNUSED_RESULT;

--- a/libfwupdplugin/fu-msgpack-item.c
+++ b/libfwupdplugin/fu-msgpack-item.c
@@ -19,7 +19,7 @@
 struct _FuMsgpackItem {
 	GObject parent_instance;
 	FuMsgpackItemKind kind;
-	GInputStream *stream;
+	FuInputStream *stream;
 	union {
 		gint64 i64;
 		gdouble f64;
@@ -272,7 +272,7 @@ fu_msgpack_item_new_binary(GByteArray *buf)
 
 /**
  * fu_msgpack_item_new_binary_stream:
- * @stream: (not nullable): a #GInputStream
+ * @stream: (not nullable): a #FuInputStream
  *
  * Creates a new msgpack item.
  *
@@ -281,10 +281,10 @@ fu_msgpack_item_new_binary(GByteArray *buf)
  * Since: 2.0.0
  **/
 FuMsgpackItem *
-fu_msgpack_item_new_binary_stream(GInputStream *stream)
+fu_msgpack_item_new_binary_stream(FuInputStream *stream)
 {
 	g_autoptr(FuMsgpackItem) self = g_object_new(FU_TYPE_MSGPACK_ITEM, NULL);
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), NULL);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), NULL);
 	self->kind = FU_MSGPACK_ITEM_KIND_BINARY;
 	self->stream = g_object_ref(stream);
 	return g_steal_pointer(&self);
@@ -481,7 +481,7 @@ fu_msgpack_item_append_binary_stream_chunk_cb(const guint8 *buf,
 }
 
 static gboolean
-fu_msgpack_item_append_binary_stream(GByteArray *buf, GInputStream *stream, GError **error)
+fu_msgpack_item_append_binary_stream(GByteArray *buf, FuInputStream *stream, GError **error)
 {
 	gsize streamsz = 0;
 	if (!fu_input_stream_size(stream, &streamsz, error))

--- a/libfwupdplugin/fu-msgpack-item.h
+++ b/libfwupdplugin/fu-msgpack-item.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "fu-input-stream.h"
 #include "fu-msgpack-struct.h"
 
 #define FU_TYPE_MSGPACK_ITEM (fu_msgpack_item_get_type())
@@ -23,7 +24,7 @@ fu_msgpack_item_new_float(gdouble value);
 FuMsgpackItem *
 fu_msgpack_item_new_binary(GByteArray *buf) G_GNUC_NON_NULL(1);
 FuMsgpackItem *
-fu_msgpack_item_new_binary_stream(GInputStream *stream) G_GNUC_NON_NULL(1);
+fu_msgpack_item_new_binary_stream(FuInputStream *stream) G_GNUC_NON_NULL(1);
 FuMsgpackItem *
 fu_msgpack_item_new_string(const gchar *str) G_GNUC_NON_NULL(1);
 FuMsgpackItem *

--- a/libfwupdplugin/fu-msgpack-test.c
+++ b/libfwupdplugin/fu-msgpack-test.c
@@ -81,7 +81,8 @@ fu_msgpack_binary_stream_func(void)
 	g_autoptr(GByteArray) buf = NULL;
 	g_autoptr(GBytes) blob = g_bytes_new(data, sizeof(data));
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = G_INPUT_STREAM(g_memory_input_stream_new_from_bytes(blob));
+	g_autoptr(FuInputStream) stream =
+	    FU_INPUT_STREAM(g_memory_input_stream_new_from_bytes(blob));
 	g_autoptr(GPtrArray) items = g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
 
 	g_ptr_array_add(items, fu_msgpack_item_new_binary_stream(stream));

--- a/libfwupdplugin/fu-msgpack-test.c
+++ b/libfwupdplugin/fu-msgpack-test.c
@@ -82,7 +82,7 @@ fu_msgpack_binary_stream_func(void)
 	g_autoptr(GBytes) blob = g_bytes_new(data, sizeof(data));
 	g_autoptr(GError) error = NULL;
 	g_autoptr(FuInputStream) stream =
-	    FU_INPUT_STREAM(g_memory_input_stream_new_from_bytes(blob));
+	    FU_INPUT_STREAM(fu_memory_input_stream_new_from_bytes(blob));
 	g_autoptr(GPtrArray) items = g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
 
 	g_ptr_array_add(items, fu_msgpack_item_new_binary_stream(stream));

--- a/libfwupdplugin/fu-oprom-device.c
+++ b/libfwupdplugin/fu-oprom-device.c
@@ -7,6 +7,7 @@
 #include "config.h"
 
 #include "fu-device-locker.h"
+#include "fu-input-stream.h"
 #include "fu-oprom-device.h"
 #include "fu-output-stream.h"
 
@@ -74,7 +75,7 @@ fu_oprom_device_dump_firmware(FuDevice *device, FuProgress *progress, GError **e
 	g_autoptr(GByteArray) buf = g_byte_array_new();
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(GFile) file = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* sanity check */
 	if (!fu_device_has_flag(device, FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE)) {
@@ -88,7 +89,7 @@ fu_oprom_device_dump_firmware(FuDevice *device, FuProgress *progress, GError **e
 	/* open file */
 	rom_fn = g_build_filename(fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(self)), "rom", NULL);
 	file = g_file_new_for_path(rom_fn);
-	stream = G_INPUT_STREAM(g_file_read(file, NULL, &error_local));
+	stream = FU_INPUT_STREAM(g_file_read(file, NULL, &error_local));
 	if (stream == NULL) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,

--- a/libfwupdplugin/fu-oprom-device.c
+++ b/libfwupdplugin/fu-oprom-device.c
@@ -74,7 +74,6 @@ fu_oprom_device_dump_firmware(FuDevice *device, FuProgress *progress, GError **e
 	g_autoptr(FuDeviceLocker) locker_enable = NULL;
 	g_autoptr(GByteArray) buf = g_byte_array_new();
 	g_autoptr(GError) error_local = NULL;
-	g_autoptr(GFile) file = NULL;
 	g_autoptr(FuInputStream) stream = NULL;
 
 	/* sanity check */
@@ -88,8 +87,7 @@ fu_oprom_device_dump_firmware(FuDevice *device, FuProgress *progress, GError **e
 
 	/* open file */
 	rom_fn = g_build_filename(fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(self)), "rom", NULL);
-	file = g_file_new_for_path(rom_fn);
-	stream = FU_INPUT_STREAM(g_file_read(file, NULL, &error_local));
+	stream = fu_input_stream_from_path(rom_fn, &error_local);
 	if (stream == NULL) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,

--- a/libfwupdplugin/fu-oprom-device.c
+++ b/libfwupdplugin/fu-oprom-device.c
@@ -110,7 +110,7 @@ fu_oprom_device_dump_firmware(FuDevice *device, FuProgress *progress, GError **e
 	while (TRUE) {
 		gssize sz;
 		guint8 tmp[32 * FU_KB] = {0x0};
-		sz = g_input_stream_read(stream, tmp, sizeof(tmp), NULL, error);
+		sz = g_input_stream_read(G_INPUT_STREAM(stream), tmp, sizeof(tmp), NULL, error);
 		if (sz == 0)
 			break;
 		g_debug("ROM returned 0x%04x bytes", (guint)sz);

--- a/libfwupdplugin/fu-oprom-firmware.c
+++ b/libfwupdplugin/fu-oprom-firmware.c
@@ -14,6 +14,7 @@
 #include "fu-byte-array.h"
 #include "fu-common.h"
 #include "fu-ifwi-cpd-firmware.h"
+#include "fu-input-stream.h"
 #include "fu-oprom-firmware.h"
 #include "fu-string.h"
 
@@ -105,14 +106,17 @@ fu_oprom_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBu
 }
 
 static gboolean
-fu_oprom_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize offset, GError **error)
+fu_oprom_firmware_validate(FuFirmware *firmware,
+			   FuInputStream *stream,
+			   gsize offset,
+			   GError **error)
 {
 	return fu_struct_oprom_validate_stream(stream, offset, error);
 }
 
 static gboolean
 fu_oprom_firmware_parse(FuFirmware *firmware,
-			GInputStream *stream,
+			FuInputStream *stream,
 			FuFirmwareParseFlags flags,
 			GError **error)
 {

--- a/libfwupdplugin/fu-partial-input-stream-test.c
+++ b/libfwupdplugin/fu-partial-input-stream-test.c
@@ -62,7 +62,7 @@ fu_partial_input_stream_simple_func(void)
 	guint8 buf[2] = {0x0};
 	g_autoptr(GBytes) blob = g_bytes_new_static("12345678", 8);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(FuInputStream) base_stream = g_memory_input_stream_new_from_bytes(blob);
+	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
 	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuInputStream) stream2 = NULL;
 
@@ -97,7 +97,7 @@ fu_partial_input_stream_closed_base_func(void)
 	g_autoptr(GBytes) blob = g_bytes_new_static("12345678", 8);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(FuInputStream) stream = NULL;
-	g_autoptr(FuInputStream) base_stream = g_memory_input_stream_new_from_bytes(blob);
+	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
 
 	stream = fu_partial_input_stream_new(base_stream, 2, 4, &error);
 	g_assert_no_error(error);
@@ -127,7 +127,7 @@ fu_partial_input_stream_func(void)
 	/*                                             \--/   */
 	g_autoptr(GBytes) blob2 = NULL;
 	g_autoptr(GFile) file = NULL;
-	g_autoptr(FuInputStream) base_stream = g_memory_input_stream_new_from_bytes(blob);
+	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
 	g_autoptr(FuInputStream) stream_complete = NULL;
 	g_autoptr(FuInputStream) stream_error = NULL;
 	g_autoptr(FuInputStream) stream_file = NULL;
@@ -178,7 +178,7 @@ fu_partial_input_stream_func(void)
 	g_assert_cmpint(rc, ==, 1);
 	g_assert_cmpint(buf[0], ==, 10);
 
-	/* check the behavior of GMemoryInputStream */
+	/* check the behavior of FuMemoryInputStream */
 	g_assert_no_error(error);
 	g_assert_nonnull(stream_file);
 	ret = g_seekable_seek(G_SEEKABLE(base_stream), 0x0, G_SEEK_SET, NULL, &error);

--- a/libfwupdplugin/fu-partial-input-stream-test.c
+++ b/libfwupdplugin/fu-partial-input-stream-test.c
@@ -16,8 +16,8 @@ fu_partial_input_stream_composite_func(void)
 	guint8 buf[4] = {0};
 	g_autoptr(GBytes) blob = g_bytes_new_static("12345678", 8);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) composite_stream = fu_composite_input_stream_new();
-	g_autoptr(GInputStream) partial_stream = NULL;
+	g_autoptr(FuInputStream) composite_stream = fu_composite_input_stream_new();
+	g_autoptr(FuInputStream) partial_stream = NULL;
 
 	ret = fu_composite_input_stream_add_bytes(FU_COMPOSITE_INPUT_STREAM(composite_stream),
 						  blob,
@@ -62,9 +62,9 @@ fu_partial_input_stream_simple_func(void)
 	guint8 buf[2] = {0x0};
 	g_autoptr(GBytes) blob = g_bytes_new_static("12345678", 8);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) base_stream = g_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(GInputStream) stream = NULL;
-	g_autoptr(GInputStream) stream2 = NULL;
+	g_autoptr(FuInputStream) base_stream = g_memory_input_stream_new_from_bytes(blob);
+	g_autoptr(FuInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream2 = NULL;
 
 	/* use G_MAXSIZE for "rest of the stream" */
 	stream = fu_partial_input_stream_new(base_stream, 4, G_MAXSIZE, &error);
@@ -96,8 +96,8 @@ fu_partial_input_stream_closed_base_func(void)
 	guint8 buf[2] = {0x0};
 	g_autoptr(GBytes) blob = g_bytes_new_static("12345678", 8);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
-	g_autoptr(GInputStream) base_stream = g_memory_input_stream_new_from_bytes(blob);
+	g_autoptr(FuInputStream) stream = NULL;
+	g_autoptr(FuInputStream) base_stream = g_memory_input_stream_new_from_bytes(blob);
 
 	stream = fu_partial_input_stream_new(base_stream, 2, 4, &error);
 	g_assert_no_error(error);
@@ -127,17 +127,17 @@ fu_partial_input_stream_func(void)
 	/*                                             \--/   */
 	g_autoptr(GBytes) blob2 = NULL;
 	g_autoptr(GFile) file = NULL;
-	g_autoptr(GInputStream) base_stream = g_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(GInputStream) stream_complete = NULL;
-	g_autoptr(GInputStream) stream_error = NULL;
-	g_autoptr(GInputStream) stream_file = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) base_stream = g_memory_input_stream_new_from_bytes(blob);
+	g_autoptr(FuInputStream) stream_complete = NULL;
+	g_autoptr(FuInputStream) stream_error = NULL;
+	g_autoptr(FuInputStream) stream_file = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* check the behavior of GFileInputStream */
 	fn = g_test_build_filename(G_TEST_DIST, "tests", "dfu.builder.xml", NULL);
 	g_assert_nonnull(fn);
 	file = g_file_new_for_path(fn);
-	stream_file = G_INPUT_STREAM(g_file_read(file, NULL, &error));
+	stream_file = FU_INPUT_STREAM(g_file_read(file, NULL, &error));
 	g_assert_no_error(error);
 	g_assert_nonnull(stream_file);
 	ret = g_seekable_seek(G_SEEKABLE(stream_file), 0x0, G_SEEK_SET, NULL, &error);

--- a/libfwupdplugin/fu-partial-input-stream-test.c
+++ b/libfwupdplugin/fu-partial-input-stream-test.c
@@ -38,7 +38,7 @@ fu_partial_input_stream_composite_func(void)
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(partial_stream)), ==, 0x0);
 
 	/* read the 34 */
-	rc = g_input_stream_read(partial_stream, buf, sizeof(buf), NULL, &error);
+	rc = g_input_stream_read(G_INPUT_STREAM(partial_stream), buf, sizeof(buf), NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 2);
 	g_assert_cmpint(buf[0], ==, '3');
@@ -47,7 +47,7 @@ fu_partial_input_stream_composite_func(void)
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(partial_stream)), ==, 0x2);
 
 	/* there is no more data to read */
-	rc = g_input_stream_read(partial_stream, buf, sizeof(buf), NULL, &error);
+	rc = g_input_stream_read(G_INPUT_STREAM(partial_stream), buf, sizeof(buf), NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(composite_stream)), ==, 0x4);
@@ -76,7 +76,7 @@ fu_partial_input_stream_simple_func(void)
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 0x2);
 
 	/* read from offset */
-	rc = g_input_stream_read(stream, buf, 2, NULL, &error);
+	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 2, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 2);
 	g_assert_cmpint(buf[0], ==, '7');
@@ -102,14 +102,14 @@ fu_partial_input_stream_closed_base_func(void)
 	stream = fu_partial_input_stream_new(base_stream, 2, 4, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(stream);
-	ret = g_input_stream_close(base_stream, NULL, &error);
+	ret = g_input_stream_close(G_INPUT_STREAM(base_stream), NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
 	ret = g_seekable_seek(G_SEEKABLE(stream), 0x0, G_SEEK_SET, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	rc = g_input_stream_read(stream, buf, sizeof(buf), NULL, &error);
+	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, sizeof(buf), NULL, &error);
 	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_CLOSED);
 	g_assert_cmpint(rc, ==, -1);
 }
@@ -148,7 +148,7 @@ fu_partial_input_stream_func(void)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream_file)), ==, 216);
-	rc = g_input_stream_read(stream_file, buf, 2, NULL, &error);
+	rc = g_input_stream_read(G_INPUT_STREAM(stream_file), buf, 2, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 	pos = g_seekable_tell(G_SEEKABLE(stream_file));
@@ -156,7 +156,7 @@ fu_partial_input_stream_func(void)
 	ret = g_seekable_seek(G_SEEKABLE(stream_file), pos, G_SEEK_SET, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	rc = g_input_stream_read(stream_file, buf, 2, NULL, &error);
+	rc = g_input_stream_read(G_INPUT_STREAM(stream_file), buf, 2, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream_file)), ==, 216);
@@ -166,14 +166,14 @@ fu_partial_input_stream_func(void)
 	g_assert_true(ret);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream_file)), ==, 10216);
 	/* reads all return zero */
-	rc = g_input_stream_read(stream_file, buf, 2, NULL, &error);
+	rc = g_input_stream_read(G_INPUT_STREAM(stream_file), buf, 2, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 	/* END offset is negative */
 	ret = g_seekable_seek(G_SEEKABLE(stream_file), -0x1, G_SEEK_END, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	rc = g_input_stream_read(stream_file, buf, 1, NULL, &error);
+	rc = g_input_stream_read(G_INPUT_STREAM(stream_file), buf, 1, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 1);
 	g_assert_cmpint(buf[0], ==, 10);
@@ -189,7 +189,7 @@ fu_partial_input_stream_func(void)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(base_stream)), ==, 8);
-	rc = g_input_stream_read(base_stream, buf, 2, NULL, &error);
+	rc = g_input_stream_read(G_INPUT_STREAM(base_stream), buf, 2, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 	pos = g_seekable_tell(G_SEEKABLE(base_stream));
@@ -197,7 +197,7 @@ fu_partial_input_stream_func(void)
 	ret = g_seekable_seek(G_SEEKABLE(base_stream), pos, G_SEEK_SET, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	rc = g_input_stream_read(base_stream, buf, 2, NULL, &error);
+	rc = g_input_stream_read(G_INPUT_STREAM(base_stream), buf, 2, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(base_stream)), ==, 8);
@@ -211,7 +211,7 @@ fu_partial_input_stream_func(void)
 	ret = g_seekable_seek(G_SEEKABLE(base_stream), -1, G_SEEK_END, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	rc = g_input_stream_read(base_stream, buf, 1, NULL, &error);
+	rc = g_input_stream_read(G_INPUT_STREAM(base_stream), buf, 1, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 1);
 	g_assert_cmpint(buf[0], ==, '8');
@@ -226,13 +226,13 @@ fu_partial_input_stream_func(void)
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 0x2);
 
 	/* read from start */
-	rc = g_input_stream_read(stream, buf, 2, NULL, &error);
+	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 2, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 2);
 	g_assert_cmpint(buf[0], ==, '5');
 	g_assert_cmpint(buf[1], ==, '6');
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 0x4);
-	rc = g_input_stream_read(stream, buf, 2, NULL, &error);
+	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 2, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 
@@ -247,7 +247,7 @@ fu_partial_input_stream_func(void)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(base_stream)), ==, 0x8);
-	rc = g_input_stream_read(base_stream, buf, 1, NULL, &error);
+	rc = g_input_stream_read(G_INPUT_STREAM(base_stream), buf, 1, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(base_stream)), ==, 0x8);
@@ -257,7 +257,7 @@ fu_partial_input_stream_func(void)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 0x4);
-	rc = g_input_stream_read(stream, buf, sizeof(buf), NULL, &error);
+	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, sizeof(buf), NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 
@@ -266,7 +266,7 @@ fu_partial_input_stream_func(void)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 0x3);
-	rc = g_input_stream_read(stream, buf, sizeof(buf), NULL, &error);
+	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, sizeof(buf), NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 1);
 	g_assert_cmpint(buf[0], ==, '6');
@@ -275,7 +275,7 @@ fu_partial_input_stream_func(void)
 	ret = g_seekable_seek(G_SEEKABLE(stream), 0x2, G_SEEK_SET, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	rc = g_input_stream_read(stream, buf, sizeof(buf), NULL, &error);
+	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, sizeof(buf), NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 2);
 
@@ -292,7 +292,7 @@ fu_partial_input_stream_func(void)
 	ret = g_seekable_seek(G_SEEKABLE(stream_complete), 0x8, G_SEEK_SET, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	rc = g_input_stream_read(stream_complete, buf, sizeof(buf), NULL, &error);
+	rc = g_input_stream_read(G_INPUT_STREAM(stream_complete), buf, sizeof(buf), NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 

--- a/libfwupdplugin/fu-partial-input-stream-test.c
+++ b/libfwupdplugin/fu-partial-input-stream-test.c
@@ -126,18 +126,16 @@ fu_partial_input_stream_func(void)
 	g_autoptr(GBytes) blob = g_bytes_new_static("12345678", 8);
 	/*                                             \--/   */
 	g_autoptr(GBytes) blob2 = NULL;
-	g_autoptr(GFile) file = NULL;
 	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
 	g_autoptr(FuInputStream) stream_complete = NULL;
 	g_autoptr(FuInputStream) stream_error = NULL;
 	g_autoptr(FuInputStream) stream_file = NULL;
 	g_autoptr(FuInputStream) stream = NULL;
 
-	/* check the behavior of GFileInputStream */
+	/* check the behavior of FuFileInputStream */
 	fn = g_test_build_filename(G_TEST_DIST, "tests", "dfu.builder.xml", NULL);
 	g_assert_nonnull(fn);
-	file = g_file_new_for_path(fn);
-	stream_file = FU_INPUT_STREAM(g_file_read(file, NULL, &error));
+	stream_file = fu_input_stream_from_path(fn, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(stream_file);
 	ret = g_seekable_seek(G_SEEKABLE(stream_file), 0x0, G_SEEK_SET, NULL, &error);

--- a/libfwupdplugin/fu-partial-input-stream.c
+++ b/libfwupdplugin/fu-partial-input-stream.c
@@ -32,8 +32,8 @@
  */
 
 struct _FuPartialInputStream {
-	GInputStream parent_instance;
-	GInputStream *base_stream;
+	FuInputStream parent_instance;
+	FuInputStream *base_stream;
 	gsize offset;
 	gsize size;
 };
@@ -45,7 +45,7 @@ fu_partial_input_stream_codec_iface_init(FwupdCodecInterface *iface);
 
 G_DEFINE_TYPE_WITH_CODE(FuPartialInputStream,
 			fu_partial_input_stream,
-			G_TYPE_INPUT_STREAM,
+			FU_TYPE_INPUT_STREAM,
 			G_IMPLEMENT_INTERFACE(G_TYPE_SEEKABLE,
 					      fu_partial_input_stream_seekable_iface_init)
 			    G_IMPLEMENT_INTERFACE(FWUPD_TYPE_CODEC,
@@ -144,7 +144,7 @@ fu_partial_input_stream_seekable_iface_init(GSeekableIface *iface)
 
 /**
  * fu_partial_input_stream_new:
- * @stream: a base #GInputStream
+ * @stream: a base #FuInputStream
  * @offset: offset into @stream
  * @size: size of @stream in bytes, or %G_MAXSIZE for the "rest" of the stream
  * @error: (nullable): optional return location for an error
@@ -155,13 +155,13 @@ fu_partial_input_stream_seekable_iface_init(GSeekableIface *iface)
  *
  * Since: 2.0.0
  **/
-GInputStream *
-fu_partial_input_stream_new(GInputStream *stream, gsize offset, gsize size, GError **error)
+FuInputStream *
+fu_partial_input_stream_new(FuInputStream *stream, gsize offset, gsize size, GError **error)
 {
 	gsize base_sz = 0;
 	g_autoptr(FuPartialInputStream) self = g_object_new(FU_TYPE_PARTIAL_INPUT_STREAM, NULL);
 
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), NULL);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
 	self->base_stream = g_object_ref(stream);
@@ -200,7 +200,7 @@ fu_partial_input_stream_new(GInputStream *stream, gsize offset, gsize size, GErr
 	}
 
 	/* success */
-	return G_INPUT_STREAM(g_steal_pointer(&self));
+	return FU_INPUT_STREAM(g_steal_pointer(&self));
 }
 
 /**

--- a/libfwupdplugin/fu-partial-input-stream.c
+++ b/libfwupdplugin/fu-partial-input-stream.c
@@ -255,7 +255,11 @@ fu_partial_input_stream_read(GInputStream *stream,
 		return -1;
 	}
 	count = MIN(count, self->size - g_seekable_tell(G_SEEKABLE(stream)));
-	return g_input_stream_read(self->base_stream, buffer, count, cancellable, error);
+	return g_input_stream_read(G_INPUT_STREAM(self->base_stream),
+				   buffer,
+				   count,
+				   cancellable,
+				   error);
 }
 
 static void

--- a/libfwupdplugin/fu-partial-input-stream.h
+++ b/libfwupdplugin/fu-partial-input-stream.h
@@ -8,14 +8,16 @@
 
 #include <fwupd.h>
 
+#include "fu-input-stream.h"
+
 #define FU_TYPE_PARTIAL_INPUT_STREAM (fu_partial_input_stream_get_type())
 
 G_DECLARE_FINAL_TYPE(FuPartialInputStream,
 		     fu_partial_input_stream,
 		     FU,
 		     PARTIAL_INPUT_STREAM,
-		     GInputStream)
+		     FuInputStream)
 
-GInputStream *
-fu_partial_input_stream_new(GInputStream *stream, gsize offset, gsize size, GError **error)
+FuInputStream *
+fu_partial_input_stream_new(FuInputStream *stream, gsize offset, gsize size, GError **error)
     G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-pefile-firmware.c
+++ b/libfwupdplugin/fu-pefile-firmware.c
@@ -55,7 +55,7 @@ fu_pefile_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbB
 
 static gboolean
 fu_pefile_firmware_validate(FuFirmware *firmware,
-			    GInputStream *stream,
+			    FuInputStream *stream,
 			    gsize offset,
 			    GError **error)
 {
@@ -99,7 +99,7 @@ fu_pefile_firmware_region_sort_cb(gconstpointer a, gconstpointer b)
 
 static gboolean
 fu_pefile_firmware_parse_section(FuPefileFirmware *self,
-				 GInputStream *stream,
+				 FuInputStream *stream,
 				 guint idx,
 				 gsize hdr_offset,
 				 gsize strtab_offset,
@@ -186,7 +186,7 @@ fu_pefile_firmware_parse_section(FuPefileFirmware *self,
 	if (fu_struct_pe_coff_section_get_virtual_size(st) > 0) {
 		guint32 sect_offset = fu_struct_pe_coff_section_get_pointer_to_raw_data(st);
 		guint32 sect_size = fu_struct_pe_coff_section_get_virtual_size(st);
-		g_autoptr(GInputStream) img_stream = NULL;
+		g_autoptr(FuInputStream) img_stream = NULL;
 
 		/* use the raw data size if the section is compressed */
 		if (fu_struct_pe_coff_section_get_virtual_size(st) >
@@ -221,7 +221,7 @@ fu_pefile_firmware_parse_section(FuPefileFirmware *self,
 
 static gboolean
 fu_pefile_firmware_parse(FuFirmware *firmware,
-			 GInputStream *stream,
+			 FuInputStream *stream,
 			 FuFirmwareParseFlags flags,
 			 GError **error)
 {
@@ -240,7 +240,7 @@ fu_pefile_firmware_parse(FuFirmware *firmware,
 	g_autoptr(FuStructPeCoffFileHeader) st_coff = NULL;
 	g_autoptr(FuStructPeDosHeader) st_doshdr = NULL;
 	g_autoptr(GPtrArray) regions = NULL;
-	g_autoptr(GInputStream) composite_stream = fu_composite_input_stream_new();
+	g_autoptr(FuInputStream) composite_stream = fu_composite_input_stream_new();
 
 	/* get size */
 	if (!fu_input_stream_size(stream, &streamsz, error))
@@ -436,7 +436,7 @@ fu_pefile_firmware_parse(FuFirmware *firmware,
 	/* calculate the checksum we would find in the dbx */
 	for (guint i = 0; i < regions->len; i++) {
 		FuPefileFirmwareRegion *r = g_ptr_array_index(regions, i);
-		g_autoptr(GInputStream) partial_stream = NULL;
+		g_autoptr(FuInputStream) partial_stream = NULL;
 
 		if (r->size == 0)
 			continue;

--- a/libfwupdplugin/fu-pkcs7.c
+++ b/libfwupdplugin/fu-pkcs7.c
@@ -63,7 +63,7 @@ fu_pkcs7_parse_x509_certificate(FuPkcs7 *self, gnutls_datum_t *data, GError **er
 
 static gboolean
 fu_pkcs7_parse(FuFirmware *firmware,
-	       GInputStream *stream,
+	       FuInputStream *stream,
 	       FuFirmwareParseFlags flags,
 	       GError **error)
 {

--- a/libfwupdplugin/fu-quirks.c
+++ b/libfwupdplugin/fu-quirks.c
@@ -278,7 +278,7 @@ fu_quirks_convert_quirk_to_xml_cb(XbBuilderSource *source,
 	bytes_xml = fu_quirks_convert_keyfile_to_xml(self, bytes, error);
 	if (bytes_xml == NULL)
 		return NULL;
-	return g_memory_input_stream_new_from_bytes(bytes_xml);
+	return G_INPUT_STREAM(fu_memory_input_stream_new_from_bytes(bytes_xml));
 }
 
 static gint

--- a/libfwupdplugin/fu-quirks.c
+++ b/libfwupdplugin/fu-quirks.c
@@ -21,6 +21,7 @@
 
 #include "fu-context-private.h"
 #include "fu-input-stream.h"
+#include "fu-memory-input-stream.h"
 #include "fu-path-store.h"
 #include "fu-path.h"
 #include "fu-quirks.h"

--- a/libfwupdplugin/fu-quirks.c
+++ b/libfwupdplugin/fu-quirks.c
@@ -20,6 +20,7 @@
 #include "fwupd-error.h"
 
 #include "fu-context-private.h"
+#include "fu-input-stream.h"
 #include "fu-path-store.h"
 #include "fu-path.h"
 #include "fu-quirks.h"
@@ -953,7 +954,7 @@ fu_quirks_db_load(FuQuirks *self, GError **error)
 		g_autofree gchar *fn = NULL;
 		g_autoptr(FuQuirksDbHelper) helper = g_new0(FuQuirksDbHelper, 1);
 		g_autoptr(GFile) file = NULL;
-		g_autoptr(GInputStream) stream = NULL;
+		g_autoptr(FuInputStream) stream = NULL;
 
 		fn = fu_context_build_filename(self->ctx,
 					       NULL,
@@ -970,7 +971,7 @@ fu_quirks_db_load(FuQuirks *self, GError **error)
 			continue;
 		}
 		g_debug("indexing vendor IDs from %s", fn);
-		stream = G_INPUT_STREAM(g_file_read(file, NULL, error));
+		stream = FU_INPUT_STREAM(g_file_read(file, NULL, error));
 		if (stream == NULL)
 			return FALSE;
 		helper->self = self;

--- a/libfwupdplugin/fu-quirks.c
+++ b/libfwupdplugin/fu-quirks.c
@@ -972,7 +972,7 @@ fu_quirks_db_load(FuQuirks *self, GError **error)
 			continue;
 		}
 		g_debug("indexing vendor IDs from %s", fn);
-		stream = FU_INPUT_STREAM(g_file_read(file, NULL, error));
+		stream = fu_input_stream_from_path(fn, error);
 		if (stream == NULL)
 			return FALSE;
 		helper->self = self;

--- a/libfwupdplugin/fu-rustgen-struct.c.in
+++ b/libfwupdplugin/fu-rustgen-struct.c.in
@@ -519,10 +519,10 @@ void
  * {{obj.c_method('ValidateStream')}}: (skip):
  **/
 {{export.value}}gboolean
-{{obj.c_method('ValidateStream')}}(GInputStream *stream, gsize offset, GError **error)
+{{obj.c_method('ValidateStream')}}(FuInputStream *stream, gsize offset, GError **error)
 {
     g_autoptr({{obj.name}}) st = {{obj.c_method('NewInternal')}}();
-    g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
+    g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
     st->buf = fu_input_stream_read_byte_array(stream, offset, {{obj.size}}, NULL, error);
     if (st->buf == NULL) {
@@ -621,7 +621,7 @@ void
  * {{obj.c_method('ParseStream')}}: (skip):
  **/
 {{export.value}}{{obj.name}} *
-{{obj.c_method('ParseStream')}}(GInputStream *stream, gsize offset, GError **error)
+{{obj.c_method('ParseStream')}}(FuInputStream *stream, gsize offset, GError **error)
 {
     g_autoptr({{obj.name}}) st = {{obj.c_method('NewInternal')}}();
     st->buf = fu_input_stream_read_byte_array(stream, offset, {{obj.size}}, NULL, error);

--- a/libfwupdplugin/fu-rustgen-struct.h.in
+++ b/libfwupdplugin/fu-rustgen-struct.h.in
@@ -20,7 +20,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC({{obj.name}}, {{obj.c_method('Unref')}})
 {{obj.name}} *{{obj.c_method('ParseBytes')}}(GBytes *blob, gsize offset, GError **error) G_GNUC_NON_NULL(1) G_GNUC_WARN_UNUSED_RESULT;
 {%- endif %}
 {%- if obj.export('ParseStream') == Export.PUBLIC %}
-{{obj.name}} *{{obj.c_method('ParseStream')}}(GInputStream *stream, gsize offset, GError **error) G_GNUC_NON_NULL(1) G_GNUC_WARN_UNUSED_RESULT;
+{{obj.name}} *{{obj.c_method('ParseStream')}}(FuInputStream *stream, gsize offset, GError **error) G_GNUC_NON_NULL(1) G_GNUC_WARN_UNUSED_RESULT;
 {%- endif %}
 {%- if obj.export('Validate') == Export.PUBLIC %}
 gboolean {{obj.c_method('Validate')}}(const guint8 *buf, gsize bufsz, gsize offset, GError **error) G_GNUC_NON_NULL(1) G_GNUC_WARN_UNUSED_RESULT;
@@ -29,7 +29,7 @@ gboolean {{obj.c_method('Validate')}}(const guint8 *buf, gsize bufsz, gsize offs
 gboolean {{obj.c_method('ValidateBytes')}}(GBytes *blob, gsize offset, GError **error) G_GNUC_NON_NULL(1) G_GNUC_WARN_UNUSED_RESULT;
 {%- endif %}
 {%- if obj.export('ValidateStream') == Export.PUBLIC %}
-gboolean {{obj.c_method('ValidateStream')}}(GInputStream *stream, gsize offset, GError **error) G_GNUC_NON_NULL(1) G_GNUC_WARN_UNUSED_RESULT;
+gboolean {{obj.c_method('ValidateStream')}}(FuInputStream *stream, gsize offset, GError **error) G_GNUC_NON_NULL(1) G_GNUC_WARN_UNUSED_RESULT;
 {%- endif %}
 {%- if obj.export('ValidateInternal') == Export.PUBLIC %}
 gboolean {{obj.c_method('ValidateInternal')}}({{obj.name}} *st, GError **error) G_GNUC_NON_NULL(1) G_GNUC_WARN_UNUSED_RESULT;

--- a/libfwupdplugin/fu-sbatlevel-section.c
+++ b/libfwupdplugin/fu-sbatlevel-section.c
@@ -20,7 +20,7 @@ G_DEFINE_TYPE(FuSbatlevelSection, fu_sbatlevel_section, FU_TYPE_FIRMWARE);
 
 static gboolean
 fu_sbatlevel_section_add_entry(FuSbatlevelSection *self,
-			       GInputStream *stream,
+			       FuInputStream *stream,
 			       gsize offset,
 			       const gchar *entry_name,
 			       guint64 entry_idx,
@@ -29,7 +29,7 @@ fu_sbatlevel_section_add_entry(FuSbatlevelSection *self,
 {
 	gsize streamsz = 0;
 	g_autoptr(FuFirmware) entry_fw = NULL;
-	g_autoptr(GInputStream) partial_stream = NULL;
+	g_autoptr(FuInputStream) partial_stream = NULL;
 
 	/* stop at the null terminator */
 	if (!fu_input_stream_size(stream, &streamsz, error))
@@ -80,7 +80,7 @@ fu_sbatlevel_section_add_entry(FuSbatlevelSection *self,
 
 static gboolean
 fu_sbatlevel_section_parse(FuFirmware *firmware,
-			   GInputStream *stream,
+			   FuInputStream *stream,
 			   FuFirmwareParseFlags flags,
 			   GError **error)
 {

--- a/libfwupdplugin/fu-smbios.c
+++ b/libfwupdplugin/fu-smbios.c
@@ -357,7 +357,7 @@ fu_smbios_setup_from_path(FuSmbios *self, const gchar *path, GError **error)
 
 static gboolean
 fu_smbios_parse(FuFirmware *firmware,
-		GInputStream *stream,
+		FuInputStream *stream,
 		FuFirmwareParseFlags flags,
 		GError **error)
 {

--- a/libfwupdplugin/fu-srec-firmware-test.c
+++ b/libfwupdplugin/fu-srec-firmware-test.c
@@ -43,7 +43,7 @@ fu_srec_firmware_tokenization_func(void)
 	data_srec = g_bytes_new_static(buf, strlen(buf));
 	g_assert_no_error(error);
 	g_assert_nonnull(data_srec);
-	stream = g_memory_input_stream_new_from_bytes(data_srec);
+	stream = fu_memory_input_stream_new_from_bytes(data_srec);
 	ret = fu_firmware_tokenize(firmware, stream, FU_FIRMWARE_PARSE_FLAG_NONE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);

--- a/libfwupdplugin/fu-srec-firmware-test.c
+++ b/libfwupdplugin/fu-srec-firmware-test.c
@@ -34,7 +34,7 @@ fu_srec_firmware_tokenization_func(void)
 	gboolean ret;
 	g_autoptr(FuFirmware) firmware = fu_srec_firmware_new();
 	g_autoptr(GBytes) data_srec = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(GError) error = NULL;
 	const gchar *buf = "S3060000001400E5\r\n"
 			   "S31000000002281102000000007F0304002C\r\n"

--- a/libfwupdplugin/fu-srec-firmware.c
+++ b/libfwupdplugin/fu-srec-firmware.c
@@ -14,6 +14,7 @@
 #include "fu-chunk-array.h"
 #include "fu-common.h"
 #include "fu-firmware-common.h"
+#include "fu-input-stream.h"
 #include "fu-srec-firmware.h"
 #include "fu-string.h"
 #include "fu-sum.h"
@@ -373,7 +374,7 @@ fu_srec_firmware_tokenize_cb(GString *token, guint token_idx, gpointer user_data
 
 static gboolean
 fu_srec_firmware_tokenize(FuFirmware *firmware,
-			  GInputStream *stream,
+			  FuInputStream *stream,
 			  FuFirmwareParseFlags flags,
 			  GError **error)
 {
@@ -397,7 +398,7 @@ fu_srec_firmware_tokenize(FuFirmware *firmware,
 
 static gboolean
 fu_srec_firmware_parse(FuFirmware *firmware,
-		       GInputStream *stream,
+		       FuInputStream *stream,
 		       FuFirmwareParseFlags flags,
 		       GError **error)
 {

--- a/libfwupdplugin/fu-string-test.c
+++ b/libfwupdplugin/fu-string-test.c
@@ -222,19 +222,19 @@ fu_strsplit_stream_func(void)
 	/* check includes NUL */
 	g_assert_cmpint(sizeof(str1), ==, 14);
 
-	stream1 = FU_INPUT_STREAM(g_memory_input_stream_new_from_data(str1, strlen(str1), NULL));
+	stream1 = FU_INPUT_STREAM(fu_memory_input_stream_new_from_data(str1, strlen(str1), NULL));
 	ret = fu_strsplit_stream(stream1, 0x0, " ", fu_strsplit_stream_cb, &cnt1, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_assert_cmpint(cnt1, ==, 2);
 
-	stream2 = FU_INPUT_STREAM(g_memory_input_stream_new_from_data(str2, strlen(str2), NULL));
+	stream2 = FU_INPUT_STREAM(fu_memory_input_stream_new_from_data(str2, strlen(str2), NULL));
 	ret = fu_strsplit_stream(stream2, 0x0, "123", fu_strsplit_stream_cb, &cnt2, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_assert_cmpint(cnt2, ==, 6);
 
-	stream3 = FU_INPUT_STREAM(g_memory_input_stream_new_from_data(str3, sizeof(str3), NULL));
+	stream3 = FU_INPUT_STREAM(fu_memory_input_stream_new_from_data(str3, sizeof(str3), NULL));
 	ret = fu_strsplit_stream(stream3, 0x0, "|", fu_strsplit_stream_cb, &cnt3, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);

--- a/libfwupdplugin/fu-string-test.c
+++ b/libfwupdplugin/fu-string-test.c
@@ -214,27 +214,27 @@ fu_strsplit_stream_func(void)
 	const gchar str1[] = "simple string";
 	const gchar str2[] = "123delimited123start123and123end123";
 	const gchar str3[] = "this|has|trailing|nuls\0\0\0\0";
-	g_autoptr(GInputStream) stream1 = NULL;
-	g_autoptr(GInputStream) stream2 = NULL;
-	g_autoptr(GInputStream) stream3 = NULL;
+	g_autoptr(FuInputStream) stream1 = NULL;
+	g_autoptr(FuInputStream) stream2 = NULL;
+	g_autoptr(FuInputStream) stream3 = NULL;
 	g_autoptr(GError) error = NULL;
 
 	/* check includes NUL */
 	g_assert_cmpint(sizeof(str1), ==, 14);
 
-	stream1 = G_INPUT_STREAM(g_memory_input_stream_new_from_data(str1, strlen(str1), NULL));
+	stream1 = FU_INPUT_STREAM(g_memory_input_stream_new_from_data(str1, strlen(str1), NULL));
 	ret = fu_strsplit_stream(stream1, 0x0, " ", fu_strsplit_stream_cb, &cnt1, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_assert_cmpint(cnt1, ==, 2);
 
-	stream2 = G_INPUT_STREAM(g_memory_input_stream_new_from_data(str2, strlen(str2), NULL));
+	stream2 = FU_INPUT_STREAM(g_memory_input_stream_new_from_data(str2, strlen(str2), NULL));
 	ret = fu_strsplit_stream(stream2, 0x0, "123", fu_strsplit_stream_cb, &cnt2, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_assert_cmpint(cnt2, ==, 6);
 
-	stream3 = G_INPUT_STREAM(g_memory_input_stream_new_from_data(str3, sizeof(str3), NULL));
+	stream3 = FU_INPUT_STREAM(g_memory_input_stream_new_from_data(str3, sizeof(str3), NULL));
 	ret = fu_strsplit_stream(stream3, 0x0, "|", fu_strsplit_stream_cb, &cnt3, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);

--- a/libfwupdplugin/fu-string.c
+++ b/libfwupdplugin/fu-string.c
@@ -10,6 +10,7 @@
 
 #include "fu-byte-array.h"
 #include "fu-chunk-array.h"
+#include "fu-input-stream.h"
 #include "fu-mem.h"
 #include "fu-partial-input-stream.h"
 #include "fu-string.h"
@@ -486,7 +487,7 @@ fu_strsplit_buffer_drain(GByteArray *buf, FuStrsplitHelper *helper, GError **err
 
 /**
  * fu_strsplit_stream:
- * @stream: a #GInputStream to split
+ * @stream: a #FuInputStream to split
  * @offset: offset into @stream
  * @delimiter: a string which specifies the places at which to split the string
  * @callback: (scope call) (closure user_data): a #FuStrsplitFunc.
@@ -504,7 +505,7 @@ fu_strsplit_buffer_drain(GByteArray *buf, FuStrsplitHelper *helper, GError **err
  * Since: 2.0.0
  */
 gboolean
-fu_strsplit_stream(GInputStream *stream,
+fu_strsplit_stream(FuInputStream *stream,
 		   gsize offset,
 		   const gchar *delimiter,
 		   FuStrsplitFunc callback,
@@ -513,7 +514,7 @@ fu_strsplit_stream(GInputStream *stream,
 {
 	g_autoptr(FuChunkArray) chunks = NULL;
 	g_autoptr(GByteArray) buf = g_byte_array_new();
-	g_autoptr(GInputStream) stream_partial = NULL;
+	g_autoptr(FuInputStream) stream_partial = NULL;
 	FuStrsplitHelper helper = {
 	    .callback = callback,
 	    .user_data = user_data,
@@ -521,7 +522,7 @@ fu_strsplit_stream(GInputStream *stream,
 	    .token_idx = 0,
 	};
 
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(delimiter != NULL && delimiter[0] != '\0', FALSE);
 	g_return_val_if_fail(callback != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);

--- a/libfwupdplugin/fu-string.h
+++ b/libfwupdplugin/fu-string.h
@@ -9,6 +9,7 @@
 #include <fwupd.h>
 
 #include "fu-endian.h"
+#include "fu-input-stream.h"
 
 typedef enum {
 	FU_INTEGER_BASE_AUTO = 0,
@@ -74,7 +75,7 @@ fu_strsplit_full(const gchar *str,
 		 gpointer user_data,
 		 GError **error) G_GNUC_NON_NULL(1, 3);
 gboolean
-fu_strsplit_stream(GInputStream *stream,
+fu_strsplit_stream(FuInputStream *stream,
 		   gsize offset,
 		   const gchar *delimiter,
 		   FuStrsplitFunc callback,

--- a/libfwupdplugin/fu-tpm-eventlog-v1.c
+++ b/libfwupdplugin/fu-tpm-eventlog-v1.c
@@ -23,7 +23,7 @@ G_DEFINE_TYPE(FuTpmEventlogV1, fu_tpm_eventlog_v1, FU_TYPE_TPM_EVENTLOG)
 
 static gboolean
 fu_tpm_eventlog_v1_parse(FuFirmware *firmware,
-			 GInputStream *stream,
+			 FuInputStream *stream,
 			 FuFirmwareParseFlags flags,
 			 GError **error)
 {

--- a/libfwupdplugin/fu-tpm-eventlog-v2.c
+++ b/libfwupdplugin/fu-tpm-eventlog-v2.c
@@ -10,6 +10,7 @@
 
 #include "fu-byte-array.h"
 #include "fu-common.h"
+#include "fu-input-stream.h"
 #include "fu-tpm-eventlog-common.h"
 #include "fu-tpm-eventlog-item.h"
 #include "fu-tpm-eventlog-v2.h"
@@ -45,7 +46,7 @@ fu_tpm_eventlog_v2_hash_get_size(FuTpmAlg hash_kind)
 
 static gboolean
 fu_tpm_eventlog_v2_parse_item(FuTpmEventlogV2 *self,
-			      GInputStream *stream,
+			      FuInputStream *stream,
 			      gsize *idx,
 			      GError **error)
 {
@@ -144,7 +145,7 @@ fu_tpm_eventlog_v2_parse_item(FuTpmEventlogV2 *self,
 
 static gboolean
 fu_tpm_eventlog_v2_parse(FuFirmware *firmware,
-			 GInputStream *stream,
+			 FuInputStream *stream,
 			 FuFirmwareParseFlags flags,
 			 GError **error)
 {

--- a/libfwupdplugin/fu-usb-bos-descriptor.c
+++ b/libfwupdplugin/fu-usb-bos-descriptor.c
@@ -20,6 +20,7 @@
 #include "fu-byte-array.h"
 #include "fu-common.h"
 #include "fu-input-stream.h"
+#include "fu-memory-input-stream.h"
 #include "fu-partial-input-stream.h"
 #include "fu-usb-bos-descriptor-private.h"
 
@@ -97,7 +98,7 @@ fu_usb_bos_descriptor_from_json(FwupdCodec *codec, FwupdJsonObject *json_obj, GE
 		g_autoptr(FuFirmware) img = fu_firmware_new();
 
 		/* create child */
-		stream = g_memory_input_stream_new_from_data(g_steal_pointer(&buf), bufsz, g_free);
+		stream = fu_memory_input_stream_new_from_data(g_steal_pointer(&buf), bufsz, g_free);
 		if (!fu_firmware_parse_stream(img,
 					      stream,
 					      0x0,

--- a/libfwupdplugin/fu-usb-bos-descriptor.c
+++ b/libfwupdplugin/fu-usb-bos-descriptor.c
@@ -19,6 +19,7 @@
 
 #include "fu-byte-array.h"
 #include "fu-common.h"
+#include "fu-input-stream.h"
 #include "fu-partial-input-stream.h"
 #include "fu-usb-bos-descriptor-private.h"
 
@@ -92,7 +93,7 @@ fu_usb_bos_descriptor_from_json(FwupdCodec *codec, FwupdJsonObject *json_obj, GE
 	if (str != NULL) {
 		gsize bufsz = 0;
 		g_autofree guchar *buf = g_base64_decode(str, &bufsz);
-		g_autoptr(GInputStream) stream = NULL;
+		g_autoptr(FuInputStream) stream = NULL;
 		g_autoptr(FuFirmware) img = fu_firmware_new();
 
 		/* create child */
@@ -153,7 +154,7 @@ fu_usb_bos_descriptor_get_capability(FuUsbBosDescriptor *self)
 
 static gboolean
 fu_usb_bos_descriptor_parse(FuFirmware *firmware,
-			    GInputStream *stream,
+			    FuInputStream *stream,
 			    FuFirmwareParseFlags flags,
 			    GError **error)
 {
@@ -175,7 +176,7 @@ fu_usb_bos_descriptor_parse(FuFirmware *firmware,
 	/* data */
 	if (self->length > st->buf->len) {
 		g_autoptr(FuFirmware) img = fu_firmware_new();
-		g_autoptr(GInputStream) img_stream = NULL;
+		g_autoptr(FuInputStream) img_stream = NULL;
 
 		img_stream = fu_partial_input_stream_new(stream,
 							 st->buf->len,

--- a/libfwupdplugin/fu-usb-config-descriptor.c
+++ b/libfwupdplugin/fu-usb-config-descriptor.c
@@ -16,6 +16,7 @@
 #include "config.h"
 
 #include "fu-common.h"
+#include "fu-input-stream.h"
 #include "fu-usb-config-descriptor-private.h"
 
 struct _FuUsbConfigDescriptor {
@@ -113,7 +114,7 @@ fu_usb_config_descriptor_get_configuration_value(FuUsbConfigDescriptor *self)
 
 static gboolean
 fu_usb_config_descriptor_parse(FuFirmware *firmware,
-			       GInputStream *stream,
+			       FuInputStream *stream,
 			       FuFirmwareParseFlags flags,
 			       GError **error)
 {

--- a/libfwupdplugin/fu-usb-descriptor.c
+++ b/libfwupdplugin/fu-usb-descriptor.c
@@ -7,13 +7,14 @@
 #include "config.h"
 
 #include "fu-common.h"
+#include "fu-input-stream.h"
 #include "fu-usb-descriptor.h"
 
 G_DEFINE_TYPE(FuUsbDescriptor, fu_usb_descriptor, FU_TYPE_FIRMWARE)
 
 static gboolean
 fu_usb_descriptor_parse(FuFirmware *firmware,
-			GInputStream *stream,
+			FuInputStream *stream,
 			FuFirmwareParseFlags flags,
 			GError **error)
 {

--- a/libfwupdplugin/fu-usb-device-ds20.c
+++ b/libfwupdplugin/fu-usb-device-ds20.c
@@ -10,6 +10,7 @@
 
 #include "fu-dump.h"
 #include "fu-input-stream.h"
+#include "fu-memory-input-stream.h"
 #include "fu-usb-device-ds20-struct.h"
 #include "fu-usb-device-ds20.h"
 
@@ -109,7 +110,7 @@ fu_usb_device_ds20_apply_to_device(FuUsbDeviceDs20 *self, FuUsbDevice *device, G
 	fu_dump_raw(G_LOG_DOMAIN, "PlatformCapabilityOs20", buf, actual_length);
 
 	/* FuUsbDeviceDs20->parse */
-	stream = g_memory_input_stream_new_from_data(buf, actual_length, NULL);
+	stream = fu_memory_input_stream_new_from_data(buf, actual_length, NULL);
 	return klass->parse(self, stream, device, error);
 }
 

--- a/libfwupdplugin/fu-usb-device-ds20.c
+++ b/libfwupdplugin/fu-usb-device-ds20.c
@@ -72,7 +72,7 @@ fu_usb_device_ds20_apply_to_device(FuUsbDeviceDs20 *self, FuUsbDevice *device, G
 	gsize total_length = fu_firmware_get_size(FU_FIRMWARE(self));
 	guint8 vendor_code = fu_firmware_get_idx(FU_FIRMWARE(self));
 	g_autofree guint8 *buf = g_malloc0(total_length);
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	g_return_val_if_fail(FU_IS_USB_DEVICE_DS20(self), FALSE);
 	g_return_val_if_fail(FU_IS_USB_DEVICE(device), FALSE);
@@ -115,7 +115,7 @@ fu_usb_device_ds20_apply_to_device(FuUsbDeviceDs20 *self, FuUsbDevice *device, G
 
 static gboolean
 fu_usb_device_ds20_validate(FuFirmware *firmware,
-			    GInputStream *stream,
+			    FuInputStream *stream,
 			    gsize offset,
 			    GError **error)
 {
@@ -154,7 +154,7 @@ fu_usb_device_ds20_sort_by_platform_ver_cb(gconstpointer a, gconstpointer b)
 
 static gboolean
 fu_usb_device_ds20_parse(FuFirmware *firmware,
-			 GInputStream *stream,
+			 FuInputStream *stream,
 			 FuFirmwareParseFlags flags,
 			 GError **error)
 {

--- a/libfwupdplugin/fu-usb-device-ds20.h
+++ b/libfwupdplugin/fu-usb-device-ds20.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "fu-firmware.h"
+#include "fu-input-stream.h"
 #include "fu-usb-device.h"
 
 #define FU_TYPE_USB_DEVICE_DS20 (fu_usb_device_ds20_get_type())
@@ -15,7 +16,7 @@ G_DECLARE_DERIVABLE_TYPE(FuUsbDeviceDs20, fu_usb_device_ds20, FU, USB_DEVICE_DS2
 struct _FuUsbDeviceDs20Class {
 	FuFirmwareClass parent_class;
 	gboolean (*parse)(FuUsbDeviceDs20 *self,
-			  GInputStream *stream,
+			  FuInputStream *stream,
 			  FuUsbDevice *device,
 			  GError **error) G_GNUC_WARN_UNUSED_RESULT;
 };

--- a/libfwupdplugin/fu-usb-device-fw-ds20.c
+++ b/libfwupdplugin/fu-usb-device-fw-ds20.c
@@ -27,7 +27,7 @@ G_DEFINE_TYPE(FuUsbDeviceFwDs20, fu_usb_device_fw_ds20, FU_TYPE_USB_DEVICE_DS20)
 
 static gboolean
 fu_usb_device_fw_ds20_parse(FuUsbDeviceDs20 *self,
-			    GInputStream *stream,
+			    FuInputStream *stream,
 			    FuUsbDevice *device,
 			    GError **error)
 {

--- a/libfwupdplugin/fu-usb-device-ms-ds20.c
+++ b/libfwupdplugin/fu-usb-device-ms-ds20.c
@@ -21,7 +21,7 @@ G_DEFINE_TYPE(FuUsbDeviceMsDs20, fu_usb_device_ms_ds20, FU_TYPE_USB_DEVICE_DS20)
 
 static gboolean
 fu_usb_device_ms_ds20_parse(FuUsbDeviceDs20 *self,
-			    GInputStream *stream,
+			    FuInputStream *stream,
 			    FuUsbDevice *device,
 			    GError **error)
 {

--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -863,7 +863,7 @@ fu_usb_device_probe_bos_descriptor(FuUsbDevice *self, FuUsbBosDescriptor *bos, G
 {
 	g_autofree gchar *str = NULL;
 	g_autoptr(FuFirmware) ds20 = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuDeviceLocker) usb_locker = NULL;
 
 	/* parse either type */

--- a/libfwupdplugin/fu-usb-endpoint.c
+++ b/libfwupdplugin/fu-usb-endpoint.c
@@ -18,6 +18,7 @@
 
 #include <string.h>
 
+#include "fu-input-stream.h"
 #include "fu-usb-endpoint-private.h"
 
 struct _FuUsbEndpoint {
@@ -207,7 +208,7 @@ fu_usb_endpoint_get_direction(FuUsbEndpoint *self)
 
 static gboolean
 fu_usb_endpoint_parse(FuFirmware *firmware,
-		      GInputStream *stream,
+		      FuInputStream *stream,
 		      FuFirmwareParseFlags flags,
 		      GError **error)
 {

--- a/libfwupdplugin/fu-usb-hid-descriptor.c
+++ b/libfwupdplugin/fu-usb-hid-descriptor.c
@@ -14,6 +14,7 @@
 #include "config.h"
 
 #include "fu-common.h"
+#include "fu-input-stream.h"
 #include "fu-usb-hid-descriptor-private.h"
 
 struct _FuUsbHidDescriptor {
@@ -148,7 +149,7 @@ fu_usb_hid_descriptor_set_blob(FuUsbHidDescriptor *self, GBytes *blob)
 
 static gboolean
 fu_usb_hid_descriptor_parse(FuFirmware *firmware,
-			    GInputStream *stream,
+			    FuInputStream *stream,
 			    FuFirmwareParseFlags flags,
 			    GError **error)
 {

--- a/libfwupdplugin/fu-usb-interface.c
+++ b/libfwupdplugin/fu-usb-interface.c
@@ -387,7 +387,7 @@ fu_usb_interface_add_endpoint(FuUsbInterface *self, FuUsbEndpoint *endpoint)
 
 static gboolean
 fu_usb_interface_parse(FuFirmware *firmware,
-		       GInputStream *stream,
+		       FuInputStream *stream,
 		       FuFirmwareParseFlags flags,
 		       GError **error)
 {

--- a/libfwupdplugin/fu-uswid-firmware.c
+++ b/libfwupdplugin/fu-uswid-firmware.c
@@ -53,7 +53,10 @@ fu_uswid_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBu
 }
 
 static gboolean
-fu_uswid_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize offset, GError **error)
+fu_uswid_firmware_validate(FuFirmware *firmware,
+			   FuInputStream *stream,
+			   gsize offset,
+			   GError **error)
 {
 	return fu_struct_uswid_validate_stream(stream, offset, error);
 }
@@ -77,7 +80,7 @@ fu_uswid_firmware_format_to_gtype(FuUswidPayloadFormat format, GError **error)
 
 static gboolean
 fu_uswid_firmware_parse(FuFirmware *firmware,
-			GInputStream *stream,
+			FuInputStream *stream,
 			FuFirmwareParseFlags flags,
 			GError **error)
 {
@@ -149,8 +152,8 @@ fu_uswid_firmware_parse(FuFirmware *firmware,
 	/* zlib stream */
 	if (priv->compression == FU_USWID_PAYLOAD_COMPRESSION_ZLIB) {
 		g_autoptr(GConverter) conv = NULL;
-		g_autoptr(GInputStream) istream1 = NULL;
-		g_autoptr(GInputStream) istream2 = NULL;
+		g_autoptr(FuInputStream) istream1 = NULL;
+		g_autoptr(FuInputStream) istream2 = NULL;
 		conv = G_CONVERTER(g_zlib_decompressor_new(G_ZLIB_COMPRESSOR_FORMAT_ZLIB));
 		istream1 = fu_partial_input_stream_new(stream, hdrsz, payloadsz, error);
 		if (istream1 == NULL) {
@@ -263,8 +266,8 @@ fu_uswid_firmware_write(FuFirmware *firmware, GError **error)
 	/* compression format */
 	if (priv->compression == FU_USWID_PAYLOAD_COMPRESSION_ZLIB) {
 		g_autoptr(GConverter) conv = NULL;
-		g_autoptr(GInputStream) istream1 = NULL;
-		g_autoptr(GInputStream) istream2 = NULL;
+		g_autoptr(FuInputStream) istream1 = NULL;
+		g_autoptr(FuInputStream) istream2 = NULL;
 
 		conv = G_CONVERTER(g_zlib_compressor_new(G_ZLIB_COMPRESSOR_FORMAT_ZLIB, -1));
 		istream1 = g_memory_input_stream_new_from_data(payload->data, payload->len, NULL);

--- a/libfwupdplugin/fu-uswid-firmware.c
+++ b/libfwupdplugin/fu-uswid-firmware.c
@@ -14,6 +14,7 @@
 #include "fu-coswid-firmware.h"
 #include "fu-input-stream.h"
 #include "fu-lzma-common.h"
+#include "fu-memory-input-stream.h"
 #include "fu-partial-input-stream.h"
 #include "fu-uswid-firmware.h"
 #include "fu-uswid-struct.h"
@@ -270,8 +271,8 @@ fu_uswid_firmware_write(FuFirmware *firmware, GError **error)
 		g_autoptr(FuInputStream) istream2 = NULL;
 
 		conv = G_CONVERTER(g_zlib_compressor_new(G_ZLIB_COMPRESSOR_FORMAT_ZLIB, -1));
-		istream1 = g_memory_input_stream_new_from_data(payload->data, payload->len, NULL);
-		istream2 = g_converter_input_stream_new(istream1, conv);
+		istream1 = fu_memory_input_stream_new_from_data(payload->data, payload->len, NULL);
+		istream2 = g_converter_input_stream_new(G_INPUT_STREAM(istream1), conv);
 		payload_blob = fu_input_stream_read_bytes(istream2, 0, G_MAXSIZE, NULL, error);
 		if (payload_blob == NULL)
 			return NULL;

--- a/libfwupdplugin/fu-x509-certificate.c
+++ b/libfwupdplugin/fu-x509-certificate.c
@@ -176,7 +176,7 @@ fu_x509_certificate_get_activation_time(FuX509Certificate *self)
 
 static gboolean
 fu_x509_certificate_parse(FuFirmware *firmware,
-			  GInputStream *stream,
+			  FuInputStream *stream,
 			  FuFirmwareParseFlags flags,
 			  GError **error)
 {

--- a/libfwupdplugin/fu-zip-firmware.c
+++ b/libfwupdplugin/fu-zip-firmware.c
@@ -10,6 +10,7 @@
 
 #include "fu-byte-array.h"
 #include "fu-common.h"
+#include "fu-input-stream.h"
 #include "fu-partial-input-stream.h"
 #include "fu-path.h"
 #include "fu-string.h"
@@ -24,7 +25,7 @@ G_DEFINE_TYPE(FuZipFirmware, fu_zip_firmware, FU_TYPE_FIRMWARE)
 #define FU_ZIP_MAX_DECOMPRESSION_RATIO	1000
 
 static gboolean
-fu_zip_firmware_parse_extra(GInputStream *stream, gsize offset, gsize extra_size, GError **error)
+fu_zip_firmware_parse_extra(FuInputStream *stream, gsize offset, gsize extra_size, GError **error)
 {
 	for (gsize i = 0; i < extra_size; i += FU_STRUCT_ZIP_EXTRA_HDR_SIZE) {
 		guint32 datasz;
@@ -52,7 +53,7 @@ fu_zip_firmware_parse_extra(GInputStream *stream, gsize offset, gsize extra_size
 
 static FuFirmware *
 fu_zip_firmware_parse_lfh(FuZipFirmware *self,
-			  GInputStream *stream,
+			  FuInputStream *stream,
 			  FuStructZipCdfh *st_cdfh,
 			  FuFirmwareParseFlags flags,
 			  GError **error)
@@ -67,7 +68,7 @@ fu_zip_firmware_parse_lfh(FuZipFirmware *self,
 	g_autofree gchar *filename = NULL;
 	g_autoptr(FuStructZipLfh) st_lfh = NULL;
 	g_autoptr(FuFirmware) zip_file = fu_zip_file_new();
-	g_autoptr(GInputStream) stream_compressed = NULL;
+	g_autoptr(FuInputStream) stream_compressed = NULL;
 
 	/* read local file header */
 	fu_firmware_set_offset(zip_file, offset);
@@ -221,7 +222,7 @@ fu_zip_firmware_parse_lfh(FuZipFirmware *self,
 	} else if (compression == FU_ZIP_COMPRESSION_DEFLATE) {
 		g_autoptr(GBytes) blob_raw = NULL;
 		g_autoptr(GConverter) conv = NULL;
-		g_autoptr(GInputStream) stream_deflate = NULL;
+		g_autoptr(FuInputStream) stream_deflate = NULL;
 
 		conv = G_CONVERTER(g_zlib_decompressor_new(G_ZLIB_COMPRESSOR_FORMAT_RAW));
 		if (!g_seekable_seek(G_SEEKABLE(stream_compressed), 0, G_SEEK_SET, NULL, error))
@@ -285,7 +286,7 @@ fu_zip_firmware_parse_lfh(FuZipFirmware *self,
 
 static gboolean
 fu_zip_firmware_parse(FuFirmware *firmware,
-		      GInputStream *stream,
+		      FuInputStream *stream,
 		      FuFirmwareParseFlags flags,
 		      GError **error)
 {
@@ -453,8 +454,8 @@ fu_zip_firmware_write(FuFirmware *firmware, GError **error)
 			blob_compressed = g_bytes_ref(blob);
 		} else if (compression == FU_ZIP_COMPRESSION_DEFLATE) {
 			g_autoptr(GConverter) conv = NULL;
-			g_autoptr(GInputStream) istream_raw = NULL;
-			g_autoptr(GInputStream) istream_compressed = NULL;
+			g_autoptr(FuInputStream) istream_raw = NULL;
+			g_autoptr(FuInputStream) istream_compressed = NULL;
 			conv = G_CONVERTER(g_zlib_compressor_new(G_ZLIB_COMPRESSOR_FORMAT_RAW, -1));
 			istream_raw = g_memory_input_stream_new_from_bytes(blob);
 			istream_compressed = g_converter_input_stream_new(istream_raw, conv);

--- a/libfwupdplugin/fu-zip-firmware.c
+++ b/libfwupdplugin/fu-zip-firmware.c
@@ -11,6 +11,7 @@
 #include "fu-byte-array.h"
 #include "fu-common.h"
 #include "fu-input-stream.h"
+#include "fu-memory-input-stream.h"
 #include "fu-partial-input-stream.h"
 #include "fu-path.h"
 #include "fu-string.h"
@@ -457,8 +458,9 @@ fu_zip_firmware_write(FuFirmware *firmware, GError **error)
 			g_autoptr(FuInputStream) istream_raw = NULL;
 			g_autoptr(FuInputStream) istream_compressed = NULL;
 			conv = G_CONVERTER(g_zlib_compressor_new(G_ZLIB_COMPRESSOR_FORMAT_RAW, -1));
-			istream_raw = g_memory_input_stream_new_from_bytes(blob);
-			istream_compressed = g_converter_input_stream_new(istream_raw, conv);
+			istream_raw = fu_memory_input_stream_new_from_bytes(blob);
+			istream_compressed =
+			    g_converter_input_stream_new(G_INPUT_STREAM(istream_raw), conv);
 			blob_compressed = fu_input_stream_read_bytes(istream_compressed,
 								     0,
 								     G_MAXSIZE,

--- a/libfwupdplugin/fwupdplugin.h
+++ b/libfwupdplugin/fwupdplugin.h
@@ -67,6 +67,7 @@
 #include <libfwupdplugin/fu-endian.h>
 #include <libfwupdplugin/fu-fdt-firmware.h>
 #include <libfwupdplugin/fu-fdt-image.h>
+#include <libfwupdplugin/fu-file-input-stream.h>
 #include <libfwupdplugin/fu-firmware-common.h>
 #include <libfwupdplugin/fu-firmware.h>
 #include <libfwupdplugin/fu-fit-firmware.h>
@@ -100,6 +101,7 @@
 #include <libfwupdplugin/fu-lzma-common.h>
 #include <libfwupdplugin/fu-mei-device.h>
 #include <libfwupdplugin/fu-mem.h>
+#include <libfwupdplugin/fu-memory-input-stream.h>
 #include <libfwupdplugin/fu-msgpack-item.h>
 #include <libfwupdplugin/fu-msgpack.h>
 #include <libfwupdplugin/fu-oprom-device.h>

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -137,6 +137,7 @@ fwupdplugin_src = [
   'fu-elf-firmware.c', # fuzzing
   'fu-fdt-firmware.c', # fuzzing
   'fu-fdt-image.c', # fuzzing
+  'fu-file-input-stream.c', # fuzzing
   'fu-firmware.c', # fuzzing
   'fu-firmware-common.c', # fuzzing
   'fu-fit-firmware.c', # fuzzing
@@ -310,6 +311,7 @@ fwupdplugin_headers = [
   'fu-endian.h',
   'fu-fdt-firmware.h',
   'fu-fdt-image.h',
+  'fu-file-input-stream.h',
   'fu-firmware-common.h',
   'fu-firmware.h',
   'fu-fit-firmware.h',

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -163,6 +163,7 @@ fwupdplugin_src = [
   'fu-ifwi-fpt-firmware.c', # fuzzing
   'fu-ihex-firmware.c', # fuzzing
   'fu-input-stream.c', # fuzzing
+  'fu-memory-input-stream.c', # fuzzing
   'fu-intel-me-device.c', # fuzzing
   'fu-intel-thunderbolt-firmware.c', # fuzzing
   'fu-intel-thunderbolt-nvm.c', # fuzzing
@@ -328,6 +329,7 @@ fwupdplugin_headers = [
   'fu-ifwi-fpt-firmware.h',
   'fu-ihex-firmware.h',
   'fu-input-stream.h',
+  'fu-memory-input-stream.h',
   'fu-intel-me-device.h',
   'fu-intel-thunderbolt-firmware.h',
   'fu-intel-thunderbolt-nvm.h',

--- a/plugins/acpi-dmar/fu-acpi-dmar-plugin.c
+++ b/plugins/acpi-dmar/fu-acpi-dmar-plugin.c
@@ -22,7 +22,7 @@ fu_acpi_dmar_plugin_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *attrs)
 	g_autofree gchar *fn = NULL;
 	g_autoptr(FuAcpiDmar) dmar = fu_acpi_dmar_new();
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(GError) error_local = NULL;
 
 	/* only Intel */

--- a/plugins/acpi-dmar/fu-acpi-dmar.c
+++ b/plugins/acpi-dmar/fu-acpi-dmar.c
@@ -19,13 +19,13 @@ G_DEFINE_TYPE(FuAcpiDmar, fu_acpi_dmar, FU_TYPE_ACPI_TABLE)
 
 static gboolean
 fu_acpi_dmar_parse(FuFirmware *firmware,
-		   GInputStream *stream,
+		   FuInputStream *stream,
 		   FuFirmwareParseFlags flags,
 		   GError **error)
 {
 	FuAcpiDmar *self = FU_ACPI_DMAR(firmware);
 	guint8 dma_flags = 0;
-	g_autoptr(GInputStream) stream_payload = NULL;
+	g_autoptr(FuInputStream) stream_payload = NULL;
 
 	/* FuAcpiTable->parse */
 	if (!FU_FIRMWARE_CLASS(fu_acpi_dmar_parent_class)

--- a/plugins/acpi-dmar/fu-self-test.c
+++ b/plugins/acpi-dmar/fu-self-test.c
@@ -14,7 +14,7 @@ fu_acpi_dmar_opt_in_func(void)
 	gboolean ret;
 	g_autoptr(FuAcpiDmar) dmar = fu_acpi_dmar_new();
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autofree gchar *fn = NULL;
 
 	fn = g_test_build_filename(G_TEST_DIST, "tests", "DMAR", NULL);
@@ -41,7 +41,7 @@ fu_acpi_dmar_opt_out_func(void)
 	gboolean ret;
 	g_autoptr(FuAcpiDmar) dmar = fu_acpi_dmar_new();
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autofree gchar *fn = NULL;
 
 	fn = g_test_build_filename(G_TEST_DIST, "tests", "DMAR-OPTOUT", NULL);

--- a/plugins/acpi-ivrs/fu-acpi-ivrs-plugin.c
+++ b/plugins/acpi-ivrs/fu-acpi-ivrs-plugin.c
@@ -23,7 +23,7 @@ fu_acpi_ivrs_plugin_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *attrs)
 	g_autofree gchar *fn = NULL;
 	g_autoptr(FuAcpiIvrs) ivrs = fu_acpi_ivrs_new();
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(GError) error_local = NULL;
 
 	/* only AMD */

--- a/plugins/acpi-ivrs/fu-acpi-ivrs.c
+++ b/plugins/acpi-ivrs/fu-acpi-ivrs.c
@@ -21,13 +21,13 @@ G_DEFINE_TYPE(FuAcpiIvrs, fu_acpi_ivrs, FU_TYPE_ACPI_TABLE)
 
 static gboolean
 fu_acpi_ivrs_parse(FuFirmware *firmware,
-		   GInputStream *stream,
+		   FuInputStream *stream,
 		   FuFirmwareParseFlags flags,
 		   GError **error)
 {
 	FuAcpiIvrs *self = FU_ACPI_IVRS(firmware);
 	guint8 ivinfo = 0;
-	g_autoptr(GInputStream) stream_payload = NULL;
+	g_autoptr(FuInputStream) stream_payload = NULL;
 
 	/* FuAcpiTable->parse */
 	if (!FU_FIRMWARE_CLASS(fu_acpi_ivrs_parent_class)

--- a/plugins/acpi-ivrs/fu-self-test.c
+++ b/plugins/acpi-ivrs/fu-self-test.c
@@ -17,7 +17,7 @@ fu_acpi_ivrs_dma_remap_func(void)
 	const gchar *oem_id;
 	g_autoptr(FuAcpiIvrs) ivrs = fu_acpi_ivrs_new();
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autofree gchar *fn = NULL;
 
 	fn = g_test_build_filename(G_TEST_DIST, "tests", "IVRS-REMAP", NULL);
@@ -58,7 +58,7 @@ fu_acpi_ivrs_no_dma_remap_func(void)
 	const gchar *oem_id;
 	g_autoptr(FuAcpiIvrs) ivrs = fu_acpi_ivrs_new();
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autofree gchar *fn = NULL;
 
 	fn = g_test_build_filename(G_TEST_DIST, "tests", "IVRS-NOREMAP", NULL);

--- a/plugins/acpi-phat/fu-acpi-phat-health-record.c
+++ b/plugins/acpi-phat/fu-acpi-phat-health-record.c
@@ -35,7 +35,7 @@ fu_acpi_phat_health_record_export(FuFirmware *firmware,
 
 static gboolean
 fu_acpi_phat_health_record_parse(FuFirmware *firmware,
-				 GInputStream *stream,
+				 FuInputStream *stream,
 				 FuFirmwareParseFlags flags,
 				 GError **error)
 {

--- a/plugins/acpi-phat/fu-acpi-phat-version-element.c
+++ b/plugins/acpi-phat/fu-acpi-phat-version-element.c
@@ -31,7 +31,7 @@ fu_acpi_phat_version_element_export(FuFirmware *firmware,
 
 static gboolean
 fu_acpi_phat_version_element_parse(FuFirmware *firmware,
-				   GInputStream *stream,
+				   FuInputStream *stream,
 				   FuFirmwareParseFlags flags,
 				   GError **error)
 {

--- a/plugins/acpi-phat/fu-acpi-phat-version-record.c
+++ b/plugins/acpi-phat/fu-acpi-phat-version-record.c
@@ -19,7 +19,7 @@ G_DEFINE_TYPE(FuAcpiPhatVersionRecord, fu_acpi_phat_version_record, FU_TYPE_FIRM
 
 static gboolean
 fu_acpi_phat_version_record_parse(FuFirmware *firmware,
-				  GInputStream *stream,
+				  FuInputStream *stream,
 				  FuFirmwareParseFlags flags,
 				  GError **error)
 {
@@ -33,7 +33,7 @@ fu_acpi_phat_version_record_parse(FuFirmware *firmware,
 	record_count = fu_struct_acpi_phat_version_record_get_record_count(st);
 	for (guint32 i = 0; i < record_count; i++) {
 		g_autoptr(FuFirmware) firmware_tmp = fu_acpi_phat_version_element_new();
-		g_autoptr(GInputStream) stream_tmp = NULL;
+		g_autoptr(FuInputStream) stream_tmp = NULL;
 		stream_tmp = fu_partial_input_stream_new(stream,
 							 offset + st->buf->len,
 							 FU_STRUCT_ACPI_PHAT_VERSION_ELEMENT_SIZE,

--- a/plugins/acpi-phat/fu-acpi-phat.c
+++ b/plugins/acpi-phat/fu-acpi-phat.c
@@ -30,7 +30,7 @@ fu_acpi_phat_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuilder
 
 static gboolean
 fu_acpi_phat_record_parse(FuAcpiPhat *self,
-			  GInputStream *stream,
+			  FuInputStream *stream,
 			  gsize *offset,
 			  FuFirmwareParseFlags flags,
 			  GError **error)
@@ -65,7 +65,7 @@ fu_acpi_phat_record_parse(FuAcpiPhat *self,
 
 	/* supported record type */
 	if (firmware_rcd != NULL) {
-		g_autoptr(GInputStream) partial_stream = NULL;
+		g_autoptr(FuInputStream) partial_stream = NULL;
 		partial_stream = fu_partial_input_stream_new(stream, *offset, record_length, error);
 		if (partial_stream == NULL)
 			return FALSE;
@@ -89,14 +89,14 @@ fu_acpi_phat_set_oem_id(FuAcpiPhat *self, const gchar *oem_id)
 }
 
 static gboolean
-fu_acpi_phat_validate(FuFirmware *firmware, GInputStream *stream, gsize offset, GError **error)
+fu_acpi_phat_validate(FuFirmware *firmware, FuInputStream *stream, gsize offset, GError **error)
 {
 	return fu_struct_acpi_phat_hdr_validate_stream(stream, offset, error);
 }
 
 static gboolean
 fu_acpi_phat_parse(FuFirmware *firmware,
-		   GInputStream *stream,
+		   FuInputStream *stream,
 		   FuFirmwareParseFlags flags,
 		   GError **error)
 {
@@ -143,7 +143,7 @@ fu_acpi_phat_parse(FuFirmware *firmware,
 	/* verify checksum */
 	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		guint8 checksum = 0;
-		g_autoptr(GInputStream) stream_tmp =
+		g_autoptr(FuInputStream) stream_tmp =
 		    fu_partial_input_stream_new(stream, 0, length, error);
 		if (stream_tmp == NULL)
 			return FALSE;

--- a/plugins/algoltek-usb/fu-algoltek-usb-device.c
+++ b/plugins/algoltek-usb/fu-algoltek-usb-device.c
@@ -224,7 +224,7 @@ fu_algoltek_usb_device_wrr(FuAlgoltekUsbDevice *self, int address, int value, GE
 
 static gboolean
 fu_algoltek_usb_device_isp(FuAlgoltekUsbDevice *self,
-			   GInputStream *stream,
+			   FuInputStream *stream,
 			   guint address,
 			   FuProgress *progress,
 			   GError **error)
@@ -384,7 +384,7 @@ fu_algoltek_usb_device_status_check_cb(FuDevice *device, gpointer user_data, GEr
 
 static gboolean
 fu_algoltek_usb_device_wrf(FuAlgoltekUsbDevice *self,
-			   GInputStream *stream,
+			   FuInputStream *stream,
 			   FuProgress *progress,
 			   GError **error)
 {
@@ -480,8 +480,8 @@ fu_algoltek_usb_device_write_firmware(FuDevice *device,
 				      GError **error)
 {
 	FuAlgoltekUsbDevice *self = FU_ALGOLTEK_USB_DEVICE(device);
-	g_autoptr(GInputStream) stream_isp = NULL;
-	g_autoptr(GInputStream) stream_payload = NULL;
+	g_autoptr(FuInputStream) stream_isp = NULL;
+	g_autoptr(FuInputStream) stream_payload = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/algoltek-usb/fu-algoltek-usb-firmware.c
+++ b/plugins/algoltek-usb/fu-algoltek-usb-firmware.c
@@ -20,7 +20,7 @@ G_DEFINE_TYPE(FuAlgoltekUsbFirmware, fu_algoltek_usb_firmware, FU_TYPE_FIRMWARE)
 
 static gboolean
 fu_algoltek_usb_firmware_validate(FuFirmware *firmware,
-				  GInputStream *stream,
+				  FuInputStream *stream,
 				  gsize offset,
 				  GError **error)
 {
@@ -29,7 +29,7 @@ fu_algoltek_usb_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_algoltek_usb_firmware_parse(FuFirmware *firmware,
-			       GInputStream *stream,
+			       FuInputStream *stream,
 			       FuFirmwareParseFlags flags,
 			       GError **error)
 {
@@ -38,8 +38,8 @@ fu_algoltek_usb_firmware_parse(FuFirmware *firmware,
 	g_autoptr(FuFirmware) img_isp = fu_firmware_new();
 	g_autoptr(FuFirmware) img_payload = fu_firmware_new();
 	g_autoptr(FuStructAlgoltekProductIdentity) st = NULL;
-	g_autoptr(GInputStream) stream_isp = NULL;
-	g_autoptr(GInputStream) stream_payload = NULL;
+	g_autoptr(FuInputStream) stream_isp = NULL;
+	g_autoptr(FuInputStream) stream_payload = NULL;
 
 	/* identity */
 	st = fu_struct_algoltek_product_identity_parse_stream(stream, offset, error);

--- a/plugins/algoltek-usbcr/fu-algoltek-usbcr-device.c
+++ b/plugins/algoltek-usbcr/fu-algoltek-usbcr-device.c
@@ -568,7 +568,7 @@ fu_algoltek_usbcr_device_write_firmware(FuDevice *device,
 {
 	FuAlgoltekUsbcrDevice *self = FU_ALGOLTEK_USBCR_DEVICE(device);
 	g_autoptr(FuChunkArray) chunks = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/algoltek-usbcr/fu-algoltek-usbcr-firmware.c
+++ b/plugins/algoltek-usbcr/fu-algoltek-usbcr-firmware.c
@@ -31,7 +31,7 @@ fu_algoltek_usbcr_firmware_export(FuFirmware *firmware,
 
 static gboolean
 fu_algoltek_usbcr_firmware_parse(FuFirmware *firmware,
-				 GInputStream *stream,
+				 FuInputStream *stream,
 				 FuFirmwareParseFlags flags,
 				 GError **error)
 {

--- a/plugins/amd-gpu/fu-amd-gpu-atom-firmware.c
+++ b/plugins/amd-gpu/fu-amd-gpu-atom-firmware.c
@@ -63,7 +63,7 @@ fu_amd_gpu_atom_firmware_export(FuFirmware *firmware,
 
 static gboolean
 fu_amd_gpu_atom_firmware_validate(FuFirmware *firmware,
-				  GInputStream *stream,
+				  FuInputStream *stream,
 				  gsize offset,
 				  GError **error)
 {
@@ -273,7 +273,7 @@ fu_amd_gpu_atom_firmware_parse_config_filename(FuAmdGpuAtomFirmware *self,
 
 static gboolean
 fu_amd_gpu_atom_firmware_parse(FuFirmware *firmware,
-			       GInputStream *stream,
+			       FuInputStream *stream,
 			       FuFirmwareParseFlags flags,
 			       GError **error)
 {

--- a/plugins/amd-gpu/fu-amd-gpu-psp-firmware.c
+++ b/plugins/amd-gpu/fu-amd-gpu-psp-firmware.c
@@ -50,7 +50,7 @@ fu_amd_gpu_psp_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags
 
 static gboolean
 fu_amd_gpu_psp_firmware_validate(FuFirmware *firmware,
-				 GInputStream *stream,
+				 FuInputStream *stream,
 				 gsize offset,
 				 GError **error)
 {
@@ -63,7 +63,7 @@ fu_amd_gpu_psp_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_amd_gpu_psp_firmware_parse_l2(FuAmdGpuPspFirmware *self,
-				 GInputStream *stream,
+				 FuInputStream *stream,
 				 gsize offset,
 				 GError **error)
 {
@@ -95,7 +95,7 @@ fu_amd_gpu_psp_firmware_parse_l2(FuAmdGpuPspFirmware *self,
 
 static gboolean
 fu_amd_gpu_psp_firmware_parse_l1(FuAmdGpuPspFirmware *self,
-				 GInputStream *stream,
+				 FuInputStream *stream,
 				 gsize offset,
 				 FuFirmwareParseFlags flags,
 				 GError **error)
@@ -119,7 +119,7 @@ fu_amd_gpu_psp_firmware_parse_l1(FuAmdGpuPspFirmware *self,
 		g_autoptr(FuFirmware) ish_img = fu_amd_gpu_psp_ish_firmware_new();
 		g_autoptr(FuFirmware) csm_img = fu_amd_gpu_atom_firmware_new();
 		g_autoptr(FuFirmware) l2_img = fu_amd_gpu_psp_l2_firmware_new();
-		g_autoptr(GInputStream) l2_stream = NULL;
+		g_autoptr(FuInputStream) l2_stream = NULL;
 
 		st_entry = fu_struct_psp_dir_table_parse_stream(stream, offset, error);
 		if (st_entry == NULL)
@@ -205,7 +205,7 @@ fu_amd_gpu_psp_firmware_parse_l1(FuAmdGpuPspFirmware *self,
 
 static gboolean
 fu_amd_gpu_psp_firmware_parse(FuFirmware *firmware,
-			      GInputStream *stream,
+			      FuInputStream *stream,
 			      FuFirmwareParseFlags flags,
 			      GError **error)
 {

--- a/plugins/amd-kria/fu-amd-kria-image-firmware.c
+++ b/plugins/amd-kria/fu-amd-kria-image-firmware.c
@@ -24,7 +24,7 @@ G_DEFINE_TYPE(FuAmdKriaImageFirmware, fu_amd_kria_image_firmware, FU_TYPE_FIRMWA
 
 static gboolean
 fu_amd_kria_image_firmware_parse(FuFirmware *firmware,
-				 GInputStream *stream,
+				 FuInputStream *stream,
 				 FuFirmwareParseFlags flags,
 				 GError **error)
 {

--- a/plugins/amd-kria/fu-amd-kria-persistent-firmware.c
+++ b/plugins/amd-kria/fu-amd-kria-persistent-firmware.c
@@ -23,7 +23,7 @@ G_DEFINE_TYPE(FuAmdKriaPersistentFirmware, fu_amd_kria_persistent_firmware, FU_T
 
 static gboolean
 fu_amd_kria_persistent_firmware_parse(FuFirmware *firmware,
-				      GInputStream *stream,
+				      FuInputStream *stream,
 				      FuFirmwareParseFlags flags,
 				      GError **error)
 {

--- a/plugins/amd-kria/fu-amd-kria-som-eeprom.c
+++ b/plugins/amd-kria/fu-amd-kria-som-eeprom.c
@@ -28,7 +28,7 @@ G_DEFINE_TYPE(FuAmdKriaSomEeprom, fu_amd_kria_som_eeprom, FU_TYPE_FIRMWARE)
 
 static gboolean
 fu_amd_kria_som_eeprom_parse(FuFirmware *firmware,
-			     GInputStream *stream,
+			     FuInputStream *stream,
 			     FuFirmwareParseFlags flags,
 			     GError **error)
 {

--- a/plugins/analogix/fu-analogix-device.c
+++ b/plugins/analogix/fu-analogix-device.c
@@ -291,7 +291,7 @@ fu_analogix_device_write_image(FuAnalogixDevice *self,
 	FuAnalogixUpdateStatus status = FU_ANALOGIX_UPDATE_STATUS_INVALID;
 	gsize streamsz = 0;
 	guint8 buf_init[4] = {0x0};
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */

--- a/plugins/analogix/fu-analogix-firmware.c
+++ b/plugins/analogix/fu-analogix-firmware.c
@@ -17,7 +17,7 @@ G_DEFINE_TYPE(FuAnalogixFirmware, fu_analogix_firmware, FU_TYPE_IHEX_FIRMWARE)
 
 static gboolean
 fu_analogix_firmware_parse(FuFirmware *firmware,
-			   GInputStream *stream,
+			   FuInputStream *stream,
 			   FuFirmwareParseFlags flags,
 			   GError **error)
 {

--- a/plugins/android-boot/fu-android-boot-device.c
+++ b/plugins/android-boot/fu-android-boot-device.c
@@ -275,7 +275,7 @@ fu_android_boot_device_write_firmware(FuDevice *device,
 				      GError **error)
 {
 	FuAndroidBootDevice *self = FU_ANDROID_BOOT_DEVICE(device);
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* get data to write */

--- a/plugins/asus-hid/fu-asus-hid-firmware.c
+++ b/plugins/asus-hid/fu-asus-hid-firmware.c
@@ -32,14 +32,14 @@ fu_asus_hid_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, X
 
 static gboolean
 fu_asus_hid_firmware_parse(FuFirmware *firmware,
-			   GInputStream *stream,
+			   FuInputStream *stream,
 			   FuFirmwareParseFlags flags,
 			   GError **error)
 {
 	FuAsusHidFirmware *self = FU_ASUS_HID_FIRMWARE(firmware);
 	g_autoptr(FuStructAsusHidDesc) st = NULL;
 	g_autoptr(FuFirmware) img_payload = fu_firmware_new();
-	g_autoptr(GInputStream) stream_payload = NULL;
+	g_autoptr(FuInputStream) stream_payload = NULL;
 
 	st = fu_struct_asus_hid_desc_parse_stream(stream, FGA_OFFSET, error);
 	if (st == NULL)

--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -788,7 +788,7 @@ fu_ata_device_write_firmware(FuDevice *device,
 	gsize streamsz = 0;
 	guint32 chunksz = (guint32)self->transfer_blocks * FU_ATA_BLOCK_SIZE;
 	guint max_size = 0xffff * FU_ATA_BLOCK_SIZE;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* get default image */

--- a/plugins/aver-hid/fu-aver-hid-device.c
+++ b/plugins/aver-hid/fu-aver-hid-device.c
@@ -395,7 +395,7 @@ fu_aver_hid_device_write_firmware(FuDevice *device,
 {
 	FuAverHidDevice *self = FU_AVER_HID_DEVICE(device);
 	gsize streamsz = 0;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */

--- a/plugins/aver-hid/fu-aver-safeisp-device.c
+++ b/plugins/aver-hid/fu-aver-safeisp-device.c
@@ -271,7 +271,7 @@ fu_aver_safeisp_device_write_firmware(FuDevice *device,
 	g_autoptr(FuChunkArray) chunks = NULL;
 	g_autoptr(GBytes) cx3_fw = NULL;
 	g_autoptr(GBytes) m12_fw = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/bcm57xx/fu-bcm57xx-common.c
+++ b/plugins/bcm57xx/fu-bcm57xx-common.c
@@ -12,12 +12,12 @@
 #include "fu-bcm57xx-common.h"
 
 gboolean
-fu_bcm57xx_verify_crc(GInputStream *stream, GError **error)
+fu_bcm57xx_verify_crc(FuInputStream *stream, GError **error)
 {
 	guint32 crc_actual = 0xFFFFFFFF;
 	guint32 crc_file = 0;
 	gsize streamsz = 0;
-	g_autoptr(GInputStream) stream_tmp = NULL;
+	g_autoptr(FuInputStream) stream_tmp = NULL;
 
 	/* expected */
 	if (!fu_input_stream_size(stream, &streamsz, error))
@@ -60,7 +60,7 @@ fu_bcm57xx_verify_crc(GInputStream *stream, GError **error)
 }
 
 gboolean
-fu_bcm57xx_verify_magic(GInputStream *stream, gsize offset, GError **error)
+fu_bcm57xx_verify_magic(FuInputStream *stream, gsize offset, GError **error)
 {
 	guint32 magic = 0;
 

--- a/plugins/bcm57xx/fu-bcm57xx-common.h
+++ b/plugins/bcm57xx/fu-bcm57xx-common.h
@@ -40,9 +40,9 @@ typedef struct {
 } FuBcm57xxVeritem;
 
 gboolean
-fu_bcm57xx_verify_crc(GInputStream *stream, GError **error);
+fu_bcm57xx_verify_crc(FuInputStream *stream, GError **error);
 gboolean
-fu_bcm57xx_verify_magic(GInputStream *stream, gsize offset, GError **error);
+fu_bcm57xx_verify_magic(FuInputStream *stream, gsize offset, GError **error);
 
 /* parses stage1 version */
 void

--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -323,7 +323,7 @@ fu_bcm57xx_device_read_firmware(FuDevice *device, FuProgress *progress, GError *
 
 static FuFirmware *
 fu_bcm57xx_device_prepare_firmware(FuDevice *device,
-				   GInputStream *stream,
+				   FuInputStream *stream,
 				   FuProgress *progress,
 				   FuFirmwareParseFlags flags,
 				   GError **error)

--- a/plugins/bcm57xx/fu-bcm57xx-dict-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-dict-image.c
@@ -29,11 +29,11 @@ fu_bcm57xx_dict_image_export(FuFirmware *firmware, FuFirmwareExportFlags flags, 
 
 static gboolean
 fu_bcm57xx_dict_image_parse(FuFirmware *firmware,
-			    GInputStream *stream,
+			    FuInputStream *stream,
 			    FuFirmwareParseFlags flags,
 			    GError **error)
 {
-	g_autoptr(GInputStream) stream_nocrc = NULL;
+	g_autoptr(FuInputStream) stream_nocrc = NULL;
 	gsize streamsz = 0;
 
 	if (!fu_input_stream_size(stream, &streamsz, error))

--- a/plugins/bcm57xx/fu-bcm57xx-firmware.c
+++ b/plugins/bcm57xx/fu-bcm57xx-firmware.c
@@ -46,7 +46,7 @@ fu_bcm57xx_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, Xb
 }
 
 static gboolean
-fu_bcm57xx_firmware_parse_header(FuBcm57xxFirmware *self, GInputStream *stream, GError **error)
+fu_bcm57xx_firmware_parse_header(FuBcm57xxFirmware *self, FuInputStream *stream, GError **error)
 {
 	/* verify magic and CRC */
 	if (!fu_bcm57xx_verify_magic(stream, 0x0, error))
@@ -64,7 +64,7 @@ fu_bcm57xx_firmware_parse_header(FuBcm57xxFirmware *self, GInputStream *stream, 
 
 static FuFirmware *
 fu_bcm57xx_firmware_parse_info(FuBcm57xxFirmware *self,
-			       GInputStream *stream,
+			       FuInputStream *stream,
 			       FuFirmwareParseFlags flags,
 			       GError **error)
 {
@@ -93,7 +93,7 @@ fu_bcm57xx_firmware_parse_info(FuBcm57xxFirmware *self,
 
 static FuFirmware *
 fu_bcm57xx_firmware_parse_stage1(FuBcm57xxFirmware *self,
-				 GInputStream *stream,
+				 FuInputStream *stream,
 				 guint32 *out_stage1_sz,
 				 FuFirmwareParseFlags flags,
 				 GError **error)
@@ -104,7 +104,7 @@ fu_bcm57xx_firmware_parse_stage1(FuBcm57xxFirmware *self,
 	guint32 stage1_off = 0;
 	g_autoptr(FuStructBcm57xxNvramHeader) st = NULL;
 	g_autoptr(FuFirmware) img = fu_bcm57xx_stage1_image_new();
-	g_autoptr(GInputStream) stream_tmp = NULL;
+	g_autoptr(FuInputStream) stream_tmp = NULL;
 
 	if (!fu_input_stream_size(stream, &streamsz, error))
 		return NULL;
@@ -165,7 +165,7 @@ fu_bcm57xx_firmware_parse_stage1(FuBcm57xxFirmware *self,
 
 static FuFirmware *
 fu_bcm57xx_firmware_parse_stage2(FuBcm57xxFirmware *self,
-				 GInputStream *stream,
+				 FuInputStream *stream,
 				 guint32 stage1_sz,
 				 FuFirmwareParseFlags flags,
 				 GError **error)
@@ -174,7 +174,7 @@ fu_bcm57xx_firmware_parse_stage2(FuBcm57xxFirmware *self,
 	guint32 stage2_off = 0;
 	guint32 stage2_sz = 0;
 	g_autoptr(FuFirmware) img = fu_bcm57xx_stage2_image_new();
-	g_autoptr(GInputStream) stream_tmp = NULL;
+	g_autoptr(FuInputStream) stream_tmp = NULL;
 
 	stage2_off = BCM_NVRAM_STAGE1_BASE + stage1_sz;
 	if (!fu_bcm57xx_verify_magic(stream, stage2_off, error))
@@ -216,7 +216,7 @@ fu_bcm57xx_firmware_parse_stage2(FuBcm57xxFirmware *self,
 
 static gboolean
 fu_bcm57xx_firmware_parse_dict(FuBcm57xxFirmware *self,
-			       GInputStream *stream,
+			       FuInputStream *stream,
 			       guint idx,
 			       FuFirmwareParseFlags flags,
 			       GError **error)
@@ -229,7 +229,7 @@ fu_bcm57xx_firmware_parse_dict(FuBcm57xxFirmware *self,
 	guint32 base = BCM_NVRAM_DIRECTORY_BASE + (idx * FU_STRUCT_BCM57XX_NVRAM_DIRECTORY_SIZE);
 	g_autoptr(FuFirmware) img = fu_bcm57xx_dict_image_new();
 	g_autoptr(FuStructBcm57xxNvramDirectory) st = NULL;
-	g_autoptr(GInputStream) stream_tmp = NULL;
+	g_autoptr(FuInputStream) stream_tmp = NULL;
 
 	/* header */
 	st = fu_struct_bcm57xx_nvram_directory_parse_stream(stream, base, error);
@@ -287,7 +287,7 @@ fu_bcm57xx_firmware_parse_dict(FuBcm57xxFirmware *self,
 
 static gboolean
 fu_bcm57xx_firmware_validate(FuFirmware *firmware,
-			     GInputStream *stream,
+			     FuInputStream *stream,
 			     gsize offset,
 			     GError **error)
 {
@@ -313,7 +313,7 @@ fu_bcm57xx_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_bcm57xx_firmware_parse(FuFirmware *firmware,
-			  GInputStream *stream,
+			  FuInputStream *stream,
 			  FuFirmwareParseFlags flags,
 			  GError **error)
 {
@@ -326,10 +326,10 @@ fu_bcm57xx_firmware_parse(FuFirmware *firmware,
 	g_autoptr(FuFirmware) img_stage1 = NULL;
 	g_autoptr(FuFirmware) img_stage2 = NULL;
 	g_autoptr(FuFirmware) img_vpd = fu_firmware_new();
-	g_autoptr(GInputStream) stream_header = NULL;
-	g_autoptr(GInputStream) stream_info2 = NULL;
-	g_autoptr(GInputStream) stream_info = NULL;
-	g_autoptr(GInputStream) stream_vpd = NULL;
+	g_autoptr(FuInputStream) stream_header = NULL;
+	g_autoptr(FuInputStream) stream_info2 = NULL;
+	g_autoptr(FuInputStream) stream_info = NULL;
+	g_autoptr(FuInputStream) stream_vpd = NULL;
 
 	/* try to autodetect the file type */
 	if (!fu_input_stream_read_u32(stream, 0x0, &magic, G_BIG_ENDIAN, error))

--- a/plugins/bcm57xx/fu-bcm57xx-stage1-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-stage1-image.c
@@ -17,13 +17,13 @@ G_DEFINE_TYPE(FuBcm57xxStage1Image, fu_bcm57xx_stage1_image, FU_TYPE_FIRMWARE)
 
 static gboolean
 fu_bcm57xx_stage1_image_parse(FuFirmware *image,
-			      GInputStream *stream,
+			      FuInputStream *stream,
 			      FuFirmwareParseFlags flags,
 			      GError **error)
 {
 	gsize streamsz = 0;
 	guint32 fwversion = 0;
-	g_autoptr(GInputStream) stream_nocrc = NULL;
+	g_autoptr(FuInputStream) stream_nocrc = NULL;
 
 	/* verify CRC */
 	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {

--- a/plugins/bcm57xx/fu-bcm57xx-stage2-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-stage2-image.c
@@ -17,12 +17,12 @@ G_DEFINE_TYPE(FuBcm57xxStage2Image, fu_bcm57xx_stage2_image, FU_TYPE_FIRMWARE)
 
 static gboolean
 fu_bcm57xx_stage2_image_parse(FuFirmware *image,
-			      GInputStream *stream,
+			      FuInputStream *stream,
 			      FuFirmwareParseFlags flags,
 			      GError **error)
 {
 	gsize streamsz = 0;
-	g_autoptr(GInputStream) stream_nocrc = NULL;
+	g_autoptr(FuInputStream) stream_nocrc = NULL;
 	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		if (!fu_bcm57xx_verify_crc(stream, error))
 			return FALSE;

--- a/plugins/blestech-tp/fu-blestech-tp-firmware.c
+++ b/plugins/blestech-tp/fu-blestech-tp-firmware.c
@@ -39,7 +39,7 @@ fu_blestech_tp_firmware_get_checksum(FuBlestechTpFirmware *self)
 
 static gboolean
 fu_blestech_tp_firmware_parse(FuFirmware *firmware,
-			      GInputStream *stream,
+			      FuInputStream *stream,
 			      FuFirmwareParseFlags flags,
 			      GError **error)
 {

--- a/plugins/blestech-tp/fu-blestech-tp-hid-device.c
+++ b/plugins/blestech-tp/fu-blestech-tp-hid-device.c
@@ -266,7 +266,7 @@ fu_blestech_tp_hid_device_program(FuBlestechTpHidDevice *self,
 				  GError **error)
 {
 	guint boot_pack_nums = 0;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	stream = fu_firmware_get_stream(firmware, error);

--- a/plugins/bnr-dp/fu-bnr-dp-device.c
+++ b/plugins/bnr-dp/fu-bnr-dp-device.c
@@ -698,7 +698,7 @@ fu_bnr_dp_device_dump_firmware(FuDevice *device, FuProgress *progress, GError **
 
 static FuFirmware *
 fu_bnr_dp_device_prepare_firmware(FuDevice *device,
-				  GInputStream *stream,
+				  FuInputStream *stream,
 				  FuProgress *progress,
 				  FuFirmwareParseFlags flags,
 				  GError **error)

--- a/plugins/bnr-dp/fu-bnr-dp-firmware.c
+++ b/plugins/bnr-dp/fu-bnr-dp-firmware.c
@@ -180,7 +180,7 @@ fu_bnr_dp_firmware_checksum_finish(guint16 csum)
 }
 
 static gboolean
-fu_bnr_dp_firmware_stream_checksum(GInputStream *stream, guint16 *csum, GError **error)
+fu_bnr_dp_firmware_stream_checksum(FuInputStream *stream, guint16 *csum, GError **error)
 {
 	if (!fu_input_stream_compute_sum16(stream, csum, error))
 		return FALSE;
@@ -196,14 +196,14 @@ fu_bnr_dp_firmware_buf_checksum(const guint8 *buf, gsize bufsz)
 
 static gboolean
 fu_bnr_dp_firmware_payload_parse(FuBnrDpFirmware *self,
-				 GInputStream *stream,
+				 FuInputStream *stream,
 				 gsize payload_offset,
 				 GError **error)
 {
 	gsize streamsz = 0;
 	guint16 xml_checksum = 0;
 	guint16 crc = G_MAXUINT16;
-	g_autoptr(GInputStream) payload_stream = NULL;
+	g_autoptr(FuInputStream) payload_stream = NULL;
 
 	payload_stream = fu_partial_input_stream_new(stream, payload_offset, G_MAXSIZE, error);
 	if (payload_stream == NULL)
@@ -268,7 +268,7 @@ fu_bnr_dp_firmware_payload_parse(FuBnrDpFirmware *self,
 
 static gboolean
 fu_bnr_dp_firmware_parse(FuFirmware *firmware,
-			 GInputStream *stream,
+			 FuInputStream *stream,
 			 FuFirmwareParseFlags flags,
 			 GError **error)
 {

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-firmware.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-firmware.c
@@ -87,7 +87,7 @@ fu_ccgx_dmc_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, X
 
 static gboolean
 fu_ccgx_dmc_firmware_parse_segment(FuCcgxDmcFirmware *self,
-				   GInputStream *stream,
+				   FuInputStream *stream,
 				   FuCcgxDmcFirmwareRecord *img_rcd,
 				   gsize *seg_off,
 				   FuFirmwareParseFlags flags,
@@ -176,7 +176,7 @@ fu_ccgx_dmc_firmware_parse_segment(FuCcgxDmcFirmware *self,
 static gboolean
 fu_ccgx_dmc_firmware_parse_image(FuCcgxDmcFirmware *self,
 				 guint8 image_count,
-				 GInputStream *stream,
+				 FuInputStream *stream,
 				 FuFirmwareParseFlags flags,
 				 GError **error)
 {
@@ -247,7 +247,7 @@ fu_ccgx_dmc_firmware_parse_image(FuCcgxDmcFirmware *self,
 
 static gboolean
 fu_ccgx_dmc_firmware_validate(FuFirmware *firmware,
-			      GInputStream *stream,
+			      FuInputStream *stream,
 			      gsize offset,
 			      GError **error)
 {
@@ -256,7 +256,7 @@ fu_ccgx_dmc_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_ccgx_dmc_firmware_parse(FuFirmware *firmware,
-			   GInputStream *stream,
+			   FuInputStream *stream,
 			   FuFirmwareParseFlags flags,
 			   GError **error)
 {

--- a/plugins/ccgx/fu-ccgx-firmware.c
+++ b/plugins/ccgx/fu-ccgx-firmware.c
@@ -356,7 +356,7 @@ fu_ccgx_firmware_tokenize_cb(GString *token, guint token_idx, gpointer user_data
 
 static gboolean
 fu_ccgx_firmware_parse(FuFirmware *firmware,
-		       GInputStream *stream,
+		       FuInputStream *stream,
 		       FuFirmwareParseFlags flags,
 		       GError **error)
 {

--- a/plugins/cfu/fu-cfu-module.c
+++ b/plugins/cfu/fu-cfu-module.c
@@ -80,7 +80,7 @@ fu_cfu_module_setup(FuCfuModule *self, const guint8 *buf, gsize bufsz, gsize off
 
 static FuFirmware *
 fu_cfu_module_prepare_firmware(FuDevice *device,
-			       GInputStream *stream,
+			       FuInputStream *stream,
 			       FuProgress *progress,
 			       FuFirmwareParseFlags flags,
 			       GError **error)

--- a/plugins/cros-ec/fu-cros-ec-firmware.c
+++ b/plugins/cros-ec/fu-cros-ec-firmware.c
@@ -172,7 +172,6 @@ fu_cros_ec_firmware_init(FuCrosEcFirmware *self)
 	section = g_new0(FuCrosEcFirmwareSection, 1);
 	section->name = "RW";
 	g_ptr_array_add(self->sections, section);
-
 }
 
 static void

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -914,7 +914,7 @@ fu_cros_ec_usb_device_write_firmware(FuDevice *device,
 
 static FuFirmware *
 fu_cros_ec_usb_device_prepare_firmware(FuDevice *device,
-				       GInputStream *stream,
+				       FuInputStream *stream,
 				       FuProgress *progress,
 				       FuFirmwareParseFlags flags,
 				       GError **error)

--- a/plugins/dell-kestrel/fu-dell-kestrel-ec.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-ec.c
@@ -622,7 +622,7 @@ fu_dell_kestrel_ec_get_package_version(FuDellKestrelEc *self)
 }
 
 gboolean
-fu_dell_kestrel_ec_commit_package(FuDellKestrelEc *self, GInputStream *stream, GError **error)
+fu_dell_kestrel_ec_commit_package(FuDellKestrelEc *self, FuInputStream *stream, GError **error)
 {
 	g_autoptr(FuStructDellKestrelEcDatabytes) st_req =
 	    fu_struct_dell_kestrel_ec_databytes_new();

--- a/plugins/dell-kestrel/fu-dell-kestrel-ec.h
+++ b/plugins/dell-kestrel/fu-dell-kestrel-ec.h
@@ -38,7 +38,7 @@ fu_dell_kestrel_ec_get_dpmux_version(FuDellKestrelEc *self);
 guint32
 fu_dell_kestrel_ec_get_package_version(FuDellKestrelEc *self);
 gboolean
-fu_dell_kestrel_ec_commit_package(FuDellKestrelEc *self, GInputStream *stream, GError **error);
+fu_dell_kestrel_ec_commit_package(FuDellKestrelEc *self, FuInputStream *stream, GError **error);
 FuDellDockBaseType
 fu_dell_kestrel_ec_get_dock_type(FuDellKestrelEc *self);
 FuDellKestrelDockSku

--- a/plugins/dell-kestrel/fu-dell-kestrel-package.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-package.c
@@ -58,7 +58,7 @@ fu_dell_kestrel_package_write(FuDevice *device,
 {
 	FuDevice *proxy;
 	guint32 pkg_version = 0;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autofree gchar *dynamic_version = NULL;
 
 	g_return_val_if_fail(device != NULL, FALSE);

--- a/plugins/dell-kestrel/fu-dell-kestrel-rtshub-firmware.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-rtshub-firmware.c
@@ -37,7 +37,7 @@ fu_dell_kestrel_rtshub_firmware_export(FuFirmware *firmware,
 }
 
 static gboolean
-fu_dell_kestrel_rtshub_firmware_set_offset(GInputStream *stream,
+fu_dell_kestrel_rtshub_firmware_set_offset(FuInputStream *stream,
 					   guint16 *version_offset,
 					   guint16 *pid_offset,
 					   GError **error)
@@ -62,7 +62,7 @@ fu_dell_kestrel_rtshub_firmware_set_offset(GInputStream *stream,
 }
 static gboolean
 fu_dell_kestrel_rtshub_firmware_parse(FuFirmware *firmware,
-				      GInputStream *stream,
+				      FuInputStream *stream,
 				      FuFirmwareParseFlags flags,
 				      GError **error)
 {

--- a/plugins/dell-kestrel/fu-dell-kestrel-rtshub.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-rtshub.c
@@ -178,7 +178,7 @@ fu_dell_kestrel_rtshub_write_firmware(FuDevice *device,
 				      GError **error)
 {
 	FuDellKestrelRtshub *self = FU_DELL_KESTREL_RTSHUB(device);
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */

--- a/plugins/dfu/fu-dfu-device.c
+++ b/plugins/dfu/fu-dfu-device.c
@@ -1304,7 +1304,7 @@ fu_dfu_device_dump_firmware(FuDevice *device, FuProgress *progress, GError **err
 
 static FuFirmware *
 fu_dfu_device_prepare_firmware(FuDevice *device,
-			       GInputStream *stream,
+			       FuInputStream *stream,
 			       FuProgress *progress,
 			       FuFirmwareParseFlags flags,
 			       GError **error)

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -438,7 +438,7 @@ fu_ebitdo_device_detach(FuDevice *device, FuProgress *progress, GError **error)
 
 static FuFirmware *
 fu_ebitdo_device_prepare_firmware(FuDevice *device,
-				  GInputStream *stream,
+				  FuInputStream *stream,
 				  FuProgress *progress,
 				  FuFirmwareParseFlags flags,
 				  GError **error)
@@ -460,7 +460,7 @@ fu_ebitdo_device_write_image(FuEbitdoDevice *self,
 	gsize bufsz = 0;
 	guint32 serial_new[3] = {0};
 	g_autoptr(GBytes) fw_hdr = NULL;
-	g_autoptr(GInputStream) stream_payload = NULL;
+	g_autoptr(FuInputStream) stream_payload = NULL;
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 	const guint32 app_key_index[16] = {

--- a/plugins/ebitdo/fu-ebitdo-firmware.c
+++ b/plugins/ebitdo/fu-ebitdo-firmware.c
@@ -17,7 +17,7 @@ G_DEFINE_TYPE(FuEbitdoFirmware, fu_ebitdo_firmware, FU_TYPE_FIRMWARE)
 
 static gboolean
 fu_ebitdo_firmware_parse(FuFirmware *firmware,
-			 GInputStream *stream,
+			 FuInputStream *stream,
 			 FuFirmwareParseFlags flags,
 			 GError **error)
 {
@@ -26,8 +26,8 @@ fu_ebitdo_firmware_parse(FuFirmware *firmware,
 	gsize total_size;
 	g_autoptr(FuFirmware) img_hdr = fu_firmware_new();
 	g_autoptr(FuStructEbitdoHdr) st = NULL;
-	g_autoptr(GInputStream) stream_hdr = NULL;
-	g_autoptr(GInputStream) stream_payload = NULL;
+	g_autoptr(FuInputStream) stream_hdr = NULL;
+	g_autoptr(FuInputStream) stream_payload = NULL;
 
 	/* check the file size */
 	st = fu_struct_ebitdo_hdr_parse_stream(stream, 0x0, error);

--- a/plugins/elan-kbd/fu-elan-kbd-firmware.c
+++ b/plugins/elan-kbd/fu-elan-kbd-firmware.c
@@ -18,7 +18,7 @@ G_DEFINE_TYPE(FuElanKbdFirmware, fu_elan_kbd_firmware, FU_TYPE_FIRMWARE)
 
 static gboolean
 fu_elan_kbd_firmware_validate(FuFirmware *firmware,
-			      GInputStream *stream,
+			      FuInputStream *stream,
 			      gsize offset,
 			      GError **error)
 {
@@ -27,16 +27,16 @@ fu_elan_kbd_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_elan_kbd_firmware_parse(FuFirmware *firmware,
-			   GInputStream *stream,
+			   FuInputStream *stream,
 			   FuFirmwareParseFlags flags,
 			   GError **error)
 {
 	g_autoptr(FuFirmware) firmware_app = fu_firmware_new();
 	g_autoptr(FuFirmware) firmware_bootloader = fu_firmware_new();
 	g_autoptr(FuFirmware) firmware_option = fu_firmware_new();
-	g_autoptr(GInputStream) stream_app = NULL;
-	g_autoptr(GInputStream) stream_bootloader = NULL;
-	g_autoptr(GInputStream) stream_option = NULL;
+	g_autoptr(FuInputStream) stream_app = NULL;
+	g_autoptr(FuInputStream) stream_bootloader = NULL;
+	g_autoptr(FuInputStream) stream_option = NULL;
 
 	/* bootloader */
 	stream_bootloader = fu_partial_input_stream_new(stream,

--- a/plugins/elan-ts/fu-elan-ts-firmware.c
+++ b/plugins/elan-ts/fu-elan-ts-firmware.c
@@ -42,7 +42,7 @@ fu_elan_ts_firmware_get_remark_id(FuElanTsFirmware *self)
 }
 
 static gboolean
-fu_elan_ts_firmware_parse_remark_id(FuElanTsFirmware *self, GInputStream *stream, GError **error)
+fu_elan_ts_firmware_parse_remark_id(FuElanTsFirmware *self, FuInputStream *stream, GError **error)
 {
 	gsize last_page_offset;
 	gsize offset_in_page;
@@ -113,7 +113,7 @@ fu_elan_ts_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, Xb
 
 static gboolean
 fu_elan_ts_firmware_validate(FuFirmware *firmware,
-			     GInputStream *stream,
+			     FuInputStream *stream,
 			     gsize offset,
 			     GError **error)
 {
@@ -122,7 +122,7 @@ fu_elan_ts_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_elan_ts_firmware_parse(FuFirmware *firmware,
-			  GInputStream *stream,
+			  FuInputStream *stream,
 			  FuFirmwareParseFlags flags,
 			  GError **error)
 {
@@ -135,7 +135,7 @@ fu_elan_ts_firmware_parse(FuFirmware *firmware,
 	g_autoptr(FuStructElanTsFwBinHeaderLvfsType1) st_header = NULL;
 	g_autoptr(GByteArray) checksum_array = g_byte_array_new();
 	g_autoptr(FuFirmware) img_payload = fu_firmware_new();
-	g_autoptr(GInputStream) stream_payload = NULL;
+	g_autoptr(FuInputStream) stream_payload = NULL;
 
 	/* parse header */
 	st_header = fu_struct_elan_ts_fw_bin_header_lvfs_type1_parse_stream(stream, 0x0, error);

--- a/plugins/elanfp/fu-elanfp-firmware.c
+++ b/plugins/elanfp/fu-elanfp-firmware.c
@@ -40,7 +40,7 @@ fu_elanfp_firmware_build(FuFirmware *firmware, XbNode *n, GError **error)
 
 static gboolean
 fu_elanfp_firmware_validate(FuFirmware *firmware,
-			    GInputStream *stream,
+			    FuInputStream *stream,
 			    gsize offset,
 			    GError **error)
 {
@@ -49,7 +49,7 @@ fu_elanfp_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_elanfp_firmware_parse(FuFirmware *firmware,
-			 GInputStream *stream,
+			 FuInputStream *stream,
 			 FuFirmwareParseFlags flags,
 			 GError **error)
 {
@@ -72,7 +72,7 @@ fu_elanfp_firmware_parse(FuFirmware *firmware,
 		guint32 length = 0;
 		guint32 fwtype = 0;
 		g_autoptr(FuFirmware) img = NULL;
-		g_autoptr(GInputStream) stream_tmp = NULL;
+		g_autoptr(FuInputStream) stream_tmp = NULL;
 
 		/* type, reserved, start-addr, len */
 		if (!fu_input_stream_read_u32(stream,

--- a/plugins/elantp/fu-elantp-firmware.c
+++ b/plugins/elantp/fu-elantp-firmware.c
@@ -70,7 +70,7 @@ fu_elantp_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbB
 
 static gboolean
 fu_elantp_firmware_validate(FuFirmware *firmware,
-			    GInputStream *stream,
+			    FuInputStream *stream,
 			    gsize offset,
 			    GError **error)
 {
@@ -97,7 +97,7 @@ fu_elantp_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_elantp_firmware_parse(FuFirmware *firmware,
-			 GInputStream *stream,
+			 FuInputStream *stream,
 			 FuFirmwareParseFlags flags,
 			 GError **error)
 {

--- a/plugins/elantp/fu-elantp-haptic-firmware.c
+++ b/plugins/elantp/fu-elantp-haptic-firmware.c
@@ -35,7 +35,7 @@ fu_elantp_haptic_firmware_export(FuFirmware *firmware,
 
 static gboolean
 fu_elantp_haptic_firmware_validate(FuFirmware *firmware,
-				   GInputStream *stream,
+				   FuInputStream *stream,
 				   gsize offset,
 				   GError **error)
 {
@@ -44,7 +44,7 @@ fu_elantp_haptic_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_elantp_haptic_firmware_parse(FuFirmware *firmware,
-				GInputStream *stream,
+				FuInputStream *stream,
 				FuFirmwareParseFlags flags,
 				GError **error)
 {

--- a/plugins/elantp/fu-elantp-hid-mcu-device.c
+++ b/plugins/elantp/fu-elantp-hid-mcu-device.c
@@ -544,8 +544,8 @@ fu_elantp_hid_mcu_device_write_firmware(FuDevice *device,
 	guint16 checksum = 0;
 	guint16 checksum_device = 0;
 	guint16 iap_addr;
-	g_autoptr(GInputStream) stream = NULL;
-	g_autoptr(GInputStream) stream_offset = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream_offset = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */

--- a/plugins/emmc/fu-emmc-device.c
+++ b/plugins/emmc/fu-emmc-device.c
@@ -376,7 +376,7 @@ fu_emmc_device_write_firmware(FuDevice *device,
 	guint8 ext_csd[512] = {0};
 	guint failure_cnt = 0;
 	g_autofree struct mmc_ioc_multi_cmd *multi_cmd = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 	g_autoptr(FuIoctl) ioctl = fu_udev_device_ioctl_new(FU_UDEV_DEVICE(self));
 

--- a/plugins/ep963x/fu-ep963x-device.c
+++ b/plugins/ep963x/fu-ep963x-device.c
@@ -234,7 +234,7 @@ fu_ep963x_device_write_firmware(FuDevice *device,
 				GError **error)
 {
 	FuEp963xDevice *self = FU_EP963X_DEVICE(device);
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(FuChunkArray) blocks = NULL;
 

--- a/plugins/ep963x/fu-ep963x-firmware.c
+++ b/plugins/ep963x/fu-ep963x-firmware.c
@@ -20,7 +20,7 @@ G_DEFINE_TYPE(FuEp963xFirmware, fu_ep963x_firmware, FU_TYPE_FIRMWARE)
 
 static gboolean
 fu_ep963x_firmware_validate(FuFirmware *firmware,
-			    GInputStream *stream,
+			    FuInputStream *stream,
 			    gsize offset,
 			    GError **error)
 {
@@ -29,7 +29,7 @@ fu_ep963x_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_ep963x_firmware_parse(FuFirmware *firmware,
-			 GInputStream *stream,
+			 FuInputStream *stream,
 			 FuFirmwareParseFlags flags,
 			 GError **error)
 {

--- a/plugins/focal-fp/fu-focal-fp-firmware.c
+++ b/plugins/focal-fp/fu-focal-fp-firmware.c
@@ -52,7 +52,7 @@ fu_focal_fp_firmware_compute_checksum_cb(const guint8 *buf,
 
 static gboolean
 fu_focal_fp_firmware_parse(FuFirmware *firmware,
-			   GInputStream *stream,
+			   FuInputStream *stream,
 			   FuFirmwareParseFlags flags,
 			   GError **error)
 {

--- a/plugins/focal-fp/fu-focal-fp-hid-device.c
+++ b/plugins/focal-fp/fu-focal-fp-hid-device.c
@@ -441,7 +441,7 @@ fu_focal_fp_hid_device_write_firmware(FuDevice *device,
 	FuFocalFpHidDevice *self = FU_FOCAL_FP_HID_DEVICE(device);
 	guint16 us_ic_id = 0;
 	guint32 checksum = 0;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */

--- a/plugins/focal-touch/fu-focal-touch-firmware.c
+++ b/plugins/focal-touch/fu-focal-touch-firmware.c
@@ -47,7 +47,7 @@ fu_focal_touch_firmware_compute_checksum_cb(const guint8 *buf,
 
 static gboolean
 fu_focal_touch_firmware_parse(FuFirmware *firmware,
-			      GInputStream *stream,
+			      FuInputStream *stream,
 			      FuFirmwareParseFlags flags,
 			      GError **error)
 {

--- a/plugins/focal-touch/fu-focal-touch-hid-device.c
+++ b/plugins/focal-touch/fu-focal-touch-hid-device.c
@@ -508,7 +508,7 @@ fu_focal_touch_hid_device_write_firmware(FuDevice *device,
 	guint32 upgrade_id = 0;
 	guint calculate_checksum_delay = 0;
 	g_autoptr(FuChunkArray) chunks = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	if (self->verify_id == 0x5822) {
 		/* FT3637 */

--- a/plugins/fpc/fu-fpc-device.c
+++ b/plugins/fpc/fu-fpc-device.c
@@ -52,7 +52,7 @@ G_DEFINE_TYPE(FuFpcDevice, fu_fpc_device, FU_TYPE_USB_DEVICE)
 
 static FuFirmware *
 fu_fpc_device_prepare_firmware(FuDevice *device,
-			       GInputStream *stream,
+			       FuInputStream *stream,
 			       FuProgress *progress,
 			       FuFirmwareParseFlags flags,
 			       GError **error)
@@ -397,7 +397,7 @@ fu_fpc_device_setup(FuDevice *device, GError **error)
 }
 
 static gboolean
-fu_fpc_device_write_ff2_blocks(FuFpcDevice *self, GInputStream *stream, GError **error)
+fu_fpc_device_write_ff2_blocks(FuFpcDevice *self, FuInputStream *stream, GError **error)
 {
 	g_autoptr(FuChunkArray) chunks = NULL;
 
@@ -441,7 +441,7 @@ fu_fpc_device_write_ff2_firmware(FuFpcDevice *self,
 {
 	gsize offset = 0;
 	guint32 blocks_num;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	stream = fu_firmware_get_stream(FU_FIRMWARE(firmware), error);
 	if (stream == NULL)
@@ -487,7 +487,7 @@ fu_fpc_device_write_ff2_firmware(FuFpcDevice *self,
 		payload_len += st_blksec->buf->len;
 
 		if (direction == FU_FPC_FF2_BLOCK_DIR_OUT) {
-			g_autoptr(GInputStream) partial_stream = NULL;
+			g_autoptr(FuInputStream) partial_stream = NULL;
 			g_autoptr(GByteArray) buf_sec = NULL;
 
 			if (payload_len < FPC_FF2_BLK_SEC_LINK_LEN) {
@@ -563,7 +563,7 @@ fu_fpc_device_write_firmware(FuDevice *device,
 			     GError **error)
 {
 	FuFpcDevice *self = FU_FPC_DEVICE(device);
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 

--- a/plugins/fpc/fu-fpc-ff2-firmware.c
+++ b/plugins/fpc/fu-fpc-ff2-firmware.c
@@ -27,7 +27,7 @@ fu_fpc_ff2_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, Xb
 
 static gboolean
 fu_fpc_ff2_firmware_validate(FuFirmware *firmware,
-			     GInputStream *stream,
+			     FuInputStream *stream,
 			     gsize offset,
 			     GError **error)
 {
@@ -36,7 +36,7 @@ fu_fpc_ff2_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_fpc_ff2_firmware_parse(FuFirmware *firmware,
-			  GInputStream *stream,
+			  FuInputStream *stream,
 			  FuFirmwareParseFlags flags,
 			  GError **error)
 {

--- a/plugins/fresco-pd/fu-fresco-pd-firmware.c
+++ b/plugins/fresco-pd/fu-fresco-pd-firmware.c
@@ -32,7 +32,7 @@ fu_fresco_pd_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, 
 
 static gboolean
 fu_fresco_pd_firmware_parse(FuFirmware *firmware,
-			    GInputStream *stream,
+			    FuInputStream *stream,
 			    FuFirmwareParseFlags flags,
 			    GError **error)
 {

--- a/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
+++ b/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
@@ -590,10 +590,7 @@ fu_genesys_gl32xx_device_dump_firmware(FuDevice *device, FuProgress *progress, G
 	g_autoptr(GBytes) fw = NULL;
 
 	g_autoptr(FuDeviceLocker) locker =
-	    fu_device_locker_new_full(FU_DEVICE(self),
-				      fu_device_detach,
-				      fu_device_attach,
-				      error);
+	    fu_device_locker_new_full(FU_DEVICE(self), fu_device_detach, fu_device_attach, error);
 
 	if (locker == NULL)
 		return NULL;

--- a/plugins/genesys-gl32xx/fu-genesys-gl32xx-firmware.c
+++ b/plugins/genesys-gl32xx/fu-genesys-gl32xx-firmware.c
@@ -21,7 +21,7 @@ G_DEFINE_TYPE(FuGenesysGl32xxFirmware, fu_genesys_gl32xx_firmware, FU_TYPE_FIRMW
 
 static gboolean
 fu_genesys_gl32xx_firmware_parse(FuFirmware *firmware,
-				 GInputStream *stream,
+				 FuInputStream *stream,
 				 FuFirmwareParseFlags flags,
 				 GError **error)
 {
@@ -45,7 +45,7 @@ fu_genesys_gl32xx_firmware_parse(FuFirmware *firmware,
 		gsize streamsz = 0;
 		guint8 chksum_actual = 0;
 		guint8 chksum_expected = 0;
-		g_autoptr(GInputStream) stream_tmp = NULL;
+		g_autoptr(FuInputStream) stream_tmp = NULL;
 
 		if (!fu_input_stream_size(stream, &streamsz, error))
 			return FALSE;

--- a/plugins/genesys/fu-genesys-scaler-firmware.c
+++ b/plugins/genesys/fu-genesys-scaler-firmware.c
@@ -18,7 +18,7 @@ G_DEFINE_TYPE(FuGenesysScalerFirmware, fu_genesys_scaler_firmware, FU_TYPE_FIRMW
 
 static gboolean
 fu_genesys_scaler_firmware_parse(FuFirmware *firmware,
-				 GInputStream *stream,
+				 FuInputStream *stream,
 				 FuFirmwareParseFlags flags,
 				 GError **error)
 {
@@ -26,7 +26,7 @@ fu_genesys_scaler_firmware_parse(FuFirmware *firmware,
 	gsize streamsz = 0;
 	g_autoptr(FuFirmware) firmware_payload = fu_firmware_new();
 	g_autoptr(FuFirmware) firmware_public_key = NULL;
-	g_autoptr(GInputStream) stream_payload = NULL;
+	g_autoptr(FuInputStream) stream_payload = NULL;
 	g_autoptr(GBytes) blob_public_key = NULL;
 
 	if (!fu_input_stream_size(stream, &streamsz, error))

--- a/plugins/genesys/fu-genesys-usbhub-codesign-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-codesign-firmware.c
@@ -28,7 +28,7 @@ fu_genesys_usbhub_codesign_firmware_get_codesign(FuGenesysUsbhubCodesignFirmware
 
 static gboolean
 fu_genesys_usbhub_codesign_firmware_validate(FuFirmware *firmware,
-					     GInputStream *stream,
+					     FuInputStream *stream,
 					     gsize offset,
 					     GError **error)
 {
@@ -56,7 +56,7 @@ fu_genesys_usbhub_codesign_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_genesys_usbhub_codesign_firmware_parse(FuFirmware *firmware,
-					  GInputStream *stream,
+					  FuInputStream *stream,
 					  FuFirmwareParseFlags flags,
 					  GError **error)
 {

--- a/plugins/genesys/fu-genesys-usbhub-dev-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-dev-firmware.c
@@ -19,7 +19,7 @@ G_DEFINE_TYPE(FuGenesysUsbhubDevFirmware, fu_genesys_usbhub_dev_firmware, FU_TYP
 
 static gboolean
 fu_genesys_usbhub_dev_firmware_validate(FuFirmware *firmware,
-					GInputStream *stream,
+					FuInputStream *stream,
 					gsize offset,
 					GError **error)
 {
@@ -28,12 +28,12 @@ fu_genesys_usbhub_dev_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_genesys_usbhub_dev_firmware_parse(FuFirmware *firmware,
-				     GInputStream *stream,
+				     FuInputStream *stream,
 				     FuFirmwareParseFlags flags,
 				     GError **error)
 {
 	gsize code_size = 0;
-	g_autoptr(GInputStream) stream_trunc = NULL;
+	g_autoptr(FuInputStream) stream_trunc = NULL;
 
 	fu_firmware_set_id(firmware, fu_genesys_fw_type_to_string(FU_GENESYS_FW_TYPE_DEV_BRIDGE));
 	fu_firmware_set_idx(firmware, FU_GENESYS_FW_TYPE_DEV_BRIDGE);

--- a/plugins/genesys/fu-genesys-usbhub-device.c
+++ b/plugins/genesys/fu-genesys-usbhub-device.c
@@ -870,7 +870,7 @@ fu_genesys_usbhub_device_get_fw_bank_version(FuGenesysUsbhubDevice *self,
 	gsize bufsz = 0;
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(GBytes) blob = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autofree guint8 *buf = NULL;
 
 	g_return_val_if_fail(fw_type < FU_GENESYS_FW_TYPE_INSIDE_HUB_COUNT, FALSE);
@@ -1955,7 +1955,7 @@ fu_genesys_usbhub_device_compare_fw_public_key(FuGenesysUsbhubDevice *self,
 					       GError **error)
 {
 	FuGenesysFwCodesign codesign_type = FU_GENESYS_FW_CODESIGN_NONE;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	g_return_val_if_fail(FU_IS_GENESYS_USBHUB_CODESIGN_FIRMWARE(firmware), FALSE);
 
@@ -2828,7 +2828,7 @@ fu_genesys_usbhub_device_examine_fw_codesign_hw(FuGenesysUsbhubDevice *self,
 {
 	gsize codesize_to_hash = 0;
 	g_autoptr(FuFirmware) codesign_img = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuStructGenesysFwCodesignInfoEcdsa) st_codesign = NULL;
 	g_autoptr(GPtrArray) imgs = fu_firmware_get_images(firmware);
 

--- a/plugins/genesys/fu-genesys-usbhub-device.c
+++ b/plugins/genesys/fu-genesys-usbhub-device.c
@@ -912,7 +912,7 @@ fu_genesys_usbhub_device_get_fw_bank_version(FuGenesysUsbhubDevice *self,
 
 	/* verify bank firmware integrity */
 	blob = g_bytes_new_take(g_steal_pointer(&buf), bufsz);
-	stream = g_memory_input_stream_new_from_bytes(blob);
+	stream = fu_memory_input_stream_new_from_bytes(blob);
 	if (!fu_genesys_usbhub_firmware_verify_checksum(stream, &error_local)) {
 		g_debug("ignoring firmware %s bank%d: %s",
 			fu_genesys_fw_type_to_string(fw_type),

--- a/plugins/genesys/fu-genesys-usbhub-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-firmware.c
@@ -24,7 +24,7 @@ G_DEFINE_TYPE(FuGenesysUsbhubFirmware, fu_genesys_usbhub_firmware, FU_TYPE_FIRMW
 
 static gboolean
 fu_genesys_usbhub_firmware_get_chip(FuGenesysUsbhubFirmware *self,
-				    GInputStream *stream,
+				    FuInputStream *stream,
 				    GError **error)
 {
 	guint8 project_ic_type[6] = {0};
@@ -136,12 +136,12 @@ fu_genesys_usbhub_firmware_get_chip(FuGenesysUsbhubFirmware *self,
 }
 
 gboolean
-fu_genesys_usbhub_firmware_verify_checksum(GInputStream *stream, GError **error)
+fu_genesys_usbhub_firmware_verify_checksum(FuInputStream *stream, GError **error)
 {
 	gsize streamsz = 0;
 	guint16 fw_checksum = 0;
 	guint16 checksum = 0;
-	g_autoptr(GInputStream) stream_tmp = NULL;
+	g_autoptr(FuInputStream) stream_tmp = NULL;
 
 	/* get checksum */
 	if (!fu_input_stream_size(stream, &streamsz, error))
@@ -182,7 +182,7 @@ fu_genesys_usbhub_firmware_verify_checksum(GInputStream *stream, GError **error)
 }
 
 gboolean
-fu_genesys_usbhub_firmware_calculate_size(GInputStream *stream, gsize *size, GError **error)
+fu_genesys_usbhub_firmware_calculate_size(FuInputStream *stream, gsize *size, GError **error)
 {
 	guint8 kbs = 0;
 	if (!fu_input_stream_read_u8(stream, GENESYS_USBHUB_CODE_SIZE_OFFSET, &kbs, error)) {
@@ -228,7 +228,7 @@ fu_genesys_usbhub_firmware_ensure_version(FuFirmware *firmware, GError **error)
 
 static gboolean
 fu_genesys_usbhub_firmware_validate(FuFirmware *firmware,
-				    GInputStream *stream,
+				    FuInputStream *stream,
 				    gsize offset,
 				    GError **error)
 {
@@ -237,7 +237,7 @@ fu_genesys_usbhub_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_genesys_usbhub_firmware_parse(FuFirmware *firmware,
-				 GInputStream *stream,
+				 FuInputStream *stream,
 				 FuFirmwareParseFlags flags,
 				 GError **error)
 {
@@ -246,7 +246,7 @@ fu_genesys_usbhub_firmware_parse(FuFirmware *firmware,
 	gsize offset = 0;
 	gsize streamsz = 0;
 	guint32 static_ts_offset = 0;
-	g_autoptr(GInputStream) stream_trunc = NULL;
+	g_autoptr(FuInputStream) stream_trunc = NULL;
 
 	/* get chip */
 	if (!fu_genesys_usbhub_firmware_get_chip(self, stream, error)) {

--- a/plugins/genesys/fu-genesys-usbhub-firmware.h
+++ b/plugins/genesys/fu-genesys-usbhub-firmware.h
@@ -16,8 +16,8 @@ G_DECLARE_FINAL_TYPE(FuGenesysUsbhubFirmware,
 		     FuFirmware)
 
 gboolean
-fu_genesys_usbhub_firmware_verify_checksum(GInputStream *stream, GError **error);
+fu_genesys_usbhub_firmware_verify_checksum(FuInputStream *stream, GError **error);
 gboolean
-fu_genesys_usbhub_firmware_calculate_size(GInputStream *stream, gsize *size, GError **error);
+fu_genesys_usbhub_firmware_calculate_size(FuInputStream *stream, gsize *size, GError **error);
 gboolean
 fu_genesys_usbhub_firmware_ensure_version(FuFirmware *firmware, GError **error);

--- a/plugins/genesys/fu-genesys-usbhub-pd-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-pd-firmware.c
@@ -19,7 +19,7 @@ G_DEFINE_TYPE(FuGenesysUsbhubPdFirmware, fu_genesys_usbhub_pd_firmware, FU_TYPE_
 
 static gboolean
 fu_genesys_usbhub_pd_firmware_validate(FuFirmware *firmware,
-				       GInputStream *stream,
+				       FuInputStream *stream,
 				       gsize offset,
 				       GError **error)
 {
@@ -28,12 +28,12 @@ fu_genesys_usbhub_pd_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_genesys_usbhub_pd_firmware_parse(FuFirmware *firmware,
-				    GInputStream *stream,
+				    FuInputStream *stream,
 				    FuFirmwareParseFlags flags,
 				    GError **error)
 {
 	gsize code_size = 0;
-	g_autoptr(GInputStream) stream_trunc = NULL;
+	g_autoptr(FuInputStream) stream_trunc = NULL;
 
 	fu_firmware_set_id(firmware, fu_genesys_fw_type_to_string(FU_GENESYS_FW_TYPE_PD));
 	fu_firmware_set_idx(firmware, FU_GENESYS_FW_TYPE_PD);

--- a/plugins/goodix-tp/fu-goodixtp-brlb-config.c
+++ b/plugins/goodix-tp/fu-goodixtp-brlb-config.c
@@ -17,7 +17,7 @@ G_DEFINE_TYPE(FuGoodixtpBrlbConfig, fu_goodixtp_brlb_config, FU_TYPE_FIRMWARE)
 
 static gboolean
 fu_goodixtp_brlb_config_parse(FuFirmware *firmware,
-			      GInputStream *stream,
+			      FuInputStream *stream,
 			      FuFirmwareParseFlags flags,
 			      GError **error)
 {

--- a/plugins/goodix-tp/fu-goodixtp-brlb-device.c
+++ b/plugins/goodix-tp/fu-goodixtp-brlb-device.c
@@ -416,7 +416,7 @@ fu_goodixtp_brlb_device_setup(FuDevice *device, GError **error)
 
 static FuFirmware *
 fu_goodixtp_brlb_device_prepare_firmware(FuDevice *device,
-					 GInputStream *stream,
+					 FuInputStream *stream,
 					 FuProgress *progress,
 					 FuFirmwareParseFlags flags,
 					 GError **error)
@@ -439,7 +439,7 @@ fu_goodixtp_brlb_device_write_image(FuGoodixtpBrlbDevice *self,
 				    GError **error)
 {
 	g_autoptr(FuChunkArray) chunks = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	stream = fu_firmware_get_stream(img, error);
 	if (stream == NULL)

--- a/plugins/goodix-tp/fu-goodixtp-brlb-firmware.c
+++ b/plugins/goodix-tp/fu-goodixtp-brlb-firmware.c
@@ -21,7 +21,7 @@ G_DEFINE_TYPE(FuGoodixtpBrlbFirmware, fu_goodixtp_brlb_firmware, FU_TYPE_GOODIXT
 
 static gboolean
 fu_goodixtp_brlb_firmware_parse_config(FuGoodixtpFirmware *self,
-				       GInputStream *stream,
+				       FuInputStream *stream,
 				       gsize offset,
 				       guint8 sensor_id,
 				       guint8 *cfg_ver,
@@ -35,7 +35,7 @@ fu_goodixtp_brlb_firmware_parse_config(FuGoodixtpFirmware *self,
 	guint16 cfg_checksum = 0;
 	g_autoptr(FuFirmware) img = fu_goodixtp_brlb_config_new();
 	g_autoptr(FuStructGoodixTpCfgGroup) st_cfg = NULL;
-	g_autoptr(GInputStream) stream_img = NULL;
+	g_autoptr(FuInputStream) stream_img = NULL;
 
 	st_cfg = fu_struct_goodix_tp_cfg_group_parse_stream(stream, offset, error);
 	if (st_cfg == NULL)
@@ -106,7 +106,7 @@ fu_goodixtp_brlb_firmware_parse_config(FuGoodixtpFirmware *self,
 
 gboolean
 fu_goodixtp_brlb_firmware_parse(FuGoodixtpFirmware *self,
-				GInputStream *stream,
+				FuInputStream *stream,
 				guint8 sensor_id,
 				GError **error)
 {
@@ -175,7 +175,7 @@ fu_goodixtp_brlb_firmware_parse(FuGoodixtpFirmware *self,
 		guint32 img_size;
 		g_autoptr(FuFirmware) img = fu_firmware_new();
 		g_autoptr(FuStructGoodixBrlbImg) st_img = NULL;
-		g_autoptr(GInputStream) stream_img = NULL;
+		g_autoptr(FuInputStream) stream_img = NULL;
 
 		st_img = fu_struct_goodix_brlb_img_parse_stream(stream, offset_hdr, error);
 		if (st_img == NULL)

--- a/plugins/goodix-tp/fu-goodixtp-brlb-firmware.h
+++ b/plugins/goodix-tp/fu-goodixtp-brlb-firmware.h
@@ -18,7 +18,7 @@ G_DECLARE_FINAL_TYPE(FuGoodixtpBrlbFirmware,
 
 gboolean
 fu_goodixtp_brlb_firmware_parse(FuGoodixtpFirmware *self,
-				GInputStream *stream,
+				FuInputStream *stream,
 				guint8 sensor_id,
 				GError **error);
 FuFirmware *

--- a/plugins/goodix-tp/fu-goodixtp-gtx8-device.c
+++ b/plugins/goodix-tp/fu-goodixtp-gtx8-device.c
@@ -467,7 +467,7 @@ fu_goodixtp_gtx8_device_setup(FuDevice *device, GError **error)
 
 static FuFirmware *
 fu_goodixtp_gtx8_device_prepare_firmware(FuDevice *device,
-					 GInputStream *stream,
+					 FuInputStream *stream,
 					 FuProgress *progress,
 					 FuFirmwareParseFlags flags,
 					 GError **error)
@@ -490,7 +490,7 @@ fu_goodixtp_gtx8_device_write_image(FuGoodixtpGtx8Device *self,
 				    GError **error)
 {
 	g_autoptr(FuChunkArray) chunks = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	stream = fu_firmware_get_stream(img, error);
 	if (stream == NULL)

--- a/plugins/goodix-tp/fu-goodixtp-gtx8-firmware.c
+++ b/plugins/goodix-tp/fu-goodixtp-gtx8-firmware.c
@@ -20,7 +20,7 @@ G_DEFINE_TYPE(FuGoodixtpGtx8Firmware, fu_goodixtp_gtx8_firmware, FU_TYPE_GOODIXT
 
 gboolean
 fu_goodixtp_gtx8_firmware_parse(FuGoodixtpFirmware *self,
-				GInputStream *stream,
+				FuInputStream *stream,
 				guint8 sensor_id,
 				GError **error)
 {

--- a/plugins/goodix-tp/fu-goodixtp-gtx8-firmware.h
+++ b/plugins/goodix-tp/fu-goodixtp-gtx8-firmware.h
@@ -18,7 +18,7 @@ G_DECLARE_FINAL_TYPE(FuGoodixtpGtx8Firmware,
 
 gboolean
 fu_goodixtp_gtx8_firmware_parse(FuGoodixtpFirmware *self,
-				GInputStream *stream,
+				FuInputStream *stream,
 				guint8 sensor_id,
 				GError **error);
 FuFirmware *

--- a/plugins/himax-tp/fu-himax-tp-firmware.c
+++ b/plugins/himax-tp/fu-himax-tp-firmware.c
@@ -107,7 +107,7 @@ fu_himax_tp_firmware_checksum_cb(const guint8 *buf, gsize bufsz, gpointer user_d
 
 static gboolean
 fu_himax_tp_firmware_parse_map_code(FuHimaxTpFirmware *self,
-				    GInputStream *stream,
+				    FuInputStream *stream,
 				    gsize offset,
 				    gboolean *done,
 				    GError **error)
@@ -205,7 +205,7 @@ fu_himax_tp_firmware_parse_map_code(FuHimaxTpFirmware *self,
 
 static gboolean
 fu_himax_tp_firmware_parse(FuFirmware *firmware,
-			   GInputStream *stream,
+			   FuInputStream *stream,
 			   FuFirmwareParseFlags flags,
 			   GError **error)
 {

--- a/plugins/huddly-usb/fu-huddly-usb-device.c
+++ b/plugins/huddly-usb/fu-huddly-usb-device.c
@@ -24,7 +24,7 @@ struct _FuHuddlyUsbDevice {
 	guint bulk_ep[EP_LAST];
 	gboolean interfaces_claimed;
 	gboolean pending_verify;
-	GInputStream *input_stream;
+	FuInputStream *input_stream;
 	gchar *product_state;
 	gboolean need_reboot;
 };
@@ -293,7 +293,7 @@ fu_huddly_usb_device_reboot(FuHuddlyUsbDevice *self, GError **error)
 static gboolean
 fu_huddly_usb_device_hcp_write_file(FuHuddlyUsbDevice *self,
 				    const gchar *filename,
-				    GInputStream *stream,
+				    FuInputStream *stream,
 				    FuProgress *progress,
 				    GError **error)
 {

--- a/plugins/hughski-colorhug/fu-hughski-colorhug-device.c
+++ b/plugins/hughski-colorhug/fu-hughski-colorhug-device.c
@@ -601,7 +601,7 @@ fu_hughski_colorhug_device_write_firmware(FuDevice *device,
 					  GError **error)
 {
 	FuHughskiColorhugDevice *self = FU_HUGHSKI_COLORHUG_DEVICE(device);
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */

--- a/plugins/ilitek-its/fu-ilitek-its-block.c
+++ b/plugins/ilitek-its/fu-ilitek-its-block.c
@@ -24,13 +24,13 @@ fu_ilitek_its_block_export(FuFirmware *firmware, FuFirmwareExportFlags flags, Xb
 
 static gboolean
 fu_ilitek_its_block_parse(FuFirmware *firmware,
-			  GInputStream *stream,
+			  FuInputStream *stream,
 			  FuFirmwareParseFlags flags,
 			  GError **error)
 {
 	FuIlitekItsBlock *self = FU_ILITEK_ITS_BLOCK(firmware);
 	gsize streamsz = 0;
-	g_autoptr(GInputStream) partial_stream = NULL;
+	g_autoptr(FuInputStream) partial_stream = NULL;
 
 	/* calculate CRC of block minus the CRC16 itself */
 	if (!fu_input_stream_size(stream, &streamsz, error))

--- a/plugins/ilitek-its/fu-ilitek-its-firmware.c
+++ b/plugins/ilitek-its/fu-ilitek-its-firmware.c
@@ -31,7 +31,7 @@ fu_ilitek_its_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags,
 
 static gboolean
 fu_ilitek_its_firmware_parse(FuFirmware *firmware,
-			     GInputStream *stream,
+			     FuInputStream *stream,
 			     FuFirmwareParseFlags flags,
 			     GError **error)
 {

--- a/plugins/intel-cvs/fu-intel-cvs-device.c
+++ b/plugins/intel-cvs/fu-intel-cvs-device.c
@@ -171,7 +171,7 @@ fu_intel_cvs_device_write_firmware(FuDevice *device,
 	g_autoptr(FuIOChannel) io_payload = NULL;
 	g_autoptr(FuStructIntelCvsWrite) st_write = fu_struct_intel_cvs_write_new();
 	g_autoptr(GError) error_local = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* get default image */
 	stream = fu_firmware_get_stream(firmware, error);

--- a/plugins/intel-cvs/fu-intel-cvs-firmware.c
+++ b/plugins/intel-cvs/fu-intel-cvs-firmware.c
@@ -29,7 +29,7 @@ fu_intel_cvs_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, 
 
 static gboolean
 fu_intel_cvs_firmware_validate(FuFirmware *firmware,
-			       GInputStream *stream,
+			       FuInputStream *stream,
 			       gsize offset,
 			       GError **error)
 {
@@ -38,7 +38,7 @@ fu_intel_cvs_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_intel_cvs_firmware_parse(FuFirmware *firmware,
-			    GInputStream *stream,
+			    FuInputStream *stream,
 			    FuFirmwareParseFlags flags,
 			    GError **error)
 {

--- a/plugins/intel-gsc/fu-igsc-aux-device.c
+++ b/plugins/intel-gsc/fu-igsc-aux-device.c
@@ -87,7 +87,7 @@ fu_igsc_aux_device_setup(FuDevice *device, GError **error)
 
 static FuFirmware *
 fu_igsc_aux_device_prepare_firmware(FuDevice *device,
-				    GInputStream *stream,
+				    FuInputStream *stream,
 				    FuProgress *progress,
 				    FuFirmwareParseFlags flags,
 				    GError **error)
@@ -145,7 +145,7 @@ fu_igsc_aux_device_write_firmware(FuDevice *device,
 {
 	FuDevice *proxy;
 	g_autoptr(GBytes) fw_info = NULL;
-	g_autoptr(GInputStream) stream_payload = NULL;
+	g_autoptr(FuInputStream) stream_payload = NULL;
 
 	/* get image */
 	fw_info =

--- a/plugins/intel-gsc/fu-igsc-aux-firmware.c
+++ b/plugins/intel-gsc/fu-igsc-aux-firmware.c
@@ -81,7 +81,7 @@ static gboolean
 fu_igsc_aux_firmware_parse_info(FuIgscAuxFirmware *self, GError **error)
 {
 	g_autoptr(FuStructIgscFwdataVersion) st = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	stream = fu_firmware_get_image_by_idx_stream(FU_FIRMWARE(self),
 						     FU_IFWI_FPT_FIRMWARE_IDX_INFO,
@@ -104,7 +104,7 @@ fu_igsc_aux_firmware_parse_info(FuIgscAuxFirmware *self, GError **error)
 
 static gboolean
 fu_igsc_aux_firmware_parse(FuFirmware *firmware,
-			   GInputStream *stream,
+			   FuInputStream *stream,
 			   FuFirmwareParseFlags flags,
 			   GError **error)
 {
@@ -112,7 +112,7 @@ fu_igsc_aux_firmware_parse(FuFirmware *firmware,
 	gboolean has_manifest_ext = FALSE;
 	g_autoptr(FuFirmware) fw_cpd = fu_ifwi_cpd_firmware_new();
 	g_autoptr(FuFirmware) fw_manifest = NULL;
-	g_autoptr(GInputStream) stream_dataimg = NULL;
+	g_autoptr(FuInputStream) stream_dataimg = NULL;
 	g_autoptr(GPtrArray) imgs = NULL;
 
 	/* FuIfwiFptFirmware->parse */

--- a/plugins/intel-gsc/fu-igsc-code-firmware.c
+++ b/plugins/intel-gsc/fu-igsc-code-firmware.c
@@ -43,7 +43,7 @@ fu_igsc_code_firmware_get_arb_svn(FuIgscCodeFirmware *self)
 }
 
 static gboolean
-fu_igsc_code_firmware_parse_imgi(FuIgscCodeFirmware *self, GInputStream *stream, GError **error)
+fu_igsc_code_firmware_parse_imgi(FuIgscCodeFirmware *self, FuInputStream *stream, GError **error)
 {
 	g_autoptr(FuStructIgscFwuGwsImageInfo) st_inf = NULL;
 
@@ -57,7 +57,7 @@ fu_igsc_code_firmware_parse_imgi(FuIgscCodeFirmware *self, GInputStream *stream,
 
 static gboolean
 fu_igsc_code_firmware_parse(FuFirmware *firmware,
-			    GInputStream *stream,
+			    FuInputStream *stream,
 			    FuFirmwareParseFlags flags,
 			    GError **error)
 {
@@ -66,8 +66,8 @@ fu_igsc_code_firmware_parse(FuFirmware *firmware,
 	g_autofree gchar *version = NULL;
 	g_autoptr(FuStructIgscFwuFwImageData) st_imgdata = NULL;
 	g_autoptr(FuStructIgscFwuImageMetadataV1) st_md1 = NULL;
-	g_autoptr(GInputStream) stream_imgi = NULL;
-	g_autoptr(GInputStream) stream_info = NULL;
+	g_autoptr(FuInputStream) stream_imgi = NULL;
+	g_autoptr(FuInputStream) stream_info = NULL;
 
 	/* FuIfwiFptFirmware->parse */
 	if (!FU_FIRMWARE_CLASS(fu_igsc_code_firmware_parent_class)

--- a/plugins/intel-gsc/fu-igsc-common.c
+++ b/plugins/intel-gsc/fu-igsc-common.c
@@ -38,7 +38,7 @@ fu_igsc_fwdata_device_info_export(GPtrArray *device_infos, XbBuilderNode *bn)
 
 static gboolean
 fu_igsc_fwdata_device_info_parse_device_type(GPtrArray *device_infos,
-					     GInputStream *stream,
+					     FuInputStream *stream,
 					     GError **error)
 {
 	gsize streamsz = 0;
@@ -68,7 +68,7 @@ fu_igsc_fwdata_device_info_parse_device_type(GPtrArray *device_infos,
 
 static gboolean
 fu_igsc_fwdata_device_info_parse_device_id_array(GPtrArray *device_infos,
-						 GInputStream *stream,
+						 FuInputStream *stream,
 						 GError **error)
 {
 	gsize streamsz = 0;
@@ -91,7 +91,7 @@ gboolean
 fu_igsc_fwdata_device_info_parse(GPtrArray *device_infos, FuFirmware *fw, GError **error)
 {
 	FuIgscFwuExtType ext_type = fu_firmware_get_idx(fw);
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* get data */
 	stream = fu_firmware_get_stream(fw, error);

--- a/plugins/intel-gsc/fu-igsc-device.c
+++ b/plugins/intel-gsc/fu-igsc-device.c
@@ -572,7 +572,7 @@ static gboolean
 fu_igsc_device_update_start(FuIgscDevice *self,
 			    guint32 payload_type,
 			    GBytes *fw_info,
-			    GInputStream *fw,
+			    FuInputStream *fw,
 			    GError **error)
 {
 	guint8 res_buf[FU_IGSC_FWU_HECI_START_RES_SIZE] = {0};
@@ -703,7 +703,7 @@ gboolean
 fu_igsc_device_write_blob(FuIgscDevice *self,
 			  FuIgscFwuHeciPayloadType payload_type,
 			  GBytes *fw_info,
-			  GInputStream *stream,
+			  FuInputStream *stream,
 			  FuProgress *progress,
 			  GError **error)
 {
@@ -828,7 +828,7 @@ fu_igsc_device_write_firmware(FuDevice *device,
 {
 	FuIgscDevice *self = FU_IGSC_DEVICE(device);
 	g_autoptr(GBytes) fw_info = NULL;
-	g_autoptr(GInputStream) stream_payload = NULL;
+	g_autoptr(FuInputStream) stream_payload = NULL;
 
 	/* get image, and install on ourself */
 	fw_info =

--- a/plugins/intel-gsc/fu-igsc-device.h
+++ b/plugins/intel-gsc/fu-igsc-device.h
@@ -28,7 +28,7 @@ gboolean
 fu_igsc_device_write_blob(FuIgscDevice *self,
 			  FuIgscFwuHeciPayloadType payload_type,
 			  GBytes *fw_info,
-			  GInputStream *stream,
+			  FuInputStream *stream,
 			  FuProgress *progress,
 			  GError **error) G_GNUC_NON_NULL(1, 3);
 

--- a/plugins/intel-gsc/fu-igsc-oprom-device.c
+++ b/plugins/intel-gsc/fu-igsc-oprom-device.c
@@ -118,14 +118,14 @@ fu_igsc_oprom_device_setup(FuDevice *device, GError **error)
 
 static FuFirmware *
 fu_igsc_oprom_device_prepare_firmware(FuDevice *device,
-				      GInputStream *stream,
+				      FuInputStream *stream,
 				      FuProgress *progress,
 				      FuFirmwareParseFlags flags,
 				      GError **error)
 {
 	FuIgscOpromDevice *self = FU_IGSC_OPROM_DEVICE(device);
 	FuDevice *proxy;
-	g_autoptr(GInputStream) stream_igsc = NULL;
+	g_autoptr(FuInputStream) stream_igsc = NULL;
 	g_autoptr(FuFirmware) firmware_igsc = g_object_new(FU_TYPE_IGSC_OPROM_FIRMWARE, NULL);
 	g_autoptr(FuFirmware) firmware_oprom = NULL;
 	g_autoptr(FuFirmware) fw_linear = fu_linear_firmware_new(FU_TYPE_OPROM_FIRMWARE);
@@ -243,8 +243,8 @@ fu_igsc_oprom_device_write_firmware(FuDevice *device,
 	FuDevice *proxy;
 	g_autoptr(FuStructIgscFwuHeciImageMetadata) st_md = NULL;
 	g_autoptr(GBytes) fw_info = NULL;
-	g_autoptr(GInputStream) partial_stream = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) partial_stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* get image, with no padding bytes */
 	stream = fu_firmware_get_stream(firmware, error);

--- a/plugins/intel-gsc/fu-igsc-oprom-firmware.c
+++ b/plugins/intel-gsc/fu-igsc-oprom-firmware.c
@@ -78,7 +78,7 @@ fu_igsc_oprom_firmware_match_device(FuIgscOpromFirmware *self,
 
 static gboolean
 fu_igsc_oprom_firmware_parse(FuFirmware *firmware,
-			     GInputStream *stream,
+			     FuInputStream *stream,
 			     FuFirmwareParseFlags flags,
 			     GError **error)
 {

--- a/plugins/jabra-file/fu-jabra-file-device.c
+++ b/plugins/jabra-file/fu-jabra-file-device.c
@@ -629,7 +629,7 @@ fu_jabra_file_device_write_firmware(FuDevice *device,
 	gboolean match = FALSE;
 	g_autofree gchar *firmware_checksum = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* check if firmware file already exists on device */
 	firmware_checksum = fu_firmware_get_checksum(firmware, G_CHECKSUM_MD5, error);

--- a/plugins/jabra-file/fu-jabra-file-firmware.c
+++ b/plugins/jabra-file/fu-jabra-file-firmware.c
@@ -70,7 +70,7 @@ fu_jabra_file_firmware_parse_info(FuJabraFileFirmware *self, XbSilo *silo, GErro
 
 static gboolean
 fu_jabra_file_firmware_parse(FuFirmware *firmware,
-			     GInputStream *stream,
+			     FuInputStream *stream,
 			     FuFirmwareParseFlags flags,
 			     GError **error)
 {

--- a/plugins/jabra-gnp/fu-jabra-gnp-child-device.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-child-device.c
@@ -211,7 +211,7 @@ fu_jabra_gnp_child_device_write_image(FuJabraGnpChildDevice *self,
 {
 	const guint chunk_size = 52;
 	g_autoptr(FuChunkArray) chunks = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/jabra-gnp/fu-jabra-gnp-device.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-device.c
@@ -371,7 +371,7 @@ fu_jabra_gnp_device_write_image(FuJabraGnpDevice *self,
 {
 	const guint chunk_size = 52;
 	g_autoptr(FuChunkArray) chunks = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/jabra-gnp/fu-jabra-gnp-firmware.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-firmware.c
@@ -97,7 +97,7 @@ fu_jabra_gnp_firmware_parse_info(FuJabraGnpFirmware *self, XbSilo *silo, GError 
 
 static gboolean
 fu_jabra_gnp_firmware_parse(FuFirmware *firmware,
-			    GInputStream *stream,
+			    FuInputStream *stream,
 			    FuFirmwareParseFlags flags,
 			    GError **error)
 {

--- a/plugins/kinetic-dp/fu-kinetic-dp-puma-device.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-puma-device.c
@@ -17,9 +17,9 @@
 #define PUMA_DPCD_DATA_SIZE	0x8000ul /* 0x80000ul ~ 0x87FFF, 32 KB*/
 #define PUMA_DPCD_DATA_ADDR_END (PUMA_DPCD_DATA_ADDR + PUMA_DPCD_DATA_SIZE - 1)
 
-#define PUMA_CHUNK_PROCESS_MAX_WAIT		    10000 /* max wait time in ms to process 32KB chunk */
-#define FU_KINETIC_DP_PUMA_REQUEST_FLASH_ERASE_TIME 2  /* typical erase time, ms */
-#define POLL_INTERVAL_MS			    20 /* check the status of installing FW images */
+#define PUMA_CHUNK_PROCESS_MAX_WAIT 10000 /* max wait time in ms to process 32KB chunk */
+#define FU_KINETIC_DP_PUMA_REQUEST_FLASH_ERASE_TIME 2 /* typical erase time, ms */
+#define POLL_INTERVAL_MS 20			      /* check the status of installing FW images */
 
 struct _FuKineticDpPumaDevice {
 	FuKineticDpDevice parent_instance;

--- a/plugins/kinetic-dp/fu-kinetic-dp-puma-firmware.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-puma-firmware.c
@@ -59,7 +59,7 @@ fu_kinetic_dp_puma_firmware_export(FuFirmware *firmware,
 }
 
 static gboolean
-fu_kinetic_dp_puma_firmware_parse_chip_id(GInputStream *stream,
+fu_kinetic_dp_puma_firmware_parse_chip_id(FuInputStream *stream,
 					  FuKineticDpChip *chip_id,
 					  GError **error)
 {
@@ -96,7 +96,7 @@ fu_kinetic_dp_puma_firmware_parse_chip_id(GInputStream *stream,
 
 static gboolean
 fu_kinetic_dp_puma_firmware_parse_app_fw(FuKineticDpPumaFirmware *self,
-					 GInputStream *stream,
+					 FuInputStream *stream,
 					 GError **error)
 {
 	FuKineticDpPumaFirmwarePrivate *priv = GET_PRIVATE(self);
@@ -256,7 +256,7 @@ fu_kinetic_dp_puma_firmware_parse_app_fw(FuKineticDpPumaFirmware *self,
 
 static gboolean
 fu_kinetic_dp_puma_firmware_parse(FuFirmware *firmware,
-				  GInputStream *stream,
+				  FuInputStream *stream,
 				  FuFirmwareParseFlags flags,
 				  GError **error)
 {
@@ -265,8 +265,8 @@ fu_kinetic_dp_puma_firmware_parse(FuFirmware *firmware,
 	gsize app_fw_size;
 	gsize streamsz = 0;
 	guint32 isp_drv_size = 0;
-	g_autoptr(GInputStream) isp_drv_stream = NULL;
-	g_autoptr(GInputStream) app_fw_stream = NULL;
+	g_autoptr(FuInputStream) isp_drv_stream = NULL;
+	g_autoptr(FuInputStream) app_fw_stream = NULL;
 	g_autoptr(FuFirmware) isp_drv_img = fu_firmware_new();
 	g_autoptr(FuFirmware) app_fw_img = fu_firmware_new();
 

--- a/plugins/kinetic-dp/fu-kinetic-dp-secure-firmware.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-secure-firmware.c
@@ -51,7 +51,7 @@ fu_kinetic_dp_secure_firmware_export(FuFirmware *firmware,
 }
 
 static gboolean
-fu_kinetic_dp_secure_firmware_parse_chip_id(GInputStream *stream,
+fu_kinetic_dp_secure_firmware_parse_chip_id(FuInputStream *stream,
 					    FuKineticDpChip *chip_id,
 					    gboolean *esm_xip_enabled,
 					    GError **error)
@@ -139,7 +139,7 @@ fu_kinetic_dp_secure_firmware_get_esm_xip_enabled(FuKineticDpSecureFirmware *sel
 
 static gboolean
 fu_kinetic_dp_secure_firmware_parse_app_fw(FuKineticDpSecureFirmware *self,
-					   GInputStream *stream,
+					   FuInputStream *stream,
 					   GError **error)
 {
 	FuKineticDpSecureFirmwarePrivate *priv = GET_PRIVATE(self);
@@ -186,7 +186,7 @@ fu_kinetic_dp_secure_firmware_parse_app_fw(FuKineticDpSecureFirmware *self,
 
 static gboolean
 fu_kinetic_dp_secure_firmware_parse(FuFirmware *firmware,
-				    GInputStream *stream,
+				    FuInputStream *stream,
 				    FuFirmwareParseFlags flags,
 				    GError **error)
 {
@@ -194,8 +194,8 @@ fu_kinetic_dp_secure_firmware_parse(FuFirmware *firmware,
 	FuKineticDpSecureFirmwarePrivate *priv = GET_PRIVATE(self);
 	gsize streamsz = 0;
 	guint32 app_fw_payload_size = 0;
-	g_autoptr(GInputStream) isp_drv_stream = NULL;
-	g_autoptr(GInputStream) app_fw_stream = NULL;
+	g_autoptr(FuInputStream) isp_drv_stream = NULL;
+	g_autoptr(FuInputStream) app_fw_stream = NULL;
 	g_autoptr(FuFirmware) isp_drv_img = fu_firmware_new();
 	g_autoptr(FuFirmware) app_fw_img = fu_firmware_new();
 

--- a/plugins/legion-hid/fu-legion-hid-device.c
+++ b/plugins/legion-hid/fu-legion-hid-device.c
@@ -283,7 +283,7 @@ fu_legion_hid_device_read_upgrade_query_size_response(FuLegionHidDevice *self,
 static gboolean
 fu_legion_hid_device_upgrade_start(FuLegionHidDevice *self,
 				   FuLegionHidDeviceId id,
-				   GInputStream *stream,
+				   FuInputStream *stream,
 				   GError **error)
 {
 	FuLegionHidRetryHelper helper = {0};
@@ -491,7 +491,7 @@ static gboolean
 fu_legion_hid_device_upgrade_write_data(FuLegionHidDevice *self,
 					FuLegionHidDeviceId id,
 					guint16 max_size,
-					GInputStream *stream,
+					FuInputStream *stream,
 					GError **error)
 {
 	g_autoptr(FuChunkArray) chunks = NULL;
@@ -630,7 +630,7 @@ fu_legion_hid_device_get_version(FuLegionHidDevice *self,
 }
 
 static gboolean
-fu_legion_hid_device_get_id(GInputStream *stream, FuLegionHidDeviceId *id, GError **error)
+fu_legion_hid_device_get_id(FuInputStream *stream, FuLegionHidDeviceId *id, GError **error)
 {
 	guint offset = 0;
 	gsize streamsz = 0;
@@ -671,7 +671,7 @@ fu_legion_hid_device_execute_upgrade(FuLegionHidDevice *self, FuFirmware *firmwa
 {
 	FuLegionHidDeviceId id = 0;
 	guint16 max_size = 0;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	stream = fu_firmware_get_stream(firmware, error);
 	if (stream == NULL)

--- a/plugins/legion-hid/fu-legion-hid-firmware.c
+++ b/plugins/legion-hid/fu-legion-hid-firmware.c
@@ -17,7 +17,7 @@ G_DEFINE_TYPE(FuLegionHidFirmware, fu_legion_hid_firmware, FU_TYPE_FIRMWARE)
 
 static gboolean
 fu_legion_hid_firmware_parse(FuFirmware *firmware,
-			     GInputStream *stream,
+			     FuInputStream *stream,
 			     FuFirmwareParseFlags flags,
 			     GError **error)
 {
@@ -26,9 +26,9 @@ fu_legion_hid_firmware_parse(FuFirmware *firmware,
 	g_autoptr(FuFirmware) img_mcu = fu_firmware_new();
 	g_autoptr(FuFirmware) img_right = fu_firmware_new();
 	g_autoptr(FuStructLegionHidBinHeader) st_header = NULL;
-	g_autoptr(GInputStream) stream_left = NULL;
-	g_autoptr(GInputStream) stream_mcu = NULL;
-	g_autoptr(GInputStream) stream_right = NULL;
+	g_autoptr(FuInputStream) stream_left = NULL;
+	g_autoptr(FuInputStream) stream_mcu = NULL;
+	g_autoptr(FuInputStream) stream_right = NULL;
 
 	st_header = fu_struct_legion_hid_bin_header_parse_stream(stream, 0x00, error);
 	if (st_header == NULL)

--- a/plugins/legion-hid2/fu-legion-hid2-firmware.c
+++ b/plugins/legion-hid2/fu-legion-hid2-firmware.c
@@ -19,14 +19,14 @@ G_DEFINE_TYPE(FuLegionHid2Firmware, fu_legion_hid2_firmware, FU_TYPE_FIRMWARE)
 
 static gboolean
 fu_legion_hid2_firmware_parse(FuFirmware *firmware,
-			      GInputStream *stream,
+			      FuInputStream *stream,
 			      FuFirmwareParseFlags flags,
 			      GError **error)
 {
 	g_autoptr(FuFirmware) img_payload = fu_firmware_new();
 	g_autoptr(FuFirmware) img_sig = fu_firmware_new();
-	g_autoptr(GInputStream) stream_payload = NULL;
-	g_autoptr(GInputStream) stream_sig = NULL;
+	g_autoptr(FuInputStream) stream_payload = NULL;
+	g_autoptr(FuInputStream) stream_sig = NULL;
 	g_autoptr(FuStructLegionHid2Header) st_header = NULL;
 	g_autoptr(FuStructLegionHid2Version) st_version = NULL;
 

--- a/plugins/legion-hid2/fu-legion-hid2-iap-device.c
+++ b/plugins/legion-hid2/fu-legion-hid2-iap-device.c
@@ -233,7 +233,7 @@ fu_legion_hid2_iap_device_write_data(FuLegionHid2IapDevice *self,
 				     FuProgress *progress,
 				     GError **error)
 {
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	stream = fu_firmware_get_image_by_id_stream(firmware, FU_FIRMWARE_ID_PAYLOAD, error);
@@ -260,7 +260,7 @@ fu_legion_hid2_iap_device_write_sig(FuLegionHid2IapDevice *self,
 				    FuProgress *progress,
 				    GError **error)
 {
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	stream = fu_firmware_get_image_by_id_stream(firmware, FU_FIRMWARE_ID_SIGNATURE, error);

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-ble-device.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-ble-device.c
@@ -28,7 +28,7 @@ G_DEFINE_TYPE_WITH_CODE(FuLenovoAccessoryBleDevice,
 static gboolean
 fu_lenovo_accessory_ble_device_write_files(FuLenovoAccessoryBleDevice *self,
 					   FuLenovoAccessoryDfuFileType file_type,
-					   GInputStream *stream,
+					   FuInputStream *stream,
 					   FuProgress *progress,
 					   GError **error)
 {
@@ -71,7 +71,7 @@ fu_lenovo_accessory_ble_device_write_firmware(FuDevice *device,
 	guint32 file_crc = 0xFFFFFFFF;
 	guint32 device_crc = 0;
 	FuLenovoAccessoryDeviceMode mode;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-hid-bootloader.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-hid-bootloader.c
@@ -26,7 +26,7 @@ G_DEFINE_TYPE_WITH_CODE(FuLenovoAccessoryHidBootloader,
 static gboolean
 fu_lenovo_accessory_hid_bootloader_write_files(FuLenovoAccessoryHidBootloader *self,
 					       FuLenovoAccessoryDfuFileType file_type,
-					       GInputStream *stream,
+					       FuInputStream *stream,
 					       FuProgress *progress,
 					       GError **error)
 {
@@ -155,7 +155,7 @@ fu_lenovo_accessory_hid_bootloader_write_firmware(FuDevice *device,
 {
 	gsize fw_size = 0;
 	guint32 file_crc = 0xFFFFFFFF;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-hid-child-device.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-hid-child-device.c
@@ -276,7 +276,7 @@ fu_lenovo_accessory_hid_child_device_setup(FuDevice *device, GError **error)
 static gboolean
 fu_lenovo_accessory_hid_child_device_write_files(FuLenovoAccessoryHidChildDevice *self,
 						 FuLenovoAccessoryDfuFileType file_type,
-						 GInputStream *stream,
+						 FuInputStream *stream,
 						 FuProgress *progress,
 						 GError **error)
 {
@@ -319,7 +319,7 @@ fu_lenovo_accessory_hid_child_device_write_firmware(FuDevice *device,
 	guint32 file_crc = 0xFFFFFFFF;
 	guint32 device_crc = 0;
 	FuLenovoAccessoryDeviceMode mode;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-hid-dual-device.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-hid-dual-device.c
@@ -25,7 +25,7 @@ G_DEFINE_TYPE_WITH_CODE(FuLenovoAccessoryHidDualDevice,
 static gboolean
 fu_lenovo_accessory_hid_dual_device_write_files(FuLenovoAccessoryHidDualDevice *self,
 						FuLenovoAccessoryDfuFileType file_type,
-						GInputStream *stream,
+						FuInputStream *stream,
 						FuProgress *progress,
 						GError **error)
 {
@@ -68,7 +68,7 @@ fu_lenovo_accessory_hid_dual_device_write_firmware(FuDevice *device,
 	guint32 file_crc = 0xFFFFFFFF;
 	guint32 device_crc = 0;
 	FuLenovoAccessoryDeviceMode mode;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/lenovo-dock/fu-lenovo-dock-firmware.c
+++ b/plugins/lenovo-dock/fu-lenovo-dock-firmware.c
@@ -79,8 +79,8 @@ fu_lenovo_dock_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags
 
 static gboolean
 fu_lenovo_dock_firmware_parse_image(FuLenovoDockFirmware *self,
-				    GInputStream *stream_usage,
-				    GInputStream *stream_composite,
+				    FuInputStream *stream_usage,
+				    FuInputStream *stream_composite,
 				    gsize offset,
 				    FuFirmwareParseFlags flags,
 				    GError **error)
@@ -91,7 +91,7 @@ fu_lenovo_dock_firmware_parse_image(FuLenovoDockFirmware *self,
 	guint32 max_size;
 	FuLenovoDockComponentId component_id;
 	g_autoptr(FuStructLenovoDockUsageItem) st_item = NULL;
-	g_autoptr(GInputStream) stream_partial = NULL;
+	g_autoptr(FuInputStream) stream_partial = NULL;
 	g_autoptr(FuFirmware) img = fu_lenovo_dock_image_new();
 
 	st_item = fu_struct_lenovo_dock_usage_item_parse_stream(stream_usage, offset, error);
@@ -153,7 +153,7 @@ fu_lenovo_dock_firmware_parse_image(FuLenovoDockFirmware *self,
 	target_crc32 = fu_struct_lenovo_dock_usage_item_get_target_crc32(st_item);
 	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		guint32 crc_calculated = G_MAXUINT32;
-		g_autoptr(GInputStream) stream_crc = NULL;
+		g_autoptr(FuInputStream) stream_crc = NULL;
 
 		stream_crc = fu_partial_input_stream_new(stream_composite,
 							 (gsize)physical_addr +
@@ -186,7 +186,7 @@ fu_lenovo_dock_firmware_parse_image(FuLenovoDockFirmware *self,
 
 static gboolean
 fu_lenovo_dock_firmware_parse(FuFirmware *firmware,
-			      GInputStream *stream,
+			      FuInputStream *stream,
 			      FuFirmwareParseFlags flags,
 			      GError **error)
 {
@@ -195,8 +195,8 @@ fu_lenovo_dock_firmware_parse(FuFirmware *firmware,
 	guint8 usage_items;
 	g_autoptr(FuFirmware) firmware_zip = fu_zip_firmware_new();
 	g_autoptr(FuStructLenovoDockUsage) st = NULL;
-	g_autoptr(GInputStream) stream_usage = NULL;
-	g_autoptr(GInputStream) stream_composite = NULL;
+	g_autoptr(FuInputStream) stream_usage = NULL;
+	g_autoptr(FuInputStream) stream_composite = NULL;
 
 	if (!fu_firmware_parse_stream(firmware_zip, stream, 0x0, flags, error))
 		return FALSE;

--- a/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
+++ b/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
@@ -991,7 +991,7 @@ fu_logitech_bulkcontroller_device_upd_send_init_cmd_cb(FuDevice *device,
 
 static gboolean
 fu_logitech_bulkcontroller_device_write_fw(FuLogitechBulkcontrollerDevice *self,
-					   GInputStream *stream,
+					   FuInputStream *stream,
 					   FuProgress *progress,
 					   GError **error)
 {
@@ -1148,7 +1148,7 @@ fu_logitech_bulkcontroller_device_write_firmware(FuDevice *device,
 	g_autoptr(GByteArray) md5_buf = NULL;
 	g_autoptr(GByteArray) end_pkt = g_byte_array_new();
 	g_autoptr(GByteArray) start_pkt = g_byte_array_new();
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(GBytes) end_pkt_blob = NULL;
 	g_autoptr(GBytes) start_pkt_blob = NULL;
 

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
@@ -1812,7 +1812,7 @@ fu_logitech_hidpp_device_write_firmware_dfu_img(FuLogitechHidppDevice *self,
 	guint8 fw_entity = 0;
 	guint8 idx;
 	g_autoptr(FuChunkArray) chunks = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* if we're in bootloader mode, we should be able to get this feature */
 	idx = fu_logitech_hidpp_device_feature_get_idx(self, FU_LOGITECH_HIDPP_FEATURE_DFU);

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-unifying.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-unifying.c
@@ -174,7 +174,7 @@ fu_logitech_hidpp_runtime_unifying_setup(FuDevice *device, GError **error)
 
 static FuFirmware *
 fu_logitech_hidpp_runtime_unifying_prepare_firmware(FuDevice *device,
-						    GInputStream *stream,
+						    FuInputStream *stream,
 						    FuProgress *progress,
 						    FuFirmwareParseFlags flags,
 						    GError **error)

--- a/plugins/logitech-hidpp/fu-logitech-rdfu-firmware.c
+++ b/plugins/logitech-hidpp/fu-logitech-rdfu-firmware.c
@@ -46,7 +46,7 @@ fu_logitech_rdfu_firmware_parse(FuFirmware *firmware,
 	}
 
 	json_node = fwupd_json_parser_load_from_stream(json_parser,
-						       stream,
+						       G_INPUT_STREAM(stream),
 						       FWUPD_JSON_LOAD_FLAG_NONE,
 						       error);
 	if (json_node == NULL)

--- a/plugins/logitech-hidpp/fu-logitech-rdfu-firmware.c
+++ b/plugins/logitech-hidpp/fu-logitech-rdfu-firmware.c
@@ -19,7 +19,7 @@ G_DEFINE_TYPE(FuLogitechRdfuFirmware, fu_logitech_rdfu_firmware, FU_TYPE_FIRMWAR
 
 static gboolean
 fu_logitech_rdfu_firmware_parse(FuFirmware *firmware,
-				GInputStream *stream,
+				FuInputStream *stream,
 				FuFirmwareParseFlags flags,
 				GError **error)
 {

--- a/plugins/logitech-rallysystem/fu-logitech-rallysystem-tablehub-device.c
+++ b/plugins/logitech-rallysystem/fu-logitech-rallysystem-tablehub-device.c
@@ -131,7 +131,7 @@ fu_logitech_rallysystem_tablehub_device_recv(FuLogitechRallysystemTablehubDevice
 
 static gboolean
 fu_logitech_rallysystem_tablehub_device_write_fw(FuLogitechRallysystemTablehubDevice *self,
-						 GInputStream *stream,
+						 FuInputStream *stream,
 						 FuProgress *progress,
 						 GError **error)
 {
@@ -212,7 +212,7 @@ fu_logitech_rallysystem_tablehub_device_write_firmware(FuDevice *device,
 	FuLogitechRallysystemTablehubDevice *self = FU_LOGITECH_RALLYSYSTEM_TABLEHUB_DEVICE(device);
 	gsize streamsz = 0;
 	guint8 buf[FU_STRUCT_USB_FIRMWARE_DOWNLOAD_RESPONSE_SIZE] = {0x0};
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuStructUsbFirmwareDownloadRequest) st_req =
 	    fu_struct_usb_firmware_download_request_new();
 	g_autoptr(FuStructUsbFirmwareDownloadResponse) st_res = NULL;

--- a/plugins/logitech-scribe/fu-logitech-scribe-device.c
+++ b/plugins/logitech-scribe/fu-logitech-scribe-device.c
@@ -210,7 +210,7 @@ fu_logitech_scribe_device_compute_hash_cb(const guint8 *buf,
 }
 
 static gchar *
-fu_logitech_scribe_device_compute_hash(GInputStream *stream, GError **error)
+fu_logitech_scribe_device_compute_hash(FuInputStream *stream, GError **error)
 {
 	guint8 md5buf[HASH_VALUE_SIZE] = {0};
 	gsize data_len = sizeof(md5buf);
@@ -367,7 +367,7 @@ fu_logitech_scribe_device_send_upd_init_cmd_cb(FuDevice *device, gpointer user_d
 static gboolean
 fu_logitech_scribe_device_write_fw(FuLogitechScribeDevice *self,
 				   FuUsbDevice *usb_device,
-				   GInputStream *stream,
+				   FuInputStream *stream,
 				   FuProgress *progress,
 				   GError **error)
 {
@@ -417,7 +417,7 @@ fu_logitech_scribe_device_write_firmware(FuDevice *device,
 	g_autofree gchar *base64hash = NULL;
 	g_autoptr(GByteArray) end_pkt = g_byte_array_new();
 	g_autoptr(GByteArray) start_pkt = g_byte_array_new();
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(FuUsbInterface) intf = NULL;
 	g_autoptr(GPtrArray) endpoints = NULL;

--- a/plugins/logitech-tap/fu-logitech-tap-hdmi-device.c
+++ b/plugins/logitech-tap/fu-logitech-tap-hdmi-device.c
@@ -391,7 +391,7 @@ fu_logitech_tap_hdmi_device_write_firmware(FuDevice *device,
 {
 	FuLogitechTapHdmiDevice *self = FU_LOGITECH_TAP_HDMI_DEVICE(device);
 	g_autofree gchar *old_firmware_version = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* for troubleshooting purpose */

--- a/plugins/logitech-tap/fu-logitech-tap-touch-device.c
+++ b/plugins/logitech-tap/fu-logitech-tap-touch-device.c
@@ -577,7 +577,7 @@ fu_logitech_tap_touch_device_write_blocks(FuLogitechTapTouchDevice *self,
 {
 	guint16 device_checksum = 0;
 	g_autoptr(FuChunkArray) chunks = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	stream = fu_firmware_get_stream(img, error);
 	if (stream == NULL)

--- a/plugins/logitech-tap/fu-logitech-tap-touch-firmware.c
+++ b/plugins/logitech-tap/fu-logitech-tap-touch-firmware.c
@@ -62,7 +62,7 @@ fu_logitech_tap_touch_firmware_export(FuFirmware *firmware,
 
 static gboolean
 fu_logitech_tap_touch_firmware_validate(FuFirmware *firmware,
-					GInputStream *stream,
+					FuInputStream *stream,
 					gsize offset,
 					GError **error)
 {
@@ -121,7 +121,7 @@ fu_logitech_tap_touch_firmware_calculate_basic_cb(const guint8 *buf,
 
 static gboolean
 fu_logitech_tap_touch_firmware_parse(FuFirmware *firmware,
-				     GInputStream *stream,
+				     FuInputStream *stream,
 				     FuFirmwareParseFlags flags,
 				     GError **error)
 {
@@ -138,10 +138,10 @@ fu_logitech_tap_touch_firmware_parse(FuFirmware *firmware,
 	guint8 protocol_id = 0;
 	g_autoptr(FuFirmware) ap_img = fu_firmware_new();
 	g_autoptr(FuFirmware) df_img = fu_firmware_new();
-	g_autoptr(GInputStream) ap_stream = NULL;
+	g_autoptr(FuInputStream) ap_stream = NULL;
 	/* temp stream to calculate ap crc, it is few bytes smaller */
-	g_autoptr(GInputStream) ap_stream_crc = NULL;
-	g_autoptr(GInputStream) df_stream = NULL;
+	g_autoptr(FuInputStream) ap_stream_crc = NULL;
+	g_autoptr(FuInputStream) df_stream = NULL;
 	const gchar *image_end_magic =
 	    "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFFILITek AP CRC   ";
 

--- a/plugins/lxs-touch/fu-lxs-touch-device.c
+++ b/plugins/lxs-touch/fu-lxs-touch-device.c
@@ -167,8 +167,8 @@ fu_lxs_touch_device_ensure_version(FuLxsTouchDevice *self, GError **error)
 	fu_device_set_version(FU_DEVICE(self), version);
 
 	/* bootloader version: informational only, not used for comparison */
-	version_bootloader = g_strdup_printf("%04X",
-					     fu_struct_lxs_touch_version_get_boot_ver(st_ver));
+	version_bootloader =
+	    g_strdup_printf("%04X", fu_struct_lxs_touch_version_get_boot_ver(st_ver));
 	fu_device_set_version_bootloader(FU_DEVICE(self), version_bootloader);
 
 	/* success */

--- a/plugins/lxs-touch/fu-lxs-touch-device.c
+++ b/plugins/lxs-touch/fu-lxs-touch-device.c
@@ -536,7 +536,7 @@ fu_lxs_touch_device_write_firmware(FuDevice *device,
 {
 	FuLxsTouchDevice *self = FU_LXS_TOUCH_DEVICE(device);
 	guint32 fw_offset = fu_lxs_touch_firmware_get_offset(FU_LXS_TOUCH_FIRMWARE(firmware));
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autofree gchar *protocol_name = NULL;
 
 	/* verify in DFUP mode */

--- a/plugins/lxs-touch/fu-lxs-touch-firmware.c
+++ b/plugins/lxs-touch/fu-lxs-touch-firmware.c
@@ -23,7 +23,7 @@ G_DEFINE_TYPE(FuLxsTouchFirmware, fu_lxs_touch_firmware, FU_TYPE_FIRMWARE)
 
 static gboolean
 fu_lxs_touch_firmware_parse(FuFirmware *firmware,
-			    GInputStream *stream,
+			    FuInputStream *stream,
 			    FuFirmwareParseFlags flags,
 			    GError **error)
 {

--- a/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
+++ b/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
@@ -596,7 +596,7 @@ fu_mediatek_scaler_device_run_isp(FuMediatekScalerDevice *self, guint16 chksum, 
 
 static gboolean
 fu_mediatek_scaler_device_commit_firmware(FuMediatekScalerDevice *self,
-					  GInputStream *stream,
+					  FuInputStream *stream,
 					  GError **error)
 {
 	guint16 sum16 = 0;
@@ -753,7 +753,7 @@ fu_mediatek_scaler_device_write_chunk_cb(FuDevice *device, gpointer user_data, G
 
 static gboolean
 fu_mediatek_scaler_device_write_firmware_impl(FuMediatekScalerDevice *self,
-					      GInputStream *stream,
+					      FuInputStream *stream,
 					      FuProgress *progress,
 					      GError **error)
 {
@@ -815,7 +815,7 @@ fu_mediatek_scaler_device_write_firmware(FuDevice *device,
 {
 	FuMediatekScalerDevice *self = FU_MEDIATEK_SCALER_DEVICE(device);
 	gsize fw_size = 0;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/mediatek-scaler/fu-mediatek-scaler-firmware.c
+++ b/plugins/mediatek-scaler/fu-mediatek-scaler-firmware.c
@@ -24,7 +24,7 @@ G_DEFINE_TYPE(FuMediatekScalerFirmware, fu_mediatek_scaler_firmware, FU_TYPE_FIR
 
 static gboolean
 fu_mediatek_scaler_firmware_parse(FuFirmware *firmware,
-				  GInputStream *stream,
+				  FuInputStream *stream,
 				  FuFirmwareParseFlags flags,
 				  GError **error)
 {

--- a/plugins/modem-manager/fu-mm-dfota-device.c
+++ b/plugins/modem-manager/fu-mm-dfota-device.c
@@ -211,7 +211,7 @@ fu_mm_dfota_device_parse_upload_result(FuMmDfotaDevice *self,
 }
 
 static gboolean
-fu_mm_dfota_device_upload_stream(FuMmDfotaDevice *self, GInputStream *stream, GError **error)
+fu_mm_dfota_device_upload_stream(FuMmDfotaDevice *self, FuInputStream *stream, GError **error)
 {
 	gsize size = 0;
 	gsize size_parsed = 0;
@@ -423,7 +423,7 @@ fu_mm_dfota_device_write_firmware(FuDevice *device,
 {
 	FuMmDfotaDevice *self = FU_MM_DFOTA_DEVICE(device);
 	g_autofree gchar *upload_cmd = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* get default stream */
 	stream = fu_firmware_get_stream(firmware, error);

--- a/plugins/modem-manager/fu-mm-mhi-qcdm-device.c
+++ b/plugins/modem-manager/fu-mm-mhi-qcdm-device.c
@@ -124,7 +124,7 @@ fu_mm_mhi_qcdm_device_cleanup(FuDevice *device,
 
 static FuFirmware *
 fu_mm_mhi_qcdm_device_prepare_firmware(FuDevice *device,
-				       GInputStream *stream,
+				       FuInputStream *stream,
 				       FuProgress *progress,
 				       FuFirmwareParseFlags flags,
 				       GError **error)

--- a/plugins/modem-manager/fu-mm-qdu-mbim-device.c
+++ b/plugins/modem-manager/fu-mm-qdu-mbim-device.c
@@ -202,7 +202,7 @@ fu_mm_qdu_mbim_device_write_firmware(FuDevice *device,
 	g_autoptr(FuFirmware) archive = fu_zip_firmware_new();
 	g_autoptr(GBytes) data_part = NULL;
 	g_autoptr(GBytes) data_xml = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(XbBuilder) builder = xb_builder_new();
 	g_autoptr(XbBuilderSource) source = xb_builder_source_new();
 	g_autoptr(XbSilo) silo = NULL;

--- a/plugins/modem-manager/fu-mm-qmi-device.c
+++ b/plugins/modem-manager/fu-mm-qmi-device.c
@@ -798,7 +798,7 @@ fu_mm_qmi_device_write_firmware(FuDevice *device,
 	FuMmQmiDevice *self = FU_MM_QMI_DEVICE(device);
 	g_autoptr(FuFirmware) archive = fu_zip_firmware_new();
 	g_autoptr(GError) error_local = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(GPtrArray) file_infos =
 	    g_ptr_array_new_with_free_func((GDestroyNotify)fu_mm_qmi_device_file_info_free);
 	g_autoptr(GPtrArray) imgs = NULL;

--- a/plugins/msr/fu-msr-plugin.c
+++ b/plugins/msr/fu-msr-plugin.c
@@ -620,8 +620,9 @@ fu_msr_plugin_add_security_attr_amd_sme_enabled(FuPlugin *plugin, FuSecurityAttr
 		return;
 
 	/* if pci_psp has already verified TSME is active, skip our check */
-	attr_existing =
-	    fu_security_attrs_get_by_appstream_id(attrs, FWUPD_SECURITY_ATTR_ID_ENCRYPTED_RAM, NULL);
+	attr_existing = fu_security_attrs_get_by_appstream_id(attrs,
+							      FWUPD_SECURITY_ATTR_ID_ENCRYPTED_RAM,
+							      NULL);
 	if (attr_existing != NULL &&
 	    fwupd_security_attr_has_flag(attr_existing, FWUPD_SECURITY_ATTR_FLAG_SUCCESS)) {
 		g_debug("ignoring: TSME already verified by pci_psp");

--- a/plugins/mtd/fu-mtd-device.c
+++ b/plugins/mtd/fu-mtd-device.c
@@ -85,7 +85,7 @@ fu_mtd_device_read_stream(FuMtdDevice *self, FuProgress *progress, GError **erro
 		blob = fu_device_event_get_bytes(event, "Data", error);
 		if (blob == NULL)
 			return NULL;
-		return g_memory_input_stream_new_from_bytes(blob);
+		return fu_memory_input_stream_new_from_bytes(blob);
 	}
 
 	/* save */

--- a/plugins/mtd/fu-mtd-device.c
+++ b/plugins/mtd/fu-mtd-device.c
@@ -61,13 +61,13 @@ fu_mtd_device_convert_version(FuDevice *device, guint64 version_raw)
 	return NULL;
 }
 
-static GInputStream *
+static FuInputStream *
 fu_mtd_device_read_stream(FuMtdDevice *self, FuProgress *progress, GError **error)
 {
 	FuDeviceEvent *event = NULL;
 	const gchar *fn;
 	g_autofree gchar *event_id = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* need event ID */
 	if (fu_device_has_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_EMULATED) ||
@@ -126,7 +126,7 @@ fu_mtd_device_read_firmware(FuDevice *device, FuProgress *progress, GError **err
 	FuMtdDevice *self = FU_MTD_DEVICE(device);
 	GType firmware_gtype = fu_device_get_firmware_gtype(device);
 	g_autoptr(FuFirmware) firmware = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* fall back to a generic firmware when no specific type was detected */
 	if (firmware_gtype == G_TYPE_INVALID)
@@ -168,12 +168,12 @@ fu_mtd_device_metadata_ensure_version_from_image(FuMtdDevice *self,
 }
 
 static gboolean
-fu_mtd_device_metadata_load_uswid(FuMtdDevice *self, GInputStream *stream, GError **error)
+fu_mtd_device_metadata_load_uswid(FuMtdDevice *self, FuInputStream *stream, GError **error)
 {
 	FuMtdDevicePrivate *priv = GET_PRIVATE(self);
 	g_autoptr(FuFirmware) img0 = NULL;
 	g_autoptr(FuFirmware) firmware = fu_uswid_firmware_new();
-	g_autoptr(GInputStream) stream_partial = NULL;
+	g_autoptr(FuInputStream) stream_partial = NULL;
 
 	/* cut it down to something reasonable, then parse */
 	if (priv->metadata_offset > 0 || priv->metadata_size > 0) {
@@ -209,13 +209,13 @@ fu_mtd_device_metadata_load_uswid(FuMtdDevice *self, GInputStream *stream, GErro
 }
 
 static gboolean
-fu_mtd_device_metadata_load_fmap(FuMtdDevice *self, GInputStream *stream, GError **error)
+fu_mtd_device_metadata_load_fmap(FuMtdDevice *self, FuInputStream *stream, GError **error)
 {
 	FuMtdDevicePrivate *priv = GET_PRIVATE(self);
 	g_autoptr(FuFirmware) firmware = fu_fmap_firmware_new();
 	g_autoptr(FuFirmware) firmware_sbom = fu_uswid_firmware_new();
 	g_autoptr(FuFirmware) img0 = NULL;
-	g_autoptr(GInputStream) stream_sbom = NULL;
+	g_autoptr(FuInputStream) stream_sbom = NULL;
 	g_autoptr(GPtrArray) imgs = NULL;
 
 	/* parse as firmware image */
@@ -269,7 +269,7 @@ fu_mtd_device_metadata_load_fmap(FuMtdDevice *self, GInputStream *stream, GError
 }
 
 static gboolean
-fu_mtd_device_metadata_load_ifd(FuMtdDevice *self, GInputStream *stream, GError **error)
+fu_mtd_device_metadata_load_ifd(FuMtdDevice *self, FuInputStream *stream, GError **error)
 {
 	FuMtdDevicePrivate *priv = GET_PRIVATE(self);
 	g_autoptr(FuFirmware) firmware = fu_ifd_firmware_new();
@@ -313,7 +313,7 @@ static gboolean
 fu_mtd_device_metadata_load_versions(FuMtdDevice *self, GError **error)
 {
 	GType firmware_gtype = fu_device_get_firmware_gtype(FU_DEVICE(self));
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* read firmware from stream */
 	stream = fu_mtd_device_read_stream(self, NULL, error);
@@ -776,7 +776,7 @@ fu_mtd_device_probe(FuDevice *device, GError **error)
 
 static gboolean
 fu_mtd_device_erase(FuMtdDevice *self,
-		    GInputStream *stream,
+		    FuInputStream *stream,
 		    gsize offset,
 		    FuProgress *progress,
 		    GError **error)
@@ -929,7 +929,7 @@ fu_mtd_device_verify(FuMtdDevice *self, FuChunkArray *chunks, FuProgress *progre
 
 static gboolean
 fu_mtd_device_write_verify(FuMtdDevice *self,
-			   GInputStream *stream,
+			   FuInputStream *stream,
 			   gsize offset,
 			   FuProgress *progress,
 			   GError **error)
@@ -999,7 +999,7 @@ fu_mtd_device_dump_firmware(FuDevice *device, FuProgress *progress, GError **err
 
 static gboolean
 fu_mtd_device_write_stream(FuMtdDevice *self,
-			   GInputStream *stream,
+			   FuInputStream *stream,
 			   gsize offset,
 			   FuProgress *progress,
 			   GError **error)
@@ -1037,7 +1037,7 @@ fu_mtd_device_write_stream(FuMtdDevice *self,
 gboolean
 fu_mtd_device_write_image(FuMtdDevice *self, FuFirmware *img, FuProgress *progress, GError **error)
 {
-	g_autoptr(GInputStream) img_stream = NULL;
+	g_autoptr(FuInputStream) img_stream = NULL;
 
 	img_stream = fu_firmware_get_stream(img, error);
 	if (img_stream == NULL)
@@ -1054,7 +1054,7 @@ fu_mtd_device_write_image(FuMtdDevice *self, FuFirmware *img, FuProgress *progre
 
 static FuFirmware *
 fu_mtd_device_fmap_prepare_firmware(FuMtdDevice *self,
-				    GInputStream *stream,
+				    FuInputStream *stream,
 				    FuFirmwareParseFlags flags,
 				    GError **error)
 {
@@ -1107,7 +1107,7 @@ fu_mtd_device_fmap_prepare_firmware(FuMtdDevice *self,
 
 static FuFirmware *
 fu_mtd_device_prepare_firmware(FuDevice *device,
-			       GInputStream *stream,
+			       FuInputStream *stream,
 			       FuProgress *progress,
 			       FuFirmwareParseFlags flags,
 			       GError **error)
@@ -1136,7 +1136,7 @@ fu_mtd_device_write_firmware(FuDevice *device,
 	FuMtdDevice *self = FU_MTD_DEVICE(device);
 	FuMtdDevicePrivate *priv = GET_PRIVATE(self);
 	gsize streamsz = 0;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* get data to write */
 	stream = fu_firmware_get_stream(firmware, error);

--- a/plugins/mtd/fu-mtd-ifd-device.c
+++ b/plugins/mtd/fu-mtd-ifd-device.c
@@ -141,7 +141,7 @@ fu_mtd_ifd_device_probe(FuDevice *device, GError **error)
 
 static FuFirmware *
 fu_mtd_ifd_device_prepare_firmware(FuDevice *device,
-				   GInputStream *stream,
+				   FuInputStream *stream,
 				   FuProgress *progress,
 				   FuFirmwareParseFlags flags,
 				   GError **error)

--- a/plugins/mtd/fu-self-test.c
+++ b/plugins/mtd/fu-self-test.c
@@ -554,9 +554,9 @@ fu_test_mtd_device_read_firmware_invalid_gtype_func(gconstpointer user_data)
 	/* with no specific firmware type set we should fall back to a generic
 	 * FuFirmware rather than crashing on g_object_new(G_TYPE_INVALID) */
 	firmware = fu_device_read_firmware(FU_DEVICE(device),
-					  progress,
-					  FU_FIRMWARE_PARSE_FLAG_NONE,
-					  &error);
+					   progress,
+					   FU_FIRMWARE_PARSE_FLAG_NONE,
+					   &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(firmware);
 }

--- a/plugins/nordic-hid/fu-nordic-hid-archive.c
+++ b/plugins/nordic-hid/fu-nordic-hid-archive.c
@@ -181,7 +181,7 @@ fu_nordic_hid_archive_parse_file_get_flash_area_id(FwupdJsonObject *obj,
 
 static gboolean
 fu_nordic_hid_archive_parse(FuFirmware *firmware,
-			    GInputStream *stream,
+			    FuInputStream *stream,
 			    FuFirmwareParseFlags flags,
 			    GError **error)
 {

--- a/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
+++ b/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
@@ -1514,7 +1514,7 @@ fu_nordic_hid_cfg_channel_write_firmware_chunk(FuNordicHidCfgChannel *self,
 
 static gboolean
 fu_nordic_hid_cfg_channel_write_firmware_blob(FuNordicHidCfgChannel *self,
-					      GInputStream *stream,
+					      FuInputStream *stream,
 					      FuProgress *progress,
 					      GError **error)
 {
@@ -1570,7 +1570,7 @@ fu_nordic_hid_cfg_channel_write_firmware(FuDevice *device,
 	guint64 val = 0;
 	g_autofree gchar *csum_str = NULL;
 	g_autofree gchar *image_id = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuNordicCfgChannelDfuInfo) dfu_info = g_new0(FuNordicCfgChannelDfuInfo, 1);
 
 	/* select correct firmware per target board, bootloader and bank */

--- a/plugins/nordic-hid/fu-nordic-hid-firmware-b0.c
+++ b/plugins/nordic-hid/fu-nordic-hid-firmware-b0.c
@@ -40,7 +40,7 @@ fu_nordic_hid_firmware_b0_write(FuFirmware *firmware, GError **error)
 
 static gboolean
 fu_nordic_hid_firmware_b0_read_fwinfo(FuNordicHidFirmwareB0 *self,
-				      GInputStream *stream,
+				      FuInputStream *stream,
 				      GError **error)
 {
 	guint32 magic_common;
@@ -112,7 +112,7 @@ fu_nordic_hid_firmware_b0_read_fwinfo(FuNordicHidFirmwareB0 *self,
 
 static gboolean
 fu_nordic_hid_firmware_b0_parse(FuFirmware *firmware,
-				GInputStream *stream,
+				FuInputStream *stream,
 				FuFirmwareParseFlags flags,
 				GError **error)
 {

--- a/plugins/nordic-hid/fu-nordic-hid-firmware-mcuboot.c
+++ b/plugins/nordic-hid/fu-nordic-hid-firmware-mcuboot.c
@@ -61,7 +61,7 @@ fu_nordic_hid_firmware_mcuboot_write(FuFirmware *firmware, GError **error)
 /* simple validation of the image */
 static gboolean
 fu_nordic_hid_firmware_mcuboot_validate(FuNordicHidFirmwareMcuboot *self,
-					GInputStream *stream,
+					FuInputStream *stream,
 					GError **error)
 {
 	guint32 magic;
@@ -127,7 +127,7 @@ fu_nordic_hid_firmware_mcuboot_validate(FuNordicHidFirmwareMcuboot *self,
 
 static gboolean
 fu_nordic_hid_firmware_mcuboot_parse(FuFirmware *firmware,
-				     GInputStream *stream,
+				     FuInputStream *stream,
 				     FuFirmwareParseFlags flags,
 				     GError **error)
 {

--- a/plugins/nordic-hid/fu-nordic-hid-firmware.c
+++ b/plugins/nordic-hid/fu-nordic-hid-firmware.c
@@ -40,7 +40,7 @@ fu_nordic_hid_firmware_get_checksum(FuFirmware *firmware, GChecksumType csum_kin
 
 static gboolean
 fu_nordic_hid_firmware_parse(FuFirmware *firmware,
-			     GInputStream *stream,
+			     FuInputStream *stream,
 			     FuFirmwareParseFlags flags,
 			     GError **error)
 {

--- a/plugins/novatek-ts/fu-novatek-ts-firmware.c
+++ b/plugins/novatek-ts/fu-novatek-ts-firmware.c
@@ -18,7 +18,7 @@ G_DEFINE_TYPE(FuNovatekTsFirmware, fu_novatek_ts_firmware, FU_TYPE_FIRMWARE)
 
 static gboolean
 fu_novatek_ts_firmware_parse(FuFirmware *firmware,
-			     GInputStream *stream,
+			     FuInputStream *stream,
 			     FuFirmwareParseFlags flags,
 			     GError **error)
 {

--- a/plugins/parade-lspcon/fu-parade-lspcon-device.c
+++ b/plugins/parade-lspcon/fu-parade-lspcon-device.c
@@ -647,7 +647,7 @@ fu_parade_lspcon_device_write_firmware(FuDevice *device,
 	/* write flag indicating device should boot the target partition */
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
 	flag_data_stream = FU_INPUT_STREAM(
-	    g_memory_input_stream_new_from_data(flag_data, sizeof(flag_data), NULL));
+	    fu_memory_input_stream_new_from_data(flag_data, sizeof(flag_data), NULL));
 	if (!fu_parade_lspcon_device_flash_write(self,
 						 0,
 						 flag_data_stream,

--- a/plugins/parade-lspcon/fu-parade-lspcon-device.c
+++ b/plugins/parade-lspcon/fu-parade-lspcon-device.c
@@ -399,7 +399,7 @@ fu_parade_lspcon_device_cleanup(FuDevice *device,
 static gboolean
 fu_parade_lspcon_device_flash_write(FuParadeLspconDevice *self,
 				    guint32 base_address,
-				    GInputStream *stream,
+				    FuInputStream *stream,
 				    FuProgress *progress,
 				    GError **error)
 {
@@ -587,8 +587,8 @@ fu_parade_lspcon_device_write_firmware(FuDevice *device,
 	const guint8 flag_data[] = {0x55, 0xaa, target_partition, 1 - target_partition};
 	g_autofree guint8 *readback_buf = NULL;
 	g_autoptr(GByteArray) buf = NULL;
-	g_autoptr(GInputStream) stream = NULL;
-	g_autoptr(GInputStream) flag_data_stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
+	g_autoptr(FuInputStream) flag_data_stream = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
@@ -646,8 +646,8 @@ fu_parade_lspcon_device_write_firmware(FuDevice *device,
 
 	/* write flag indicating device should boot the target partition */
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
-	flag_data_stream =
-	    G_INPUT_STREAM(g_memory_input_stream_new_from_data(flag_data, sizeof(flag_data), NULL));
+	flag_data_stream = FU_INPUT_STREAM(
+	    g_memory_input_stream_new_from_data(flag_data, sizeof(flag_data), NULL));
 	if (!fu_parade_lspcon_device_flash_write(self,
 						 0,
 						 flag_data_stream,

--- a/plugins/parade-usbhub/fu-parade-usbhub-device.c
+++ b/plugins/parade-usbhub/fu-parade-usbhub-device.c
@@ -1162,7 +1162,7 @@ fu_parade_usbhub_device_write_firmware(FuDevice *device,
 				       GError **error)
 {
 	FuParadeUsbhubDevice *self = FU_PARADE_USBHUB_DEVICE(device);
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(GByteArray) blob = NULL;
 	guint32 checksum;
 	guint32 checksum_new;

--- a/plugins/parade-usbhub/fu-parade-usbhub-firmware.c
+++ b/plugins/parade-usbhub/fu-parade-usbhub-firmware.c
@@ -18,7 +18,7 @@ G_DEFINE_TYPE(FuParadeUsbhubFirmware, fu_parade_usbhub_firmware, FU_TYPE_FIRMWAR
 
 static gboolean
 fu_parade_usbhub_firmware_validate(FuFirmware *firmware,
-				   GInputStream *stream,
+				   FuInputStream *stream,
 				   gsize offset,
 				   GError **error)
 {
@@ -27,7 +27,7 @@ fu_parade_usbhub_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_parade_usbhub_firmware_parse(FuFirmware *firmware,
-				GInputStream *stream,
+				FuInputStream *stream,
 				FuFirmwareParseFlags flags,
 				GError **error)
 {

--- a/plugins/pixart-rf/fu-pixart-rf-ble-device.c
+++ b/plugins/pixart-rf/fu-pixart-rf-ble-device.c
@@ -55,7 +55,7 @@ fu_pixart_rf_ble_device_to_string(FuDevice *device, guint idt, GString *str)
 
 static FuFirmware *
 fu_pixart_rf_ble_device_prepare_firmware(FuDevice *device,
-					 GInputStream *stream,
+					 FuInputStream *stream,
 					 FuProgress *progress,
 					 FuFirmwareParseFlags flags,
 					 GError **error)
@@ -69,7 +69,7 @@ fu_pixart_rf_ble_device_prepare_firmware(FuDevice *device,
 	if (fu_device_has_private_flag(device, FU_PIXART_RF_DEVICE_FLAG_IS_HPAC) &&
 	    fu_pixart_rf_firmware_is_hpac(FU_PIXART_RF_FIRMWARE(firmware))) {
 		guint32 hpac_fw_size = 0;
-		g_autoptr(GInputStream) stream_new = NULL;
+		g_autoptr(FuInputStream) stream_new = NULL;
 
 		if (!fu_input_stream_read_u32(stream, 9, &hpac_fw_size, G_LITTLE_ENDIAN, error))
 			return NULL;

--- a/plugins/pixart-rf/fu-pixart-rf-firmware.c
+++ b/plugins/pixart-rf/fu-pixart-rf-firmware.c
@@ -41,7 +41,7 @@ fu_pixart_rf_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, 
 
 static gboolean
 fu_pixart_rf_firmware_validate(FuFirmware *firmware,
-			       GInputStream *stream,
+			       FuInputStream *stream,
 			       gsize offset,
 			       GError **error)
 {
@@ -105,7 +105,7 @@ fu_pixart_rf_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_pixart_rf_firmware_parse(FuFirmware *firmware,
-			    GInputStream *stream,
+			    FuInputStream *stream,
 			    FuFirmwareParseFlags flags,
 			    GError **error)
 {

--- a/plugins/pixart-rf/fu-pixart-rf-receiver-device.c
+++ b/plugins/pixart-rf/fu-pixart-rf-receiver-device.c
@@ -28,7 +28,7 @@ fu_pixart_rf_receiver_device_to_string(FuDevice *device, guint idt, GString *str
 
 static FuFirmware *
 fu_pixart_rf_receiver_device_prepare_firmware(FuDevice *device,
-					      GInputStream *stream,
+					      FuInputStream *stream,
 					      FuProgress *progress,
 					      FuFirmwareParseFlags flags,
 					      GError **error)
@@ -41,7 +41,7 @@ fu_pixart_rf_receiver_device_prepare_firmware(FuDevice *device,
 	if (fu_device_has_private_flag(device, FU_PIXART_RF_DEVICE_FLAG_IS_HPAC) &&
 	    fu_pixart_rf_firmware_is_hpac(FU_PIXART_RF_FIRMWARE(firmware))) {
 		guint32 hpac_fw_size = 0;
-		g_autoptr(GInputStream) stream_new = NULL;
+		g_autoptr(FuInputStream) stream_new = NULL;
 
 		if (!fu_input_stream_read_u32(stream, 9, &hpac_fw_size, G_LITTLE_ENDIAN, error))
 			return NULL;

--- a/plugins/pixart-rf/fu-pixart-rf-wireless-device.c
+++ b/plugins/pixart-rf/fu-pixart-rf-wireless-device.c
@@ -37,7 +37,7 @@ fu_pixart_rf_wireless_device_to_string(FuDevice *device, guint idt, GString *str
 
 static FuFirmware *
 fu_pixart_rf_wireless_device_prepare_firmware(FuDevice *device,
-					      GInputStream *stream,
+					      FuInputStream *stream,
 					      FuProgress *progress,
 					      FuFirmwareParseFlags flags,
 					      GError **error)
@@ -55,7 +55,7 @@ fu_pixart_rf_wireless_device_prepare_firmware(FuDevice *device,
 	if (fu_device_has_private_flag(proxy, FU_PIXART_RF_DEVICE_FLAG_IS_HPAC) &&
 	    fu_pixart_rf_firmware_is_hpac(FU_PIXART_RF_FIRMWARE(firmware))) {
 		guint32 hpac_fw_size = 0;
-		g_autoptr(GInputStream) stream_new = NULL;
+		g_autoptr(FuInputStream) stream_new = NULL;
 
 		if (!fu_input_stream_read_u32(stream, 9, &hpac_fw_size, G_LITTLE_ENDIAN, error))
 			return NULL;

--- a/plugins/pixart-tp/fu-pixart-tp-device.c
+++ b/plugins/pixart-tp/fu-pixart-tp-device.c
@@ -1057,7 +1057,7 @@ fu_pixart_tp_device_write_section(FuPixartTpDevice *self,
 	guint32 target_flash_start = fu_pixart_tp_section_get_target_flash_start(section);
 	guint start_sector;
 	g_autoptr(FuChunkArray) chunks = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* nothing to do */
 	if (fu_firmware_get_size(FU_FIRMWARE(section)) == 0)

--- a/plugins/pixart-tp/fu-pixart-tp-firmware.c
+++ b/plugins/pixart-tp/fu-pixart-tp-firmware.c
@@ -21,7 +21,7 @@ G_DEFINE_TYPE(FuPixartTpFirmware, fu_pixart_tp_firmware, FU_TYPE_FIRMWARE)
 
 static gboolean
 fu_pixart_tp_firmware_validate(FuFirmware *firmware,
-			       GInputStream *stream,
+			       FuInputStream *stream,
 			       gsize offset,
 			       GError **error)
 {
@@ -30,7 +30,7 @@ fu_pixart_tp_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_pixart_tp_firmware_parse(FuFirmware *firmware,
-			    GInputStream *stream,
+			    FuInputStream *stream,
 			    FuFirmwareParseFlags flags,
 			    GError **error)
 {
@@ -57,7 +57,7 @@ fu_pixart_tp_firmware_parse(FuFirmware *firmware,
 	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		guint32 stored = 0;
 		guint32 calc = G_MAXUINT32;
-		g_autoptr(GInputStream) partial_stream = NULL;
+		g_autoptr(FuInputStream) partial_stream = NULL;
 
 		if (!fu_input_stream_read_u32(stream,
 					      FU_STRUCT_PIXART_TP_FIRMWARE_HDR_DEFAULT_HEADER_LEN -

--- a/plugins/pixart-tp/fu-pixart-tp-haptic-device.c
+++ b/plugins/pixart-tp/fu-pixart-tp-haptic-device.c
@@ -687,7 +687,7 @@ fu_pixart_tp_haptic_device_setup(FuDevice *device, GError **error)
 
 static FuFirmware *
 fu_pixart_tp_haptic_device_prepare_firmware(FuDevice *device,
-					    GInputStream *stream,
+					    FuInputStream *stream,
 					    FuProgress *progress,
 					    FuFirmwareParseFlags flags,
 					    GError **error)

--- a/plugins/pixart-tp/fu-pixart-tp-plp239-device.c
+++ b/plugins/pixart-tp/fu-pixart-tp-plp239-device.c
@@ -1129,7 +1129,7 @@ fu_pixart_tp_plp239_device_write_section(FuPixartTpPlp239Device *self,
 	guint sector_count;
 	guint first_idx;
 	g_autoptr(FuChunkArray) chunks = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* nothing to do */
 	if (fu_firmware_get_size(FU_FIRMWARE(section)) == 0)

--- a/plugins/pixart-tp/fu-pixart-tp-section.c
+++ b/plugins/pixart-tp/fu-pixart-tp-section.c
@@ -130,7 +130,7 @@ fu_pixart_tp_section_build(FuFirmware *firmware, XbNode *n, GError **error)
 
 static gboolean
 fu_pixart_tp_section_parse(FuFirmware *firmware,
-			   GInputStream *stream,
+			   FuInputStream *stream,
 			   gsize offset,
 			   FuFirmwareParseFlags flags,
 			   GError **error)
@@ -143,7 +143,7 @@ fu_pixart_tp_section_parse(FuFirmware *firmware,
 	g_autoptr(FuStructPixartTpFirmwareSectionHdr) st = NULL;
 
 	g_return_val_if_fail(FU_IS_PIXART_TP_SECTION(self), FALSE);
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
 
 	st = fu_struct_pixart_tp_firmware_section_hdr_parse_stream(stream, offset, error);
 	if (st == NULL)
@@ -171,7 +171,7 @@ fu_pixart_tp_section_parse(FuFirmware *firmware,
 
 	/* data */
 	if (section_length != 0) {
-		g_autoptr(GInputStream) partial_stream = NULL;
+		g_autoptr(FuInputStream) partial_stream = NULL;
 		partial_stream = fu_partial_input_stream_new(stream,
 							     fu_firmware_get_offset(firmware),
 							     section_length,

--- a/plugins/qc-firehose/fu-qc-firehose-raw-device.c
+++ b/plugins/qc-firehose/fu-qc-firehose-raw-device.c
@@ -50,7 +50,7 @@ fu_qc_firehose_raw_device_impl_add_function(FuQcFirehoseImpl *impl, FuQcFirehose
 
 static FuFirmware *
 fu_qc_firehose_raw_device_impl_prepare_firmware(FuDevice *device,
-						GInputStream *stream,
+						FuInputStream *stream,
 						FuProgress *progress,
 						FuFirmwareParseFlags flags,
 						GError **error)

--- a/plugins/qc-firehose/fu-qc-firehose-usb-device.c
+++ b/plugins/qc-firehose/fu-qc-firehose-usb-device.c
@@ -243,7 +243,7 @@ fu_qc_firehose_usb_device_attach(FuDevice *device, FuProgress *progress, GError 
 
 static FuFirmware *
 fu_qc_firehose_usb_device_impl_prepare_firmware(FuDevice *device,
-						GInputStream *stream,
+						FuInputStream *stream,
 						FuProgress *progress,
 						FuFirmwareParseFlags flags,
 						GError **error)

--- a/plugins/qc-s5gen2/fu-qc-s5gen2-device.c
+++ b/plugins/qc-s5gen2/fu-qc-s5gen2-device.c
@@ -616,7 +616,7 @@ fu_qc_s5gen2_device_write_blocks(FuQcS5gen2Device *self,
 
 static FuFirmware *
 fu_qc_s5gen2_device_prepare_firmware(FuDevice *device,
-				     GInputStream *stream,
+				     FuInputStream *stream,
 				     FuProgress *progress,
 				     FuFirmwareParseFlags flags,
 				     GError **error)

--- a/plugins/qc-s5gen2/fu-qc-s5gen2-firmware.c
+++ b/plugins/qc-s5gen2/fu-qc-s5gen2-firmware.c
@@ -46,7 +46,7 @@ fu_qc_s5gen2_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, 
 
 static gboolean
 fu_qc_s5gen2_firmware_validate(FuFirmware *firmware,
-			       GInputStream *stream,
+			       FuInputStream *stream,
 			       gsize offset,
 			       GError **error)
 {
@@ -55,7 +55,7 @@ fu_qc_s5gen2_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_qc_s5gen2_firmware_parse(FuFirmware *firmware,
-			    GInputStream *stream,
+			    FuInputStream *stream,
 			    FuFirmwareParseFlags flags,
 			    GError **error)
 {

--- a/plugins/qsi-dock/fu-qsi-dock-child-device.c
+++ b/plugins/qsi-dock/fu-qsi-dock-child-device.c
@@ -32,7 +32,7 @@ fu_qsi_dock_child_device_to_string(FuDevice *device, guint idt, GString *str)
 /* use the parents parser */
 static FuFirmware *
 fu_qsi_dock_child_device_prepare_firmware(FuDevice *device,
-					  GInputStream *stream,
+					  FuInputStream *stream,
 					  FuProgress *progress,
 					  FuFirmwareParseFlags flags,
 					  GError **error)

--- a/plugins/raydium-tp/fu-raydium-tp-firmware.c
+++ b/plugins/raydium-tp/fu-raydium-tp-firmware.c
@@ -42,7 +42,7 @@ fu_raydium_tp_firmware_get_product_id(FuRaydiumTpFirmware *self)
 
 static gboolean
 fu_raydium_tp_firmware_parse(FuFirmware *firmware,
-			     GInputStream *stream,
+			     FuInputStream *stream,
 			     FuFirmwareParseFlags flags,
 			     GError **error)
 {
@@ -50,8 +50,8 @@ fu_raydium_tp_firmware_parse(FuFirmware *firmware,
 	g_autoptr(FuFirmware) firmware_desc = g_object_new(FU_TYPE_RAYDIUM_TP_IMAGE, NULL);
 	g_autoptr(FuFirmware) firmware_pram = g_object_new(FU_TYPE_RAYDIUM_TP_IMAGE, NULL);
 	g_autoptr(FuStructRaydiumTpFwHdr) st = NULL;
-	g_autoptr(GInputStream) stream_desc = NULL;
-	g_autoptr(GInputStream) stream_fw = NULL;
+	g_autoptr(FuInputStream) stream_desc = NULL;
+	g_autoptr(FuInputStream) stream_fw = NULL;
 
 	st = fu_struct_raydium_tp_fw_hdr_parse_stream(stream, 0x0, error);
 	if (st == NULL)

--- a/plugins/raydium-tp/fu-raydium-tp-hid-device.c
+++ b/plugins/raydium-tp/fu-raydium-tp-hid-device.c
@@ -647,7 +647,7 @@ fu_raydium_tp_hid_device_bl_write_flash(FuRaydiumTpHidDevice *self,
 {
 	guint page_no = 0;
 	guint8 sub_page_no = 0;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	stream = fu_firmware_get_stream(img, error);

--- a/plugins/raydium-tp/fu-raydium-tp-image.c
+++ b/plugins/raydium-tp/fu-raydium-tp-image.c
@@ -31,14 +31,14 @@ fu_raydium_tp_image_get_checksum(FuRaydiumTpImage *self)
 
 static gboolean
 fu_raydium_tp_image_parse(FuFirmware *firmware,
-			  GInputStream *stream,
+			  FuInputStream *stream,
 			  FuFirmwareParseFlags flags,
 			  GError **error)
 {
 	FuRaydiumTpImage *self = FU_RAYDIUM_TP_IMAGE(firmware);
 	gsize streamsz = 0;
 	guint32 crc_calc = G_MAXUINT32;
-	g_autoptr(GInputStream) stream_crc = NULL;
+	g_autoptr(FuInputStream) stream_crc = NULL;
 
 	if (!fu_input_stream_size(stream, &streamsz, error))
 		return FALSE;

--- a/plugins/redfish/fu-redfish-smbios.c
+++ b/plugins/redfish/fu-redfish-smbios.c
@@ -140,7 +140,7 @@ fu_redfish_smbios_build(FuFirmware *firmware, XbNode *n, GError **error)
 
 static gboolean
 fu_redfish_smbios_parse_interface_data(FuRedfishSmbios *self,
-				       GInputStream *stream,
+				       FuInputStream *stream,
 				       gsize offset,
 				       GError **error)
 {
@@ -211,7 +211,7 @@ fu_redfish_smbios_parse_interface_data(FuRedfishSmbios *self,
 
 static gboolean
 fu_redfish_smbios_parse_over_ip(FuRedfishSmbios *self,
-				GInputStream *stream,
+				FuInputStream *stream,
 				gsize offset,
 				GError **error)
 {
@@ -266,7 +266,7 @@ fu_redfish_smbios_parse_over_ip(FuRedfishSmbios *self,
 
 static gboolean
 fu_redfish_smbios_parse(FuFirmware *firmware,
-			GInputStream *stream,
+			FuInputStream *stream,
 			FuFirmwareParseFlags flags,
 			GError **error)
 {

--- a/plugins/rts54hub/fu-rts54hub-device.c
+++ b/plugins/rts54hub/fu-rts54hub-device.c
@@ -453,7 +453,7 @@ fu_rts54hub_device_write_firmware(FuDevice *device,
 				  GError **error)
 {
 	FuRts54hubDevice *self = FU_RTS54HUB_DEVICE(device);
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */
@@ -545,7 +545,7 @@ fu_rts54hub_device_write_firmware(FuDevice *device,
 
 static FuFirmware *
 fu_rts54hub_device_prepare_firmware(FuDevice *device,
-				    GInputStream *stream,
+				    FuInputStream *stream,
 				    FuProgress *progress,
 				    FuFirmwareParseFlags flags,
 				    GError **error)

--- a/plugins/rts54hub/fu-rts54hub-rtd21xx-background.c
+++ b/plugins/rts54hub/fu-rts54hub-rtd21xx-background.c
@@ -173,7 +173,7 @@ fu_rts54hub_rtd21xx_background_write_firmware(FuDevice *device,
 	guint8 read_buf[10] = {0x0};
 	guint8 write_buf[ISP_PACKET_SIZE] = {0x0};
 	g_autoptr(FuDeviceLocker) locker = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */

--- a/plugins/rts54hub/fu-rts54hub-rtd21xx-foreground.c
+++ b/plugins/rts54hub/fu-rts54hub-rtd21xx-foreground.c
@@ -232,7 +232,7 @@ fu_rts54hub_rtd21xx_foreground_write_firmware(FuDevice *device,
 	guint8 read_buf[10] = {0x0};
 	guint8 write_buf[ISP_PACKET_SIZE] = {0x0};
 	g_autoptr(FuDeviceLocker) locker = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */

--- a/plugins/scsi/fu-scsi-device.c
+++ b/plugins/scsi/fu-scsi-device.c
@@ -174,7 +174,7 @@ fu_scsi_device_probe(FuDevice *device, GError **error)
 
 static FuFirmware *
 fu_scsi_device_prepare_firmware(FuDevice *device,
-				GInputStream *stream,
+				FuInputStream *stream,
 				FuProgress *progress,
 				FuFirmwareParseFlags flags,
 				GError **error)
@@ -360,7 +360,7 @@ fu_scsi_device_write_firmware(FuDevice *device,
 	FuScsiDevice *self = FU_SCSI_DEVICE(device);
 	guint32 chunksz = self->write_buffer_size;
 	guint32 offset = 0;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* get default image */

--- a/plugins/steelseries/fu-steelseries-firmware.c
+++ b/plugins/steelseries/fu-steelseries-firmware.c
@@ -17,7 +17,7 @@ G_DEFINE_TYPE(FuSteelseriesFirmware, fu_steelseries_firmware, FU_TYPE_FIRMWARE)
 
 static gboolean
 fu_steelseries_firmware_parse(FuFirmware *firmware,
-			      GInputStream *stream,
+			      FuInputStream *stream,
 			      FuFirmwareParseFlags flags,
 			      GError **error)
 {
@@ -25,7 +25,7 @@ fu_steelseries_firmware_parse(FuFirmware *firmware,
 	guint32 checksum_tmp = 0xFFFFFFFF;
 	guint32 checksum = 0;
 	gsize streamsz = 0;
-	g_autoptr(GInputStream) stream_tmp = NULL;
+	g_autoptr(FuInputStream) stream_tmp = NULL;
 
 	if (!fu_input_stream_size(stream, &streamsz, error))
 		return FALSE;

--- a/plugins/steelseries/fu-steelseries-sonic.c
+++ b/plugins/steelseries/fu-steelseries-sonic.c
@@ -866,7 +866,7 @@ fu_steelseries_sonic_parse_firmware(FuFirmware *firmware,
 
 static FuFirmware *
 fu_steelseries_sonic_prepare_firmware(FuDevice *device,
-				      GInputStream *stream,
+				      FuInputStream *stream,
 				      FuProgress *progress,
 				      FuFirmwareParseFlags flags,
 				      GError **error)

--- a/plugins/sunplus-camera/fu-sunplus-camera-device.c
+++ b/plugins/sunplus-camera/fu-sunplus-camera-device.c
@@ -565,7 +565,7 @@ fu_sunplus_camera_device_write_firmware(FuDevice *device,
 	guint8 checksum_dev = 0;
 	guint8 finish = 0x01;
 	g_autoptr(FuChunkArray) chunks = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	stream = fu_firmware_get_stream(firmware, error);
 	if (stream == NULL)

--- a/plugins/sunwinon-hid/fu-sunwinon-hid-device.c
+++ b/plugins/sunwinon-hid/fu-sunwinon-hid-device.c
@@ -409,7 +409,7 @@ fu_sunwinon_hid_device_dfu_program_start_cmd(FuSunwinonHidDevice *self,
 	gsize streamsz = 0;
 	g_autoptr(FuStructSunwinonDfuPayloadProgramStart) st_prog_start =
 	    fu_struct_sunwinon_dfu_payload_program_start_new();
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuStructSunwinonDfuImageInfo) st_info = NULL;
 
 	stream = fu_firmware_get_stream(FU_FIRMWARE(firmware_sh), error);
@@ -457,7 +457,7 @@ fu_sunwinon_hid_device_dfu_do_update_normal(FuSunwinonHidDevice *self,
 					    GError **error)
 {
 	g_autoptr(FuChunkArray) chunks = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* chunkify */
 	stream = fu_firmware_get_stream(FU_FIRMWARE(firmware_sh), error);

--- a/plugins/sunwinon-hid/fu-sunwinon-hid-firmware.c
+++ b/plugins/sunwinon-hid/fu-sunwinon-hid-firmware.c
@@ -53,7 +53,7 @@ fu_sunwinon_hid_firmware_get_fw_type(FuSunwinonHidFirmware *self)
 
 static gboolean
 fu_sunwinon_hid_firmware_parse(FuFirmware *firmware,
-			       GInputStream *stream,
+			       FuInputStream *stream,
 			       FuFirmwareParseFlags flags,
 			       GError **error)
 {

--- a/plugins/synaptics-cape/fu-synaptics-cape-device.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-device.c
@@ -399,7 +399,7 @@ fu_synaptics_cape_device_setup(FuDevice *device, GError **error)
 
 static FuFirmware *
 fu_synaptics_cape_device_prepare_firmware(FuDevice *device,
-					  GInputStream *stream,
+					  FuInputStream *stream,
 					  FuProgress *progress,
 					  FuFirmwareParseFlags flags,
 					  GError **error)
@@ -408,7 +408,7 @@ fu_synaptics_cape_device_prepare_firmware(FuDevice *device,
 	gsize bufsz = 0;
 	gsize offset = 0;
 	g_autoptr(FuFirmware) firmware = fu_synaptics_cape_hid_firmware_new();
-	g_autoptr(GInputStream) stream_fw = NULL;
+	g_autoptr(FuInputStream) stream_fw = NULL;
 
 	/* a "fw" includes two firmware data for each partition, we need to divide a 'fw' into
 	 * two equal parts */
@@ -513,7 +513,7 @@ fu_synaptics_cape_device_write_firmware_header(FuSynapticsCapeDevice *self,
 /* sends firmware image to device */
 static gboolean
 fu_synaptics_cape_device_write_firmware_image(FuSynapticsCapeDevice *self,
-					      GInputStream *stream,
+					      FuInputStream *stream,
 					      FuProgress *progress,
 					      GError **error)
 {
@@ -587,7 +587,7 @@ fu_synaptics_cape_device_write_firmware(FuDevice *device,
 					GError **error)
 {
 	FuSynapticsCapeDevice *self = FU_SYNAPTICS_CAPE_DEVICE(device);
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(GBytes) fw_header = NULL;
 
 	g_return_val_if_fail(FU_IS_SYNAPTICS_CAPE_DEVICE(self), FALSE);

--- a/plugins/synaptics-cape/fu-synaptics-cape-hid-firmware.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-hid-firmware.c
@@ -21,7 +21,7 @@ G_DEFINE_TYPE(FuSynapticsCapeHidFirmware,
 
 static gboolean
 fu_synaptics_cape_hid_firmware_parse(FuFirmware *firmware,
-				     GInputStream *stream,
+				     FuInputStream *stream,
 				     FuFirmwareParseFlags flags,
 				     GError **error)
 {
@@ -30,8 +30,8 @@ fu_synaptics_cape_hid_firmware_parse(FuFirmware *firmware,
 	g_autofree gchar *version_str = NULL;
 	g_autoptr(FuFirmware) img_hdr = fu_firmware_new();
 	g_autoptr(FuStructSynapticsCapeHidHdr) st = NULL;
-	g_autoptr(GInputStream) stream_hdr = NULL;
-	g_autoptr(GInputStream) stream_body = NULL;
+	g_autoptr(FuInputStream) stream_hdr = NULL;
+	g_autoptr(FuInputStream) stream_body = NULL;
 
 	/* sanity check */
 	if (!fu_input_stream_size(stream, &streamsz, error))

--- a/plugins/synaptics-cape/fu-synaptics-cape-sngl-firmware.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-sngl-firmware.c
@@ -21,7 +21,7 @@ G_DEFINE_TYPE(FuSynapticsCapeSnglFirmware,
 
 static gboolean
 fu_synaptics_cape_sngl_firmware_parse(FuFirmware *firmware,
-				      GInputStream *stream,
+				      FuInputStream *stream,
 				      FuFirmwareParseFlags flags,
 				      GError **error)
 {
@@ -64,7 +64,7 @@ fu_synaptics_cape_sngl_firmware_parse(FuFirmware *firmware,
 	/* check CRC */
 	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		guint32 crc_calc = 0xFFFFFFFF;
-		g_autoptr(GInputStream) stream_tmp = NULL;
+		g_autoptr(FuInputStream) stream_tmp = NULL;
 
 		stream_tmp = fu_partial_input_stream_new(stream, 8, G_MAXSIZE, error);
 		if (stream_tmp == NULL)

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-firmware.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-firmware.c
@@ -153,7 +153,7 @@ fu_synaptics_cxaudio_firmware_avoid_badblocks(GPtrArray *badblocks, GPtrArray *r
 
 static gboolean
 fu_synaptics_cxaudio_firmware_parse(FuFirmware *firmware,
-				    GInputStream *stream,
+				    FuInputStream *stream,
 				    FuFirmwareParseFlags flags,
 				    GError **error)
 {

--- a/plugins/synaptics-mst/fu-synaptics-mst-firmware.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-firmware.c
@@ -49,7 +49,7 @@ fu_synaptics_mst_firmware_export(FuFirmware *firmware,
 
 static gboolean
 fu_synaptics_mst_firmware_detect_family(FuSynapticsMstFirmware *self,
-					GInputStream *stream,
+					FuInputStream *stream,
 					gsize offset,
 					GError **error)
 {
@@ -76,7 +76,7 @@ fu_synaptics_mst_firmware_detect_family(FuSynapticsMstFirmware *self,
 
 static gboolean
 fu_synaptics_mst_firmware_parse(FuFirmware *firmware,
-				GInputStream *stream,
+				FuInputStream *stream,
 				FuFirmwareParseFlags flags,
 				GError **error)
 {

--- a/plugins/synaptics-prometheus/fu-self-test.c
+++ b/plugins/synaptics-prometheus/fu-self-test.c
@@ -22,7 +22,7 @@ fu_test_synaptics_prometheus_firmware_func(void)
 	g_autoptr(GBytes) blob2 = NULL;
 	g_autoptr(GBytes) fw = NULL;
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuFirmware) firmware2 = NULL;
 	g_autoptr(FuFirmware) firmware = fu_synaptics_prometheus_firmware_new();
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);

--- a/plugins/synaptics-prometheus/fu-self-test.c
+++ b/plugins/synaptics-prometheus/fu-self-test.c
@@ -68,7 +68,7 @@ fu_test_synaptics_prometheus_firmware_func(void)
 
 	/* payload needs to exist */
 	fu_synaptics_prometheus_device_set_version(device, 10, 1, 1234);
-	stream = g_memory_input_stream_new_from_bytes(fw);
+	stream = fu_memory_input_stream_new_from_bytes(fw);
 	firmware2 =
 	    fu_synaptics_prometheus_device_prepare_firmware(FU_DEVICE(device),
 							    stream,

--- a/plugins/synaptics-prometheus/fu-synaptics-prometheus-config.c
+++ b/plugins/synaptics-prometheus/fu-synaptics-prometheus-config.c
@@ -128,7 +128,7 @@ fu_synaptics_prometheus_config_setup(FuDevice *device, GError **error)
 
 static FuFirmware *
 fu_synaptics_prometheus_config_prepare_firmware(FuDevice *device,
-						GInputStream *stream,
+						FuInputStream *stream,
 						FuProgress *progress,
 						FuFirmwareParseFlags flags,
 						GError **error)
@@ -136,7 +136,7 @@ fu_synaptics_prometheus_config_prepare_firmware(FuDevice *device,
 	FuSynapticsPrometheusConfig *self = FU_SYNAPTICS_PROMETHEUS_CONFIG(device);
 	FuDevice *proxy;
 	g_autoptr(FuStructSynapticsPrometheusCfgHdr) st_hdr = NULL;
-	g_autoptr(GInputStream) stream_hdr = NULL;
+	g_autoptr(FuInputStream) stream_hdr = NULL;
 	g_autoptr(FuFirmware) firmware = fu_synaptics_prometheus_firmware_new();
 	g_autoptr(FuFirmware) img_hdr = NULL;
 

--- a/plugins/synaptics-prometheus/fu-synaptics-prometheus-device.c
+++ b/plugins/synaptics-prometheus/fu-synaptics-prometheus-device.c
@@ -248,7 +248,7 @@ fu_synaptics_prometheus_device_setup(FuDevice *device, GError **error)
 
 FuFirmware *
 fu_synaptics_prometheus_device_prepare_firmware(FuDevice *device,
-						GInputStream *stream,
+						FuInputStream *stream,
 						FuProgress *progress,
 						FuFirmwareParseFlags flags,
 						GError **error)

--- a/plugins/synaptics-prometheus/fu-synaptics-prometheus-device.h
+++ b/plugins/synaptics-prometheus/fu-synaptics-prometheus-device.h
@@ -39,7 +39,7 @@ fu_synaptics_prometheus_device_set_version(FuSynapticsPrometheusDevice *self,
 					   guint32 buildnum);
 FuFirmware *
 fu_synaptics_prometheus_device_prepare_firmware(FuDevice *device,
-						GInputStream *stream,
+						FuInputStream *stream,
 						FuProgress *progress,
 						FuFirmwareParseFlags flags,
 						GError **error);

--- a/plugins/synaptics-prometheus/fu-synaptics-prometheus-firmware.c
+++ b/plugins/synaptics-prometheus/fu-synaptics-prometheus-firmware.c
@@ -52,7 +52,7 @@ fu_synaptics_prometheus_firmware_export(FuFirmware *firmware,
 
 static gboolean
 fu_synaptics_prometheus_firmware_parse(FuFirmware *firmware,
-				       GInputStream *stream,
+				       FuInputStream *stream,
 				       FuFirmwareParseFlags flags,
 				       GError **error)
 {
@@ -78,7 +78,7 @@ fu_synaptics_prometheus_firmware_parse(FuFirmware *firmware,
 		g_autoptr(FuFirmware) img = fu_firmware_new();
 		g_autoptr(FuFirmware) img_old = NULL;
 		g_autoptr(FuStructSynapticsPrometheusHdr) st_hdr = NULL;
-		g_autoptr(GInputStream) partial_stream = NULL;
+		g_autoptr(FuInputStream) partial_stream = NULL;
 
 		/* verify item header */
 		st_hdr = fu_struct_synaptics_prometheus_hdr_parse_stream(stream, offset, error);

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
@@ -36,7 +36,7 @@ G_DEFINE_TYPE(FuSynapticsRmiFirmware, fu_synaptics_rmi_firmware, FU_TYPE_FIRMWAR
 
 static gboolean
 fu_synaptics_rmi_firmware_parse_sbl_container_v10(FuSynapticsRmiFirmware *self,
-						  GInputStream *stream,
+						  FuInputStream *stream,
 						  const guint8 *buf,
 						  gsize bufsz,
 						  guint32 start_offset,
@@ -46,14 +46,14 @@ fu_synaptics_rmi_firmware_parse_sbl_container_v10(FuSynapticsRmiFirmware *self,
 static gboolean
 fu_synaptics_rmi_firmware_add_image(FuSynapticsRmiFirmware *self,
 				    const gchar *id,
-				    GInputStream *stream,
+				    FuInputStream *stream,
 				    gsize offset,
 				    gsize bufsz,
 				    FuFirmwareParseFlags flags,
 				    GError **error)
 {
 	g_autoptr(FuFirmware) img = fu_firmware_new();
-	g_autoptr(GInputStream) partial_stream = NULL;
+	g_autoptr(FuInputStream) partial_stream = NULL;
 	partial_stream = fu_partial_input_stream_new(stream, offset, bufsz, error);
 	if (partial_stream == NULL)
 		return FALSE;
@@ -66,7 +66,7 @@ fu_synaptics_rmi_firmware_add_image(FuSynapticsRmiFirmware *self,
 static gboolean
 fu_synaptics_rmi_firmware_add_image_v10(FuSynapticsRmiFirmware *self,
 					const gchar *id,
-					GInputStream *stream,
+					FuInputStream *stream,
 					gsize offset,
 					gsize bufsz,
 					gsize sig_sz,
@@ -76,7 +76,7 @@ fu_synaptics_rmi_firmware_add_image_v10(FuSynapticsRmiFirmware *self,
 	if (!fu_synaptics_rmi_firmware_add_image(self, id, stream, offset, bufsz, flags, error))
 		return FALSE;
 	if (sig_sz != 0) {
-		g_autoptr(GInputStream) partial_stream = NULL;
+		g_autoptr(FuInputStream) partial_stream = NULL;
 		g_autoptr(FuFirmware) img = fu_firmware_new();
 		g_autofree gchar *sig_id = NULL;
 
@@ -114,7 +114,7 @@ fu_synaptics_rmi_firmware_export(FuFirmware *firmware,
 
 static gboolean
 fu_synaptics_rmi_firmware_parse_v10(FuSynapticsRmiFirmware *self,
-				    GInputStream *stream,
+				    FuInputStream *stream,
 				    FuFirmwareParseFlags flags,
 				    GError **error)
 {
@@ -374,7 +374,7 @@ fu_synaptics_rmi_firmware_parse_v10(FuSynapticsRmiFirmware *self,
 
 static gboolean
 fu_synaptics_rmi_firmware_parse_v0x(FuSynapticsRmiFirmware *self,
-				    GInputStream *stream,
+				    FuInputStream *stream,
 				    FuFirmwareParseFlags flags,
 				    GError **error)
 {
@@ -444,7 +444,7 @@ fu_synaptics_rmi_firmware_parse_v0x(FuSynapticsRmiFirmware *self,
 
 static gboolean
 fu_synaptics_rmi_firmware_parse(FuFirmware *firmware,
-				GInputStream *stream,
+				FuInputStream *stream,
 				FuFirmwareParseFlags flags,
 				GError **error)
 {
@@ -760,7 +760,7 @@ fu_synaptics_rmi_firmware_class_init(FuSynapticsRmiFirmwareClass *klass)
 
 static gboolean
 fu_synaptics_rmi_firmware_parse_sbl_container_v10(FuSynapticsRmiFirmware *self,
-						  GInputStream *stream,
+						  FuInputStream *stream,
 						  const guint8 *buf,
 						  gsize bufsz,
 						  guint32 start_offset,

--- a/plugins/synaptics-vmm9/fu-synaptics-vmm9-device.c
+++ b/plugins/synaptics-vmm9/fu-synaptics-vmm9-device.c
@@ -375,14 +375,14 @@ fu_synaptics_vmm9_device_close(FuDevice *device, GError **error)
 
 static FuFirmware *
 fu_synaptics_vmm9_device_prepare_firmware(FuDevice *device,
-					  GInputStream *stream,
+					  FuInputStream *stream,
 					  FuProgress *progress,
 					  FuFirmwareParseFlags flags,
 					  GError **error)
 {
 	FuSynapticsVmm9Device *self = FU_SYNAPTICS_VMM9_DEVICE(device);
 	g_autoptr(FuFirmware) firmware = fu_synaptics_vmm9_firmware_new();
-	g_autoptr(GInputStream) stream_partial = NULL;
+	g_autoptr(FuInputStream) stream_partial = NULL;
 
 	/* parse */
 	stream_partial = fu_partial_input_stream_new(stream,
@@ -541,7 +541,7 @@ fu_synaptics_vmm9_device_write_firmware(FuDevice *device,
 					GError **error)
 {
 	FuSynapticsVmm9Device *self = FU_SYNAPTICS_VMM9_DEVICE(device);
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */

--- a/plugins/synaptics-vmm9/fu-synaptics-vmm9-firmware.c
+++ b/plugins/synaptics-vmm9/fu-synaptics-vmm9-firmware.c
@@ -35,7 +35,7 @@ fu_synaptics_vmm9_firmware_export(FuFirmware *firmware,
 
 static gboolean
 fu_synaptics_vmm9_firmware_validate(FuFirmware *firmware,
-				    GInputStream *stream,
+				    FuInputStream *stream,
 				    gsize offset,
 				    GError **error)
 {
@@ -44,7 +44,7 @@ fu_synaptics_vmm9_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_synaptics_vmm9_firmware_parse(FuFirmware *firmware,
-				 GInputStream *stream,
+				 FuInputStream *stream,
 				 FuFirmwareParseFlags flags,
 				 GError **error)
 {

--- a/plugins/telink-dfu/fu-telink-dfu-archive.c
+++ b/plugins/telink-dfu/fu-telink-dfu-archive.c
@@ -108,7 +108,7 @@ fu_telink_dfu_archive_load_file(FuTelinkDfuArchive *self,
 
 static gboolean
 fu_telink_dfu_archive_parse(FuFirmware *firmware,
-			    GInputStream *stream,
+			    FuInputStream *stream,
 			    FuFirmwareParseFlags flags,
 			    GError **error)
 {

--- a/plugins/telink-dfu/fu-telink-dfu-ble-device.c
+++ b/plugins/telink-dfu/fu-telink-dfu-ble-device.c
@@ -198,7 +198,7 @@ fu_telink_dfu_ble_device_write_firmware(FuDevice *device,
 	FuTelinkDfuBleDevice *self = FU_TELINK_DFU_BLE_DEVICE(device);
 	g_autoptr(FuFirmware) archive = fu_zip_firmware_new();
 	g_autoptr(GBytes) blob = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* get default image */
 	stream = fu_firmware_get_stream(firmware, error);

--- a/plugins/test/fu-test-plugin.c
+++ b/plugins/test/fu-test-plugin.c
@@ -288,7 +288,7 @@ fu_test_plugin_write_firmware(FuPlugin *plugin,
 	} else {
 		g_autofree gchar *ver = NULL;
 		g_autoptr(GBytes) blob_fw = NULL;
-		g_autoptr(GInputStream) stream = NULL;
+		g_autoptr(FuInputStream) stream = NULL;
 
 		/* live update */
 		fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);

--- a/plugins/thunderbolt/fu-self-test.c
+++ b/plugins/thunderbolt/fu-self-test.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 
 #include "fu-context-private.h"
+#include "fu-file-input-stream.h"
 #include "fu-plugin-private.h"
 #include "fu-thunderbolt-plugin.h"
 #include "fu-udev-device-private.h"
@@ -238,7 +239,7 @@ mock_tree_firmware_verify(const FuThunderboltMockTree *node, GBytes *data)
 	nvm_device = g_file_new_for_path(node->nvm_non_active);
 	nvm = g_file_get_child(nvm_device, "nvmem");
 
-	is = FU_INPUT_STREAM(g_file_read(nvm, NULL, &error)); /* nocheck:blocked */
+	is = fu_file_input_stream_from_file(nvm, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(is);
 

--- a/plugins/thunderbolt/fu-self-test.c
+++ b/plugins/thunderbolt/fu-self-test.c
@@ -222,7 +222,7 @@ mock_tree_firmware_verify(const FuThunderboltMockTree *node, GBytes *data)
 {
 	g_autoptr(GFile) nvm_device = NULL;
 	g_autoptr(GFile) nvm = NULL;
-	g_autoptr(GInputStream) is = NULL;
+	g_autoptr(FuInputStream) is = NULL;
 	g_autoptr(GChecksum) chk = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autofree gchar *sum_data = NULL;
@@ -238,7 +238,7 @@ mock_tree_firmware_verify(const FuThunderboltMockTree *node, GBytes *data)
 	nvm_device = g_file_new_for_path(node->nvm_non_active);
 	nvm = g_file_get_child(nvm_device, "nvmem");
 
-	is = (GInputStream *)g_file_read(nvm, NULL, &error);
+	is = FU_INPUT_STREAM(g_file_read(nvm, NULL, &error)); /* nocheck:blocked */
 	g_assert_no_error(error);
 	g_assert_nonnull(is);
 
@@ -331,7 +331,7 @@ write_controller_fw(const gchar *nvm)
 	g_autoptr(GFile) nvmem = NULL;
 	g_autofree gchar *fw_path = NULL;
 	g_autoptr(GBytes) fw_blob = NULL;
-	g_autoptr(GInputStream) is = NULL;
+	g_autoptr(FuInputStream) is = NULL;
 	g_autoptr(GOutputStream) os = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(FuFirmware) firmware_ctl = NULL;
@@ -857,7 +857,7 @@ typedef struct FuThunderboltTest {
 
 	/* if FuThunderboltTestParam::firmware_file is nonnull */
 	GBytes *fw_data;
-	GInputStream *fw_stream;
+	FuInputStream *fw_stream;
 
 } FuThunderboltTest;
 

--- a/plugins/thunderbolt/fu-self-test.c
+++ b/plugins/thunderbolt/fu-self-test.c
@@ -246,7 +246,7 @@ mock_tree_firmware_verify(const FuThunderboltMockTree *node, GBytes *data)
 		g_autoptr(GBytes) b = NULL;
 		const guchar *d;
 
-		b = g_input_stream_read_bytes(is, 4096, NULL, &error);
+		b = g_input_stream_read_bytes(G_INPUT_STREAM(is), 4096, NULL, &error);
 		g_assert_no_error(error);
 		g_assert_nonnull(is);
 

--- a/plugins/thunderbolt/fu-self-test.c
+++ b/plugins/thunderbolt/fu-self-test.c
@@ -356,7 +356,7 @@ write_controller_fw(const gchar *nvm)
 	g_assert_no_error(error);
 	g_assert_nonnull(os);
 
-	is = g_memory_input_stream_new_from_bytes(fw_blob);
+	is = fu_memory_input_stream_new_from_bytes(fw_blob);
 
 	n = g_output_stream_splice(os, is, G_OUTPUT_STREAM_SPLICE_NONE, NULL, &error);
 	g_assert_no_error(error);
@@ -965,7 +965,7 @@ test_set_up(FuThunderboltTest *tt, gconstpointer params)
 		tt->fw_data = fu_firmware_write(firmware, &error);
 		g_assert_no_error(error);
 		g_assert_nonnull(tt->fw_data);
-		tt->fw_stream = g_memory_input_stream_new_from_bytes(tt->fw_data);
+		tt->fw_stream = fu_memory_input_stream_new_from_bytes(tt->fw_data);
 		g_assert_nonnull(tt->fw_stream);
 	}
 }

--- a/plugins/thunderbolt/fu-thunderbolt-controller.c
+++ b/plugins/thunderbolt/fu-thunderbolt-controller.c
@@ -122,7 +122,7 @@ fu_thunderbolt_controller_read_status_block(FuThunderboltController *self, GErro
 	gsize nr_chunks;
 	g_autofree gchar *nvmem = NULL;
 	g_autoptr(GBytes) blob = NULL;
-	g_autoptr(GInputStream) istr = NULL;
+	g_autoptr(FuInputStream) istr = NULL;
 	g_autoptr(FuFirmware) firmware = NULL;
 
 	nvmem = fu_thunderbolt_device_find_nvmem(FU_THUNDERBOLT_DEVICE(self), TRUE, error);

--- a/plugins/thunderbolt/fu-thunderbolt-controller.c
+++ b/plugins/thunderbolt/fu-thunderbolt-controller.c
@@ -138,7 +138,7 @@ fu_thunderbolt_controller_read_status_block(FuThunderboltController *self, GErro
 					    error);
 	if (blob == NULL)
 		return FALSE;
-	istr = g_memory_input_stream_new_from_bytes(blob);
+	istr = fu_memory_input_stream_new_from_bytes(blob);
 	firmware = fu_firmware_new_from_gtypes(istr,
 					       0x0,
 					       FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -302,7 +302,7 @@ fu_thunderbolt_device_prepare_firmware(FuDevice *device,
 		    fu_device_get_contents_bytes(device, nvmem, G_MAXSIZE, progress, error);
 		if (controller_blob == NULL)
 			return NULL;
-		controller_fw = g_memory_input_stream_new_from_bytes(controller_blob);
+		controller_fw = fu_memory_input_stream_new_from_bytes(controller_blob);
 		firmware_old = fu_firmware_new_from_gtypes(controller_fw,
 							   0x0,
 							   flags,

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -268,7 +268,7 @@ fu_thunderbolt_device_write_data(FuThunderboltDevice *self,
 
 static FuFirmware *
 fu_thunderbolt_device_prepare_firmware(FuDevice *device,
-				       GInputStream *stream,
+				       FuInputStream *stream,
 				       FuProgress *progress,
 				       FuFirmwareParseFlags flags,
 				       GError **error)
@@ -292,7 +292,7 @@ fu_thunderbolt_device_prepare_firmware(FuDevice *device,
 		g_autofree gchar *nvmem = NULL;
 		g_autoptr(FuFirmware) firmware_old = NULL;
 		g_autoptr(GBytes) controller_blob = NULL;
-		g_autoptr(GInputStream) controller_fw = NULL;
+		g_autoptr(FuInputStream) controller_fw = NULL;
 
 		fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_READ);
 		nvmem = fu_thunderbolt_device_find_nvmem(self, TRUE, error);

--- a/plugins/ti-tps6598x/fu-ti-tps6598x-device.c
+++ b/plugins/ti-tps6598x/fu-ti-tps6598x-device.c
@@ -657,9 +657,9 @@ fu_ti_tps6598x_device_write_firmware(FuDevice *device,
 				     GError **error)
 {
 	FuTiTps6598xDevice *self = FU_TI_TPS6598X_DEVICE(device);
-	g_autoptr(GInputStream) stream_sig = NULL;
-	g_autoptr(GInputStream) stream_pubkey = NULL;
-	g_autoptr(GInputStream) stream_payload = NULL;
+	g_autoptr(FuInputStream) stream_sig = NULL;
+	g_autoptr(FuInputStream) stream_pubkey = NULL;
+	g_autoptr(FuInputStream) stream_payload = NULL;
 	g_autoptr(FuChunkArray) chunks_pubkey = NULL;
 	g_autoptr(FuChunkArray) chunks_sig = NULL;
 	g_autoptr(FuChunkArray) chunks_payload = NULL;

--- a/plugins/ti-tps6598x/fu-ti-tps6598x-firmware.c
+++ b/plugins/ti-tps6598x/fu-ti-tps6598x-firmware.c
@@ -20,7 +20,7 @@ G_DEFINE_TYPE(FuTiTps6598xFirmware, fu_ti_tps6598x_firmware, FU_TYPE_FIRMWARE)
 
 static gboolean
 fu_ti_tps6598x_firmware_validate(FuFirmware *firmware,
-				 GInputStream *stream,
+				 FuInputStream *stream,
 				 gsize offset,
 				 GError **error)
 {
@@ -29,7 +29,7 @@ fu_ti_tps6598x_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_ti_tps6598x_firmware_parse(FuFirmware *firmware,
-			      GInputStream *stream,
+			      FuInputStream *stream,
 			      FuFirmwareParseFlags flags,
 			      GError **error)
 {
@@ -40,9 +40,9 @@ fu_ti_tps6598x_firmware_parse(FuFirmware *firmware,
 	g_autoptr(FuFirmware) img_payload = fu_firmware_new();
 	g_autoptr(FuFirmware) img_pubkey = fu_firmware_new();
 	g_autoptr(FuFirmware) img_sig = fu_firmware_new();
-	g_autoptr(GInputStream) stream_payload = NULL;
-	g_autoptr(GInputStream) stream_pubkey = NULL;
-	g_autoptr(GInputStream) stream_sig = NULL;
+	g_autoptr(FuInputStream) stream_payload = NULL;
+	g_autoptr(FuInputStream) stream_pubkey = NULL;
+	g_autoptr(FuInputStream) stream_sig = NULL;
 
 	/* skip magic */
 	if (!fu_size_checked_inc(&offset, 0x4, error)) {

--- a/plugins/tpm/fu-tpm-plugin.c
+++ b/plugins/tpm/fu-tpm-plugin.c
@@ -393,7 +393,7 @@ fu_tpm_plugin_coldplug_eventlog(FuPlugin *plugin, GError **error)
 	blob = fu_bytes_get_contents(fn, error);
 	if (blob == NULL)
 		return FALSE;
-	stream = g_memory_input_stream_new_from_bytes(blob);
+	stream = fu_memory_input_stream_new_from_bytes(blob);
 	eventlog = fu_firmware_new_from_gtypes(stream,
 					       0x0,
 					       FU_FIRMWARE_PARSE_FLAG_NONE,

--- a/plugins/tpm/fu-tpm-plugin.c
+++ b/plugins/tpm/fu-tpm-plugin.c
@@ -371,7 +371,7 @@ fu_tpm_plugin_coldplug_eventlog(FuPlugin *plugin, GError **error)
 	FuTpmPlugin *self = FU_TPM_PLUGIN(plugin);
 	g_autoptr(FuFirmware) eventlog = NULL;
 	g_autoptr(GBytes) blob = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autofree gchar *fn = NULL;
 	g_autofree gchar *str = NULL;
 

--- a/plugins/tpm/fu-tpm-v2-device.c
+++ b/plugins/tpm/fu-tpm-v2-device.c
@@ -325,7 +325,7 @@ fu_tpm_v2_device_setup(FuDevice *device, GError **error)
 
 static gboolean
 fu_tpm_v2_device_upgrade_data(FuTpmV2Device *self,
-			      GInputStream *stream,
+			      FuInputStream *stream,
 			      FuProgress *progress,
 			      GError **error)
 {
@@ -400,7 +400,7 @@ fu_tpm_v2_device_write_firmware(FuDevice *device,
 	FuTpmV2Device *self = FU_TPM_V2_DEVICE(device);
 	TPM2B_DIGEST digest = {0x0};
 	TSS2_RC rc;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/uefi-capsule/fu-acpi-uefi.c
+++ b/plugins/uefi-capsule/fu-acpi-uefi.c
@@ -34,7 +34,7 @@ fu_acpi_uefi_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuilder
 }
 
 static gboolean
-fu_acpi_uefi_parse_insyde(FuAcpiUefi *self, GInputStream *stream, GError **error)
+fu_acpi_uefi_parse_insyde(FuAcpiUefi *self, FuInputStream *stream, GError **error)
 {
 	const gchar *needle = "$QUIRK";
 	gsize data_offset = 0;
@@ -72,13 +72,13 @@ fu_acpi_uefi_parse_insyde(FuAcpiUefi *self, GInputStream *stream, GError **error
 
 static gboolean
 fu_acpi_uefi_parse(FuFirmware *firmware,
-		   GInputStream *stream,
+		   FuInputStream *stream,
 		   FuFirmwareParseFlags flags,
 		   GError **error)
 {
 	FuAcpiUefi *self = FU_ACPI_UEFI(firmware);
 	fwupd_guid_t guid = {0x0};
-	g_autoptr(GInputStream) stream_payload = NULL;
+	g_autoptr(FuInputStream) stream_payload = NULL;
 
 	/* FuAcpiTable->parse */
 	if (!FU_FIRMWARE_CLASS(fu_acpi_uefi_parent_class)

--- a/plugins/uefi-capsule/fu-bitmap-image.c
+++ b/plugins/uefi-capsule/fu-bitmap-image.c
@@ -27,7 +27,7 @@ fu_bitmap_image_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuil
 
 static gboolean
 fu_bitmap_image_parse(FuFirmware *firmware,
-		      GInputStream *stream,
+		      FuInputStream *stream,
 		      FuFirmwareParseFlags flags,
 		      GError **error)
 {

--- a/plugins/uefi-capsule/fu-self-test.c
+++ b/plugins/uefi-capsule/fu-self-test.c
@@ -30,7 +30,7 @@ fu_uefi_update_esp_valid_func(void)
 	g_autoptr(GBytes) blob = g_bytes_new_static((const guint8 *)"BOB", 3);
 	g_autoptr(GBytes) blob_padded = fu_bytes_pad(blob, 4 * FU_MB, 0xFF);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = g_memory_input_stream_new_from_bytes(blob_padded);
+	g_autoptr(FuInputStream) stream = g_memory_input_stream_new_from_bytes(blob_padded);
 
 	/* enough to fit the firmware */
 	fu_volume_set_filesystem_free(volume_esp, 10 * FU_MB);
@@ -57,7 +57,7 @@ fu_uefi_update_esp_invalid_func(void)
 	g_autoptr(GBytes) blob = g_bytes_new_static((const guint8 *)"BOB", 3);
 	g_autoptr(GBytes) blob_padded = fu_bytes_pad(blob, 4 * FU_MB, 0xFF);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = g_memory_input_stream_new_from_bytes(blob_padded);
+	g_autoptr(FuInputStream) stream = g_memory_input_stream_new_from_bytes(blob_padded);
 
 	/* enough to fit the firmware */
 	fu_volume_set_filesystem_free(volume_esp, FU_MB);
@@ -84,7 +84,7 @@ fu_uefi_update_esp_no_backup_func(void)
 	g_autoptr(GBytes) blob = g_bytes_new_static((const guint8 *)"BOB", 3);
 	g_autoptr(GBytes) blob_padded = fu_bytes_pad(blob, 4 * FU_MB, 0xFF);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = g_memory_input_stream_new_from_bytes(blob_padded);
+	g_autoptr(FuInputStream) stream = g_memory_input_stream_new_from_bytes(blob_padded);
 
 	/* enough to fit the firmware */
 	fu_volume_set_filesystem_free(volume_esp, 6 * FU_MB);
@@ -153,7 +153,7 @@ fu_uefi_bitmap_func(void)
 	g_autofree gchar *fn = NULL;
 	g_autoptr(FuBitmapImage) bmp_image = fu_bitmap_image_new();
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	fn = g_test_build_filename(G_TEST_DIST, "tests", "test.bmp", NULL);
 	stream = fu_input_stream_from_path(fn, &error);

--- a/plugins/uefi-capsule/fu-self-test.c
+++ b/plugins/uefi-capsule/fu-self-test.c
@@ -30,7 +30,7 @@ fu_uefi_update_esp_valid_func(void)
 	g_autoptr(GBytes) blob = g_bytes_new_static((const guint8 *)"BOB", 3);
 	g_autoptr(GBytes) blob_padded = fu_bytes_pad(blob, 4 * FU_MB, 0xFF);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(FuInputStream) stream = g_memory_input_stream_new_from_bytes(blob_padded);
+	g_autoptr(FuInputStream) stream = fu_memory_input_stream_new_from_bytes(blob_padded);
 
 	/* enough to fit the firmware */
 	fu_volume_set_filesystem_free(volume_esp, 10 * FU_MB);
@@ -57,7 +57,7 @@ fu_uefi_update_esp_invalid_func(void)
 	g_autoptr(GBytes) blob = g_bytes_new_static((const guint8 *)"BOB", 3);
 	g_autoptr(GBytes) blob_padded = fu_bytes_pad(blob, 4 * FU_MB, 0xFF);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(FuInputStream) stream = g_memory_input_stream_new_from_bytes(blob_padded);
+	g_autoptr(FuInputStream) stream = fu_memory_input_stream_new_from_bytes(blob_padded);
 
 	/* enough to fit the firmware */
 	fu_volume_set_filesystem_free(volume_esp, FU_MB);
@@ -84,7 +84,7 @@ fu_uefi_update_esp_no_backup_func(void)
 	g_autoptr(GBytes) blob = g_bytes_new_static((const guint8 *)"BOB", 3);
 	g_autoptr(GBytes) blob_padded = fu_bytes_pad(blob, 4 * FU_MB, 0xFF);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(FuInputStream) stream = g_memory_input_stream_new_from_bytes(blob_padded);
+	g_autoptr(FuInputStream) stream = fu_memory_input_stream_new_from_bytes(blob_padded);
 
 	/* enough to fit the firmware */
 	fu_volume_set_filesystem_free(volume_esp, 6 * FU_MB);

--- a/plugins/uefi-capsule/fu-uefi-capsule-device.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-device.c
@@ -798,7 +798,7 @@ fu_uefi_capsule_device_build_efi_path(FuUefiCapsuleDevice *self,
 
 static FuFirmware *
 fu_uefi_capsule_device_prepare_firmware(FuDevice *device,
-					GInputStream *stream,
+					FuInputStream *stream,
 					FuProgress *progress,
 					FuFirmwareParseFlags flags,
 					GError **error)

--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -324,7 +324,7 @@ fu_uefi_capsule_plugin_get_splash_data(FuUefiCapsulePlugin *self,
 	g_autofree gchar *filename_archive = NULL;
 	g_autofree gchar *langs_str = NULL;
 	g_autoptr(FuFirmware) archive = fu_zip_firmware_new();
-	g_autoptr(GInputStream) stream_archive = NULL;
+	g_autoptr(FuInputStream) stream_archive = NULL;
 
 	/* load archive */
 	filename_archive = fu_context_build_filename(ctx,

--- a/plugins/uefi-capsule/fu-uefi-update-info.c
+++ b/plugins/uefi-capsule/fu-uefi-update-info.c
@@ -144,7 +144,7 @@ fu_uefi_update_info_write(FuFirmware *firmware, GError **error)
 
 static gboolean
 fu_uefi_update_info_parse(FuFirmware *firmware,
-			  GInputStream *stream,
+			  FuInputStream *stream,
 			  FuFirmwareParseFlags flags,
 			  GError **error)
 {

--- a/plugins/uefi-dbx/fu-uefi-dbx-device.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-device.c
@@ -169,7 +169,7 @@ fu_uefi_dbx_device_vendor_notify_cb(FuDevice *device, GParamSpec *pspec, gpointe
 
 static FuFirmware *
 fu_uefi_dbx_device_prepare_firmware(FuDevice *device,
-				    GInputStream *stream,
+				    FuInputStream *stream,
 				    FuProgress *progress,
 				    FuFirmwareParseFlags flags,
 				    GError **error)

--- a/plugins/uefi-sbat/fu-uefi-sbat-device.c
+++ b/plugins/uefi-sbat/fu-uefi-sbat-device.c
@@ -55,7 +55,7 @@ fu_uefi_sbat_device_probe(FuDevice *device, GError **error)
 
 static FuFirmware *
 fu_uefi_sbat_device_prepare_firmware(FuDevice *device,
-				     GInputStream *stream,
+				     FuInputStream *stream,
 				     FuProgress *progress,
 				     FuFirmwareParseFlags flags,
 				     GError **error)
@@ -63,7 +63,7 @@ fu_uefi_sbat_device_prepare_firmware(FuDevice *device,
 	FuContext *ctx = fu_device_get_context(device);
 	g_autoptr(FuFirmware) firmware_pefile = fu_pefile_firmware_new();
 	g_autoptr(FuFirmware) firmware_sbat = fu_uefi_sbat_firmware_new();
-	g_autoptr(GInputStream) stream_sbata = NULL;
+	g_autoptr(FuInputStream) stream_sbata = NULL;
 	g_autoptr(GPtrArray) esp_files = NULL;
 
 	if (!fu_firmware_parse_stream(firmware_pefile, stream, 0x0, flags, error))

--- a/plugins/uefi-sbat/fu-uefi-sbat-firmware.c
+++ b/plugins/uefi-sbat/fu-uefi-sbat-firmware.c
@@ -16,7 +16,7 @@ G_DEFINE_TYPE(FuUefiSbatFirmware, fu_uefi_sbat_firmware, FU_TYPE_CSV_FIRMWARE)
 
 static gboolean
 fu_uefi_sbat_firmware_parse(FuFirmware *firmware,
-			    GInputStream *stream,
+			    FuInputStream *stream,
 			    FuFirmwareParseFlags flags,
 			    GError **error)
 {

--- a/plugins/uf2/fu-uf2-device.c
+++ b/plugins/uf2/fu-uf2-device.c
@@ -21,7 +21,7 @@ G_DEFINE_TYPE(FuUf2Device, fu_uf2_device, FU_TYPE_BLOCK_PARTITION)
 
 static FuFirmware *
 fu_uf2_device_prepare_firmware(FuDevice *device,
-			       GInputStream *stream,
+			       FuInputStream *stream,
 			       FuProgress *progress,
 			       FuFirmwareParseFlags flags,
 			       GError **error)
@@ -108,7 +108,7 @@ fu_uf2_device_write_firmware(FuDevice *device,
 {
 	FuUf2Device *self = FU_UF2_DEVICE(device);
 	g_autofree gchar *fn = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* get blob */
 	stream = fu_firmware_get_stream(firmware, error);

--- a/plugins/uf2/fu-uf2-firmware.c
+++ b/plugins/uf2/fu-uf2-firmware.c
@@ -176,7 +176,7 @@ fu_uf2_firmware_parse_chunk(FuUf2Firmware *self, FuChunk *chk, GByteArray *tmp, 
 
 static gboolean
 fu_uf2_firmware_parse(FuFirmware *firmware,
-		      GInputStream *stream,
+		      FuInputStream *stream,
 		      FuFirmwareParseFlags flags,
 		      GError **error)
 {
@@ -292,7 +292,7 @@ fu_uf2_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuUf2Firmware *self = FU_UF2_FIRMWARE(firmware);
 	g_autoptr(GByteArray) buf = g_byte_array_new();
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* data first */

--- a/plugins/usi-dock/fu-usi-dock-child-device.c
+++ b/plugins/usi-dock/fu-usi-dock-child-device.c
@@ -41,7 +41,7 @@ fu_usi_dock_child_device_to_string(FuDevice *device, guint idt, GString *str)
 /* use the parents parser */
 static FuFirmware *
 fu_usi_dock_child_device_prepare_firmware(FuDevice *device,
-					  GInputStream *stream,
+					  FuInputStream *stream,
 					  FuProgress *progress,
 					  FuFirmwareParseFlags flags,
 					  GError **error)

--- a/plugins/usi-dock/fu-usi-dock-mcu-device.c
+++ b/plugins/usi-dock/fu-usi-dock-mcu-device.c
@@ -671,7 +671,7 @@ fu_usi_dock_mcu_device_write_firmware_with_idx(FuUsiDockMcuDevice *self,
 					       GError **error)
 {
 	guint8 cmd;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 	guint8 checksum = 0xFF;
 

--- a/plugins/vbe/fu-vbe-simple-device.c
+++ b/plugins/vbe/fu-vbe-simple-device.c
@@ -224,7 +224,7 @@ fu_vbe_simple_device_get_cfg_compatible(FuVbeSimpleDevice *self,
 
 static FuFirmware *
 fu_vbe_simple_device_prepare_firmware(FuDevice *device,
-				      GInputStream *stream,
+				      FuInputStream *stream,
 				      FuProgress *progress,
 				      FuFirmwareParseFlags flags,
 				      GError **error)

--- a/plugins/vendor-example/fu-vendor-example-device.c.in
+++ b/plugins/vendor-example/fu-vendor-example-device.c.in
@@ -146,7 +146,7 @@ fu_{{vendor_example}}_device_cleanup(FuDevice *device,
 
 static FuFirmware *
 fu_{{vendor_example}}_device_prepare_firmware(FuDevice *device,
-					  GInputStream *stream,
+					  FuInputStream *stream,
 					  FuProgress *progress,
 					  FwupdInstallFlags flags,
 					  GError **error)
@@ -240,7 +240,7 @@ fu_{{vendor_example}}_device_write_firmware(FuDevice *device,
 					GError **error)
 {
 	Fu{{VendorExample}}Device *self = FU_{{VENDOR_EXAMPLE}}_DEVICE(device);
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */

--- a/plugins/vendor-example/fu-vendor-example-firmware.c.in
+++ b/plugins/vendor-example/fu-vendor-example-firmware.c.in
@@ -44,7 +44,7 @@ fu_{{vendor_example}}_firmware_build(FuFirmware *firmware, XbNode *n, GError **e
 
 static gboolean
 fu_{{vendor_example}}_firmware_validate(FuFirmware *firmware,
-					GInputStream *stream,
+					FuInputStream *stream,
 					gsize offset,
 					GError **error)
 {
@@ -55,7 +55,7 @@ fu_{{vendor_example}}_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_{{vendor_example}}_firmware_parse(FuFirmware *firmware,
-				 GInputStream *stream, FuFirmwareParseFlags flags,
+				 FuInputStream *stream, FuFirmwareParseFlags flags,
 				 GError **error)
 {
 	Fu{{VendorExample}}Firmware *self = FU_{{VENDOR_EXAMPLE}}_FIRMWARE(firmware);

--- a/plugins/vli/fu-vli-pd-firmware.c
+++ b/plugins/vli/fu-vli-pd-firmware.c
@@ -36,7 +36,7 @@ fu_vli_pd_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbB
 
 static gboolean
 fu_vli_pd_firmware_parse(FuFirmware *firmware,
-			 GInputStream *stream,
+			 FuInputStream *stream,
 			 FuFirmwareParseFlags flags,
 			 GError **error)
 {
@@ -71,7 +71,7 @@ fu_vli_pd_firmware_parse(FuFirmware *firmware,
 	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		guint16 crc_actual = 0xFFFF;
 		guint16 crc_file = 0x0;
-		g_autoptr(GInputStream) stream_tmp = NULL;
+		g_autoptr(FuInputStream) stream_tmp = NULL;
 
 		if (streamsz < 2) {
 			g_set_error_literal(error,

--- a/plugins/vli/fu-vli-usbhub-firmware.c
+++ b/plugins/vli/fu-vli-usbhub-firmware.c
@@ -43,7 +43,7 @@ fu_vli_usbhub_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags,
 
 static gboolean
 fu_vli_usbhub_firmware_parse_version(FuVliUsbhubFirmware *self,
-				     GInputStream *stream,
+				     FuInputStream *stream,
 				     guint8 strapping1,
 				     GError **error)
 {
@@ -128,7 +128,7 @@ fu_vli_usbhub_firmware_parse_version(FuVliUsbhubFirmware *self,
 
 static gboolean
 fu_vli_usbhub_firmware_parse(FuFirmware *firmware,
-			     GInputStream *stream,
+			     FuInputStream *stream,
 			     FuFirmwareParseFlags flags,
 			     GError **error)
 {

--- a/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
+++ b/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
@@ -288,7 +288,7 @@ fu_vli_usbhub_rtd21xx_device_write_firmware(FuDevice *device,
 	guint8 project_id_count;
 	guint8 read_buf[10] = {0};
 	guint8 write_buf[ISP_PACKET_SIZE] = {0};
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */

--- a/plugins/wacom-usb/fu-wacom-usb-device.c
+++ b/plugins/wacom-usb/fu-wacom-usb-device.c
@@ -447,8 +447,9 @@ fu_wacom_usb_device_write_checksum_table(FuWacomUsbDevice *self, GError **error)
 gboolean
 fu_wacom_usb_device_switch_to_flash_loader(FuWacomUsbDevice *self, GError **error)
 {
-	guint8 buf[] =
-	    {[0] = FU_WACOM_USB_REPORT_ID_SWITCH_TO_FLASH_LOADER, [1] = 0x05, [2] = 0x6a};
+	guint8 buf[] = {[0] = FU_WACOM_USB_REPORT_ID_SWITCH_TO_FLASH_LOADER,
+			[1] = 0x05,
+			[2] = 0x6a};
 
 	/* hit hardware */
 	return fu_wacom_usb_device_set_feature_report(self,

--- a/plugins/wacom-usb/fu-wacom-usb-firmware.c
+++ b/plugins/wacom-usb/fu-wacom-usb-firmware.c
@@ -262,7 +262,7 @@ fu_wacom_usb_firmware_tokenize_cb(GString *token,
 
 static gboolean
 fu_wacom_usb_firmware_validate(FuFirmware *firmware,
-			       GInputStream *stream,
+			       FuInputStream *stream,
 			       gsize offset,
 			       GError **error)
 {
@@ -271,7 +271,7 @@ fu_wacom_usb_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_wacom_usb_firmware_parse(FuFirmware *firmware,
-			    GInputStream *stream,
+			    FuInputStream *stream,
 			    FuFirmwareParseFlags flags,
 			    GError **error)
 {

--- a/plugins/wacom-usb/fu-wacom-usb-module-bluetooth-id6.c
+++ b/plugins/wacom-usb/fu-wacom-usb-module-bluetooth-id6.c
@@ -63,7 +63,7 @@ fu_wacom_usb_module_bluetooth_id6_calculate_crc(const guint8 *buf, gsize bufsz)
 
 static gboolean
 fu_wacom_usb_module_bluetooth_id6_write_blob(FuWacomUsbModule *self,
-					     GInputStream *stream,
+					     FuInputStream *stream,
 					     FuProgress *progress,
 					     GError **error)
 {
@@ -130,7 +130,7 @@ fu_wacom_usb_module_bluetooth_id6_write_firmware(FuDevice *device,
 	FuWacomUsbModule *self = FU_WACOM_USB_MODULE(device);
 	const guint8 buf_start[] = {FU_WACOM_USB_MODULE_BLUETOOTH_ID6_START_NORMAL};
 	g_autoptr(GBytes) blob_start = g_bytes_new_static(buf_start, sizeof(buf_start));
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/wacom-usb/fu-wacom-usb-module-bluetooth-id9.c
+++ b/plugins/wacom-usb/fu-wacom-usb-module-bluetooth-id9.c
@@ -38,12 +38,12 @@ G_DEFINE_TYPE(FuWacomUsbModuleBluetoothId9,
 /* CRC(concat(spi_cmd, data)) */
 static gboolean
 fu_wacom_usb_module_bluetooth_id9_calculate_crc32(GByteArray *buf,
-						  GInputStream *stream,
+						  FuInputStream *stream,
 						  guint32 *crc,
 						  GError **error)
 {
 	g_autoptr(GBytes) blob = g_bytes_new(buf->data, buf->len);
-	g_autoptr(GInputStream) composite_stream = fu_composite_input_stream_new();
+	g_autoptr(FuInputStream) composite_stream = fu_composite_input_stream_new();
 	if (!fu_composite_input_stream_add_bytes(FU_COMPOSITE_INPUT_STREAM(composite_stream),
 						 blob,
 						 error))
@@ -59,7 +59,7 @@ fu_wacom_usb_module_bluetooth_id9_calculate_crc32(GByteArray *buf,
 }
 
 static FuChunk *
-fu_wacom_usb_module_bluetooth_id9_get_startcmd(GInputStream *stream,
+fu_wacom_usb_module_bluetooth_id9_get_startcmd(FuInputStream *stream,
 					       gboolean full_erase,
 					       GError **error)
 {
@@ -130,7 +130,7 @@ fu_wacom_usb_module_bluetooth_id9_write_block(FuWacomUsbModule *self,
 static gboolean
 fu_wacom_usb_module_bluetooth_id9_write_blocks(FuWacomUsbModule *self,
 					       guint8 phase,
-					       GInputStream *stream,
+					       FuInputStream *stream,
 					       gsize block_len,
 					       FuProgress *progress,
 					       GError **error)
@@ -168,7 +168,7 @@ fu_wacom_usb_module_bluetooth_id9_write_blocks(FuWacomUsbModule *self,
 
 static FuFirmware *
 fu_wacom_usb_module_bluetooth_id9_prepare_firmware(FuDevice *device,
-						   GInputStream *stream,
+						   FuInputStream *stream,
 						   FuProgress *progress,
 						   FuFirmwareParseFlags flags,
 						   GError **error)
@@ -240,8 +240,8 @@ fu_wacom_usb_module_bluetooth_id9_write_firmware(FuDevice *device,
 	FuWacomUsbModule *self = FU_WACOM_USB_MODULE(device);
 	const guint8 buf_start[] = {FU_WACOM_USB_MODULE_BLUETOOTH_ID9_START_NORMAL};
 	g_autoptr(GBytes) blob_start = g_bytes_new_static(buf_start, sizeof(buf_start));
-	g_autoptr(GInputStream) stream_loader = NULL;
-	g_autoptr(GInputStream) stream_payload = NULL;
+	g_autoptr(FuInputStream) stream_loader = NULL;
+	g_autoptr(FuInputStream) stream_payload = NULL;
 	g_autoptr(FuChunk) cmd = NULL;
 
 	/* get firmware images */

--- a/plugins/wacom-usb/fu-wacom-usb-module-sub-cpu.c
+++ b/plugins/wacom-usb/fu-wacom-usb-module-sub-cpu.c
@@ -213,7 +213,7 @@ fu_wacom_usb_module_sub_cpu_write_firmware(FuDevice *device,
 
 static FuFirmware *
 fu_wacom_usb_module_sub_cpu_prepare_firmware(FuDevice *device,
-					     GInputStream *stream,
+					     FuInputStream *stream,
 					     FuProgress *progress,
 					     FuFirmwareParseFlags flags,
 					     GError **error)

--- a/plugins/wacom-usb/fu-wacom-usb-module-touch.c
+++ b/plugins/wacom-usb/fu-wacom-usb-module-touch.c
@@ -26,7 +26,7 @@ fu_wacom_usb_module_touch_write_firmware(FuDevice *device,
 					 GError **error)
 {
 	FuWacomUsbModule *self = FU_WACOM_USB_MODULE(device);
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */

--- a/plugins/wistron-dock/fu-wistron-dock-device.c
+++ b/plugins/wistron-dock/fu-wistron-dock-device.c
@@ -332,7 +332,7 @@ fu_wistron_dock_device_write_blocks(FuWistronDockDevice *self,
 
 static FuFirmware *
 fu_wistron_dock_device_prepare_firmware(FuDevice *device,
-					GInputStream *stream,
+					FuInputStream *stream,
 					FuProgress *progress,
 					FuFirmwareParseFlags flags,
 					GError **error)
@@ -397,7 +397,7 @@ fu_wistron_dock_device_write_firmware(FuDevice *device,
 				      GError **error)
 {
 	FuWistronDockDevice *self = FU_WISTRON_DOCK_DEVICE(device);
-	g_autoptr(GInputStream) stream_cbin = NULL;
+	g_autoptr(FuInputStream) stream_cbin = NULL;
 	g_autoptr(GBytes) fw_wdfl = NULL;
 	g_autoptr(GBytes) fw_wsig = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;

--- a/src/fu-cabinet-test.c
+++ b/src/fu-cabinet-test.c
@@ -69,7 +69,7 @@ fu_cabinet_func(void)
 	g_autoptr(GBytes) jcat_blob1 = g_bytes_new_static("hello", 6);
 	g_autoptr(GBytes) jcat_blob2 = g_bytes_new_static("hellX", 6);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	filename = g_test_build_filename(G_TEST_BUILT,
 					 "tests",

--- a/src/fu-cabinet.c
+++ b/src/fu-cabinet.c
@@ -114,7 +114,7 @@ fu_cabinet_verify_payload_target(FuCabinet *self,
 	g_autofree gchar *checksum_sha256 = NULL;
 	g_autofree gchar *checksum_sha512 = NULL;
 	g_autoptr(GPtrArray) results = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(FwupdJcatBlob) blob_target_sha256 = NULL;
 	g_autoptr(FwupdJcatBlob) blob_target_sha512 = NULL;
 	g_autoptr(FwupdJcatItem) item = NULL;
@@ -232,7 +232,7 @@ fu_cabinet_parse_release(FuCabinet *self,
 	gsize streamsz = 0;
 	g_autofree gchar *basename = NULL;
 	g_autoptr(FuFirmware) img_blob = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(GError) error_local2 = NULL;
 	g_autoptr(GError) error_payload = NULL;
 	g_autoptr(XbNode) artifact = NULL;
@@ -614,7 +614,7 @@ fu_cabinet_build_jcat_folder(FuCabinet *self, FuFirmware *img, GError **error)
 		return FALSE;
 	}
 	if (g_str_has_suffix(fn, ".jcat")) {
-		g_autoptr(GInputStream) istream = NULL;
+		g_autoptr(FuInputStream) istream = NULL;
 		istream = fu_firmware_get_stream(img, error);
 		if (istream == NULL)
 			return FALSE;
@@ -929,7 +929,7 @@ fu_cabinet_sign(FuCabinet *self,
 	/* load existing .jcat file if it exists */
 	img = fu_firmware_get_image_by_id(FU_FIRMWARE(self), "firmware.jcat", NULL);
 	if (img != NULL) {
-		g_autoptr(GInputStream) stream = fu_firmware_get_stream(img, error);
+		g_autoptr(FuInputStream) stream = fu_firmware_get_stream(img, error);
 		if (stream == NULL)
 			return FALSE;
 		if (!g_seekable_seek(G_SEEKABLE(stream), 0x0, G_SEEK_SET, NULL, error))
@@ -969,7 +969,7 @@ fu_cabinet_sign(FuCabinet *self,
 
 static gboolean
 fu_cabinet_parse(FuFirmware *firmware,
-		 GInputStream *stream,
+		 FuInputStream *stream,
 		 FuFirmwareParseFlags flags,
 		 GError **error)
 {

--- a/src/fu-cabinet.c
+++ b/src/fu-cabinet.c
@@ -621,7 +621,9 @@ fu_cabinet_build_jcat_folder(FuCabinet *self, FuFirmware *img, GError **error)
 		/* TODO: move this to libjcat? */
 		if (!g_seekable_seek(G_SEEKABLE(istream), 0x0, G_SEEK_SET, NULL, error))
 			return FALSE;
-		if (!fwupd_jcat_file_import_stream(self->jcat_file, istream, error)) {
+		if (!fwupd_jcat_file_import_stream(self->jcat_file,
+						   G_INPUT_STREAM(istream),
+						   error)) {
 			g_prefix_error_literal(error, "failed to import JCat stream: ");
 			return FALSE;
 		}
@@ -934,7 +936,7 @@ fu_cabinet_sign(FuCabinet *self,
 			return FALSE;
 		if (!g_seekable_seek(G_SEEKABLE(stream), 0x0, G_SEEK_SET, NULL, error))
 			return FALSE;
-		if (!fwupd_jcat_file_import_stream(jcat_file, stream, error))
+		if (!fwupd_jcat_file_import_stream(jcat_file, G_INPUT_STREAM(stream), error))
 			return FALSE;
 	}
 

--- a/src/fu-dbus-daemon.c
+++ b/src/fu-dbus-daemon.c
@@ -269,7 +269,7 @@ typedef struct {
 	GPtrArray *checksums;
 	GPtrArray *errors;
 	guint64 flags;
-	GInputStream *stream;
+	FuInputStream *stream;
 	FuDbusDaemon *self;
 	gchar *device_id;
 	gchar *remote_id;
@@ -1048,14 +1048,14 @@ fu_dbus_daemon_client_flags_notify_cb(FuClient *client, GParamSpec *pspec, FuMai
 }
 #endif
 
-static GInputStream *
+static FuInputStream *
 fu_dbus_daemon_invocation_get_input_stream(GDBusMethodInvocation *invocation, GError **error)
 {
 #ifdef HAVE_GIO_UNIX
 	GDBusMessage *message;
 	GUnixFDList *fd_list;
 	g_autofd gint fd = -1;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* get the fd */
 	message = g_dbus_method_invocation_get_message(invocation);
@@ -1667,7 +1667,7 @@ fu_dbus_daemon_authorize_emulation_load_cb(GObject *source, GAsyncResult *res, g
 {
 	g_autoptr(FuMainAuthHelper) helper = (FuMainAuthHelper *)user_data;
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	FuEngine *engine = fu_daemon_get_engine(FU_DAEMON(helper->self));
 
 	/* get result */
@@ -2538,7 +2538,7 @@ fu_dbus_daemon_method_get_details(FuDbusDaemon *self,
 	FuEngine *engine = fu_daemon_get_engine(FU_DAEMON(self));
 	gint32 fd_handle = 0;
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(GPtrArray) results = NULL;
 
 	/* get parameters */

--- a/src/fu-engine-emulator.c
+++ b/src/fu-engine-emulator.c
@@ -12,6 +12,7 @@
 #include "fu-context-private.h"
 #include "fu-device-private.h"
 #include "fu-engine-emulator.h"
+#include "fu-input-stream.h"
 
 struct _FuEngineEmulator {
 	GObject parent_instance;
@@ -273,7 +274,7 @@ fu_engine_emulator_load_phases(FuEngineEmulator *self,
 }
 
 gboolean
-fu_engine_emulator_load(FuEngineEmulator *self, GInputStream *stream, GError **error)
+fu_engine_emulator_load(FuEngineEmulator *self, FuInputStream *stream, GError **error)
 {
 	gboolean got_json = FALSE;
 	const gchar *json_empty = "{\"UsbDevices\":[]}";
@@ -282,7 +283,7 @@ fu_engine_emulator_load(FuEngineEmulator *self, GInputStream *stream, GError **e
 	g_autoptr(GError) error_archive = NULL;
 
 	g_return_val_if_fail(FU_IS_ENGINE_EMULATOR(self), FALSE);
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	/* unload any existing devices */

--- a/src/fu-engine-emulator.h
+++ b/src/fu-engine-emulator.h
@@ -8,6 +8,7 @@
 
 #include "fu-engine-struct.h"
 #include "fu-engine.h"
+#include "fu-input-stream.h"
 
 #define FU_TYPE_ENGINE_EMULATOR (fu_engine_emulator_get_type())
 G_DECLARE_FINAL_TYPE(FuEngineEmulator, fu_engine_emulator, FU, ENGINE_EMULATOR, GObject)
@@ -27,7 +28,7 @@ gboolean
 fu_engine_emulator_save(FuEngineEmulator *self, GOutputStream *stream, GError **error)
     G_GNUC_NON_NULL(1, 2);
 gboolean
-fu_engine_emulator_load(FuEngineEmulator *self, GInputStream *stream, GError **error)
+fu_engine_emulator_load(FuEngineEmulator *self, FuInputStream *stream, GError **error)
     G_GNUC_NON_NULL(1, 2);
 gboolean
 fu_engine_emulator_load_phase(FuEngineEmulator *self,

--- a/src/fu-engine-gtypes-test.c
+++ b/src/fu-engine-gtypes-test.c
@@ -11,6 +11,7 @@
 #include "fu-drm-device-private.h"
 #include "fu-engine.h"
 #include "fu-firmware-private.h"
+#include "fu-input-stream.h"
 #include "fu-plugin-private.h"
 #include "fu-security-attrs-private.h"
 
@@ -30,7 +31,7 @@ fu_engine_plugin_device_gtype(FuContext *ctx, GType gtype, gboolean is_fake)
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GHashTable) metadata_post = NULL;
 	g_autoptr(GHashTable) metadata_pre = NULL;
-	g_autoptr(GInputStream) stream = g_memory_input_stream_new();
+	g_autoptr(FuInputStream) stream = g_memory_input_stream_new();
 
 	g_debug("loading %s", g_type_name(gtype));
 	device = g_object_new(gtype, "context", ctx, "physical-id", "/sys", NULL);

--- a/src/fu-engine-gtypes-test.c
+++ b/src/fu-engine-gtypes-test.c
@@ -31,7 +31,7 @@ fu_engine_plugin_device_gtype(FuContext *ctx, GType gtype, gboolean is_fake)
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GHashTable) metadata_post = NULL;
 	g_autoptr(GHashTable) metadata_pre = NULL;
-	g_autoptr(FuInputStream) stream = g_memory_input_stream_new();
+	g_autoptr(FuInputStream) stream = fu_memory_input_stream_new();
 
 	g_debug("loading %s", g_type_name(gtype));
 	device = g_object_new(gtype, "context", ctx, "physical-id", "/sys", NULL);

--- a/src/fu-engine-test.c
+++ b/src/fu-engine-test.c
@@ -16,6 +16,7 @@
 #include "fu-engine-requirements.h"
 #include "fu-engine.h"
 #include "fu-history.h"
+#include "fu-input-stream.h"
 #include "fu-plugin-private.h"
 #include "fu-remote.h"
 #include "fu-test.h"
@@ -833,7 +834,7 @@ fu_engine_require_hwid_func(void)
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(FuRelease) release = fu_release_new();
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(XbNode) component = NULL;
 	g_autoptr(XbSilo) silo_empty = xb_silo_new();
 
@@ -904,7 +905,7 @@ fu_engine_get_details_added_func(void)
 	g_autoptr(FuEngineRequest) request = fu_engine_request_new(NULL);
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
 	g_autoptr(XbSilo) silo_empty = xb_silo_new();
 
@@ -960,7 +961,7 @@ fu_engine_get_details_missing_func(void)
 	g_autoptr(FuEngine) engine = fu_engine_new(ctx);
 	g_autoptr(FuEngineRequest) request = fu_engine_request_new(NULL);
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
 	g_autoptr(XbSilo) silo_empty = xb_silo_new();
@@ -1837,7 +1838,7 @@ fu_engine_history_func(void)
 	g_autoptr(FwupdDevice) device3 = NULL;
 	g_autoptr(FwupdDevice) device4 = NULL;
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
 	g_autoptr(XbNode) component = NULL;
 	g_autoptr(XbSilo) silo_empty = xb_silo_new();
@@ -2042,7 +2043,7 @@ fu_engine_install_loop_restart_func(void)
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(FuRelease) release = fu_release_new();
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream_fw = NULL;
+	g_autoptr(FuInputStream) stream_fw = NULL;
 	g_autoptr(XbSilo) silo_empty = xb_silo_new();
 
 	/* no metadata in daemon */
@@ -2111,7 +2112,7 @@ fu_engine_multiple_rels_func(void)
 	g_autoptr(FuPlugin) plugin = fu_plugin_new_from_gtype(fu_test_plugin_get_type(), ctx);
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(XbNode) component = NULL;
 	g_autoptr(XbSilo) silo_empty = xb_silo_new();
 	g_autoptr(FuEngineRequest) request = fu_engine_request_new(NULL);
@@ -2231,7 +2232,7 @@ fu_engine_history_inherit(void)
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(FuTemporaryDirectory) tmpdir = NULL;
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
 	g_autoptr(XbNode) component = NULL;
 	g_autoptr(XbSilo) silo_empty = xb_silo_new();
@@ -2378,7 +2379,7 @@ fu_engine_install_needs_reboot(void)
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(FuTemporaryDirectory) tmpdir = NULL;
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
 	g_autoptr(XbNode) component = NULL;
 	g_autoptr(XbSilo) silo_empty = xb_silo_new();
@@ -2496,7 +2497,7 @@ fu_engine_install_request(void)
 	g_autoptr(FuPlugin) plugin = fu_plugin_new_from_gtype(fu_test_plugin_get_type(), ctx);
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
 	g_autoptr(XbNode) component = NULL;
 	g_autoptr(XbSilo) silo_empty = xb_silo_new();
@@ -2596,7 +2597,7 @@ fu_engine_history_error_func(void)
 	g_autoptr(FuTemporaryDirectory) tmpdir = NULL;
 	g_autoptr(GError) error2 = NULL;
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
 	g_autoptr(XbNode) component = NULL;
 	g_autoptr(XbSilo) silo_empty = xb_silo_new();

--- a/src/fu-engine-test.c
+++ b/src/fu-engine-test.c
@@ -2079,7 +2079,7 @@ fu_engine_install_loop_restart_func(void)
 	fu_device_set_metadata_integer(device, "nr-update", 0);
 	fu_device_set_metadata_integer(device, "nr-attach", 0);
 
-	stream_fw = g_memory_input_stream_new_from_data((const guint8 *)"1.2.3", 5, NULL);
+	stream_fw = fu_memory_input_stream_new_from_data((const guint8 *)"1.2.3", 5, NULL);
 	fu_release_set_stream(release, stream_fw);
 	ret = fu_engine_install_blob(engine,
 				     device,

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -131,10 +131,10 @@ struct _FuEngine {
 #ifdef HAVE_PASSIM
 	PassimClient *passim_client;
 #endif
-	GPtrArray *disabled_devices;   /* (element-type utf-8) */
-	GPtrArray *disabled_plugins;   /* (element-type utf-8) */
-	GPtrArray *trusted_reports;    /* (element-type FwupdReport) */
-	GArray *trusted_uids;	       /* (element-type guint64) */
+	GPtrArray *disabled_devices; /* (element-type utf-8) */
+	GPtrArray *disabled_plugins; /* (element-type utf-8) */
+	GPtrArray *trusted_reports;  /* (element-type FwupdReport) */
+	GArray *trusted_uids;	     /* (element-type guint64) */
 };
 
 enum { PROP_0, PROP_CONTEXT, PROP_LAST };

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2506,7 +2506,7 @@ fu_engine_publish_release(FuEngine *self, FuRelease *release, GError **error)
 		if (!fu_input_stream_size(stream, &streamsz, error))
 			return FALSE;
 		passim_item_set_size(passim_item, streamsz);
-		passim_item_set_stream(passim_item, stream);
+		passim_item_set_stream(passim_item, G_INPUT_STREAM(stream));
 		passim_item_set_hash(passim_item, checksum);
 		if (!passim_client_publish(self->passim_client, passim_item, &error_passim)) {
 			if (!g_error_matches(error_passim, G_IO_ERROR, G_IO_ERROR_EXISTS)) {

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -4362,7 +4362,8 @@ fu_engine_builder_cabinet_adapter_cb(XbBuilderSource *source,
 	xml = xb_silo_export(silo, XB_NODE_EXPORT_FLAG_NONE, error);
 	if (xml == NULL)
 		return NULL;
-	return g_memory_input_stream_new_from_data(g_steal_pointer(&xml), -1, g_free);
+	return G_INPUT_STREAM(
+	    fu_memory_input_stream_new_from_data(g_steal_pointer(&xml), -1, g_free));
 }
 
 static XbBuilderSource *
@@ -4835,7 +4836,7 @@ fu_engine_get_system_jcat_result(FuEngine *self, FwupdRemote *remote, GError **e
 	istream = fu_input_stream_from_path(fwupd_remote_get_filename_cache_sig(remote), error);
 	if (istream == NULL)
 		return NULL;
-	if (!fwupd_jcat_file_import_stream(jcat_file, istream, error))
+	if (!fwupd_jcat_file_import_stream(jcat_file, G_INPUT_STREAM(istream), error))
 		return NULL;
 	jcat_item = fwupd_jcat_file_get_item_default(jcat_file, error);
 	if (jcat_item == NULL)
@@ -4953,8 +4954,8 @@ fu_engine_update_metadata_bytes(FuEngine *self,
 	}
 
 	/* verify JCatFile, or create a dummy one from legacy data */
-	istream = g_memory_input_stream_new_from_bytes(bytes_sig);
-	if (!fwupd_jcat_file_import_stream(jcat_file, istream, error))
+	istream = fu_memory_input_stream_new_from_bytes(bytes_sig);
+	if (!fwupd_jcat_file_import_stream(jcat_file, G_INPUT_STREAM(istream), error))
 		return FALSE;
 
 	/* distrusting RSA? */

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -937,7 +937,7 @@ fu_engine_get_releases_for_container_checksum(FuEngine *self, const gchar *csum)
 
 /* does this exist in any enabled remote */
 gchar *
-fu_engine_get_remote_id_for_stream(FuEngine *self, GInputStream *stream)
+fu_engine_get_remote_id_for_stream(FuEngine *self, FuInputStream *stream)
 {
 	GChecksumType checksum_types[] = {
 	    G_CHECKSUM_SHA256,
@@ -945,7 +945,7 @@ fu_engine_get_remote_id_for_stream(FuEngine *self, GInputStream *stream)
 	};
 
 	g_return_val_if_fail(FU_IS_ENGINE(self), NULL);
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), NULL);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), NULL);
 
 	for (guint i = 0; i < G_N_ELEMENTS(checksum_types); i++) {
 		g_autofree gchar *csum = NULL;
@@ -2481,7 +2481,7 @@ fu_engine_publish_release(FuEngine *self, FuRelease *release, GError **error)
 {
 #ifdef HAVE_PASSIM
 	FuDevice *device = fu_release_get_device(release);
-	GInputStream *stream = fu_release_get_stream(release);
+	FuInputStream *stream = fu_release_get_stream(release);
 
 	/* lazy load */
 	fu_engine_ensure_passim_client(self);
@@ -2904,7 +2904,7 @@ fu_engine_install_release(FuEngine *self,
 	FuEngineRequest *request = fu_release_get_request(release);
 	FuPlugin *plugin;
 	FwupdFeatureFlags feature_flags = FWUPD_FEATURE_FLAG_NONE;
-	GInputStream *stream = fu_release_get_stream(release);
+	FuInputStream *stream = fu_release_get_stream(release);
 	const gchar *tmp;
 	g_autoptr(FuDevice) device = NULL;
 	g_autoptr(FuDevice) device_tmp = NULL;
@@ -3101,12 +3101,12 @@ fu_engine_get_plugin_by_name(FuEngine *self, const gchar *name, GError **error)
 }
 
 gboolean
-fu_engine_emulation_load(FuEngine *self, GInputStream *stream, GError **error)
+fu_engine_emulation_load(FuEngine *self, FuInputStream *stream, GError **error)
 {
 	gsize streamsz = 0;
 
 	g_return_val_if_fail(FU_IS_ENGINE(self), FALSE);
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	/* sanity check */
@@ -3281,7 +3281,7 @@ fu_engine_device_check_power(FuEngine *self,
 static FuFirmware *
 fu_engine_prepare_firmware(FuEngine *self,
 			   const gchar *device_id,
-			   GInputStream *stream,
+			   FuInputStream *stream,
 			   FuProgress *progress,
 			   FuFirmwareParseFlags flags,
 			   GError **error)
@@ -3820,7 +3820,7 @@ fu_engine_install_loop(FuEngine *self,
 		       FuProgress *progress,
 		       GError **error)
 {
-	GInputStream *stream_fw;
+	FuInputStream *stream_fw;
 	gsize streamsz = 0;
 	g_autoptr(FuDevice) device = NULL;
 	g_autoptr(FuDevice) device_tmp = NULL;
@@ -4347,7 +4347,7 @@ fu_engine_builder_cabinet_adapter_cb(XbBuilderSource *source,
 				     GError **error)
 {
 	FuEngine *self = FU_ENGINE(user_data);
-	GInputStream *stream = xb_builder_source_ctx_get_stream(ctx);
+	GInputStream *stream = xb_builder_source_ctx_get_stream(ctx); /* nocheck:blocked */
 	g_autoptr(FuCabinet) cabinet = NULL;
 	g_autoptr(XbSilo) silo = NULL;
 	g_autofree gchar *xml = NULL;
@@ -4821,7 +4821,7 @@ static FuJcatResult *
 fu_engine_get_system_jcat_result(FuEngine *self, FwupdRemote *remote, GError **error)
 {
 	g_autoptr(GBytes) blob = NULL;
-	g_autoptr(GInputStream) istream = NULL;
+	g_autoptr(FuInputStream) istream = NULL;
 	g_autoptr(GPtrArray) results = NULL;
 	g_autoptr(FwupdJcatItem) jcat_item = NULL;
 	g_autoptr(FwupdJcatFile) jcat_file = fwupd_jcat_file_new();
@@ -4924,7 +4924,7 @@ fu_engine_update_metadata_bytes(FuEngine *self,
 {
 	g_autoptr(FwupdRemote) remote = NULL;
 	g_autoptr(GError) error_local = NULL;
-	g_autoptr(GInputStream) istream = NULL;
+	g_autoptr(FuInputStream) istream = NULL;
 	g_autoptr(GPtrArray) results = NULL;
 	g_autoptr(FwupdJcatFile) jcat_file = fwupd_jcat_file_new();
 	g_autoptr(FwupdJcatItem) jcat_item = NULL;
@@ -5068,8 +5068,8 @@ fu_engine_update_metadata(FuEngine *self,
 #ifdef HAVE_GIO_UNIX
 	g_autoptr(GBytes) bytes_raw = NULL;
 	g_autoptr(GBytes) bytes_sig = NULL;
-	g_autoptr(GInputStream) stream_fd = NULL;
-	g_autoptr(GInputStream) stream_sig = NULL;
+	g_autoptr(FuInputStream) stream_fd = NULL;
+	g_autoptr(FuInputStream) stream_sig = NULL;
 
 	g_return_val_if_fail(FU_IS_ENGINE(self), FALSE);
 	g_return_val_if_fail(remote_id != NULL, FALSE);
@@ -5117,7 +5117,7 @@ fu_engine_update_metadata(FuEngine *self,
 /**
  * fu_engine_build_cabinet_from_stream:
  * @self: a #FuEngine
- * @stream: a #GInputStream
+ * @stream: a #FuInputStream
  * @error: (nullable): optional return location for an error
  *
  * Creates a silo from a .cab file blob.
@@ -5125,13 +5125,13 @@ fu_engine_update_metadata(FuEngine *self,
  * Returns: (transfer container): a #XbSilo, or %NULL
  **/
 FuCabinet *
-fu_engine_build_cabinet_from_stream(FuEngine *self, GInputStream *stream, GError **error)
+fu_engine_build_cabinet_from_stream(FuEngine *self, FuInputStream *stream, GError **error)
 {
 	FuFirmwareParseFlags flags = FU_FIRMWARE_PARSE_FLAG_CACHE_STREAM;
 	g_autoptr(FuCabinet) cabinet = fu_cabinet_new();
 
 	g_return_val_if_fail(FU_IS_ENGINE(self), NULL);
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), NULL);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
 	/* distrusting RSA? */
@@ -5276,7 +5276,7 @@ fu_engine_get_details_sort_cb(gconstpointer a, gconstpointer b)
  * fu_engine_get_details:
  * @self: a #FuEngine
  * @request: a #FuEngineRequest
- * @stream: a seekable #GInputStream
+ * @stream: a seekable #FuInputStream
  * @error: (nullable): optional return location for an error
  *
  * Gets the details about a local file.
@@ -5288,7 +5288,7 @@ fu_engine_get_details_sort_cb(gconstpointer a, gconstpointer b)
 GPtrArray *
 fu_engine_get_details(FuEngine *self,
 		      FuEngineRequest *request,
-		      GInputStream *stream,
+		      FuInputStream *stream,
 		      GError **error)
 {
 	GChecksumType checksum_types[] = {
@@ -5302,7 +5302,7 @@ fu_engine_get_details(FuEngine *self,
 	g_autoptr(GPtrArray) rels_by_csum = NULL;
 
 	g_return_val_if_fail(FU_IS_ENGINE(self), NULL);
-	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), NULL);
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
 	cabinet = fu_engine_build_cabinet_from_stream(self, stream, error);
@@ -7690,8 +7690,8 @@ fu_engine_load_host_emulation(FuEngine *self, const gchar *fn, GError **error)
 	g_autoptr(FwupdJsonObject) json_obj = NULL;
 	g_autoptr(FwupdJsonParser) json_parser = fwupd_json_parser_new();
 	g_autoptr(GFile) file = g_file_new_for_path(fn);
-	g_autoptr(GInputStream) istream_json = NULL;
-	g_autoptr(GInputStream) istream_raw = NULL;
+	g_autoptr(FuInputStream) istream_json = NULL;
+	g_autoptr(FuInputStream) istream_raw = NULL;
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
 	g_autoptr(FuBiosSettings) bios_settings = fu_context_get_bios_settings(self->ctx);
 
@@ -7708,7 +7708,7 @@ fu_engine_load_host_emulation(FuEngine *self, const gchar *fn, GError **error)
 	fu_security_attrs_append(self->host_security_attrs, attr);
 
 	/* add from file */
-	istream_raw = G_INPUT_STREAM(g_file_read(file, NULL, error));
+	istream_raw = FU_INPUT_STREAM(g_file_read(file, NULL, error));
 	if (istream_raw == NULL)
 		return FALSE;
 	if (g_str_has_suffix(fn, ".gz")) {

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -7690,7 +7690,6 @@ fu_engine_load_host_emulation(FuEngine *self, const gchar *fn, GError **error)
 	g_autoptr(FwupdJsonNode) json_node = NULL;
 	g_autoptr(FwupdJsonObject) json_obj = NULL;
 	g_autoptr(FwupdJsonParser) json_parser = fwupd_json_parser_new();
-	g_autoptr(GFile) file = g_file_new_for_path(fn);
 	g_autoptr(FuInputStream) istream_json = NULL;
 	g_autoptr(FuInputStream) istream_raw = NULL;
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
@@ -7709,7 +7708,7 @@ fu_engine_load_host_emulation(FuEngine *self, const gchar *fn, GError **error)
 	fu_security_attrs_append(self->host_security_attrs, attr);
 
 	/* add from file */
-	istream_raw = FU_INPUT_STREAM(g_file_read(file, NULL, error));
+	istream_raw = fu_input_stream_from_path(fn, error);
 	if (istream_raw == NULL)
 		return FALSE;
 	if (g_str_has_suffix(fn, ".gz")) {

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -45,7 +45,7 @@ fu_engine_is_uid_trusted(FuEngine *self, guint64 calling_uid) G_GNUC_NON_NULL(1)
 gchar *
 fu_engine_get_host_security_id(FuEngine *self, const gchar *fwupd_version) G_GNUC_NON_NULL(1);
 FuCabinet *
-fu_engine_build_cabinet_from_stream(FuEngine *self, GInputStream *stream, GError **error)
+fu_engine_build_cabinet_from_stream(FuEngine *self, FuInputStream *stream, GError **error)
     G_GNUC_NON_NULL(1, 2);
 GPtrArray *
 fu_engine_get_plugins(FuEngine *self) G_GNUC_NON_NULL(1);
@@ -213,7 +213,7 @@ fu_engine_add_runtime_version(FuEngine *self, const gchar *component_id, const g
 GPtrArray *
 fu_engine_get_details(FuEngine *self,
 		      FuEngineRequest *request,
-		      GInputStream *stream,
+		      FuInputStream *stream,
 		      GError **error) G_GNUC_NON_NULL(1, 2, 3);
 gboolean
 fu_engine_check_trust(FuEngine *self, FuRelease *release, GError **error) G_GNUC_NON_NULL(1, 2);
@@ -230,14 +230,14 @@ fu_engine_load_release(FuEngine *self,
 		       FwupdInstallFlags install_flags,
 		       GError **error) G_GNUC_NON_NULL(1, 2, 4);
 gchar *
-fu_engine_get_remote_id_for_stream(FuEngine *self, GInputStream *stream) G_GNUC_NON_NULL(1, 2);
+fu_engine_get_remote_id_for_stream(FuEngine *self, FuInputStream *stream) G_GNUC_NON_NULL(1, 2);
 gboolean
 fu_engine_modify_bios_settings(FuEngine *self,
 			       GHashTable *settings,
 			       gboolean force_ro,
 			       GError **error) G_GNUC_NON_NULL(1, 2);
 gboolean
-fu_engine_emulation_load(FuEngine *self, GInputStream *stream, GError **error)
+fu_engine_emulation_load(FuEngine *self, FuInputStream *stream, GError **error)
     G_GNUC_NON_NULL(1, 2);
 gboolean
 fu_engine_emulation_save(FuEngine *self, GOutputStream *stream, GError **error)

--- a/src/fu-jcat-test.c
+++ b/src/fu-jcat-test.c
@@ -219,10 +219,10 @@ fwupd_jcat_pkcs7_engine_func(gconstpointer test_data)
 	g_assert_no_error(error);
 	g_assert_nonnull(blob_sig2);
 	result_pass2 = fu_jcat_engine_pubkey_verify(engine,
-						   data_fwbin,
-						   blob_sig2,
-						   FU_JCAT_VERIFY_FLAG_NONE,
-						   &error);
+						    data_fwbin,
+						    blob_sig2,
+						    FU_JCAT_VERIFY_FLAG_NONE,
+						    &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(result_pass2);
 	g_assert_cmpstr(fu_jcat_result_get_authority(result_pass2), ==, "O=Hughski Limited");

--- a/src/fu-release.c
+++ b/src/fu-release.c
@@ -9,6 +9,7 @@
 #include "config.h"
 
 #include "fu-device-private.h"
+#include "fu-input-stream.h"
 #include "fu-release-common.h"
 #include "fu-release.h"
 
@@ -26,7 +27,7 @@ struct _FuRelease {
 	FuDevice *device;
 	FwupdRemote *remote;
 	FuConfig *config;
-	GInputStream *stream;
+	FuInputStream *stream;
 	gchar *update_request_id;
 	gchar *device_version_old;
 	gchar *firmware_basename;
@@ -198,7 +199,7 @@ fu_release_get_device(FuRelease *self)
  *
  * Returns: (transfer none) (nullable): data
  **/
-GInputStream *
+FuInputStream *
 fu_release_get_stream(FuRelease *self)
 {
 	g_return_val_if_fail(FU_IS_RELEASE(self), NULL);
@@ -207,10 +208,10 @@ fu_release_get_stream(FuRelease *self)
 
 /* private: for tests */
 void
-fu_release_set_stream(FuRelease *self, GInputStream *stream)
+fu_release_set_stream(FuRelease *self, FuInputStream *stream)
 {
 	g_return_if_fail(FU_IS_RELEASE(self));
-	g_return_if_fail(G_IS_INPUT_STREAM(stream));
+	g_return_if_fail(FU_IS_INPUT_STREAM(stream));
 	g_set_object(&self->stream, stream);
 }
 

--- a/src/fu-release.h
+++ b/src/fu-release.h
@@ -53,10 +53,10 @@ FuDevice *
 fu_release_get_device(FuRelease *self) G_GNUC_NON_NULL(1);
 FwupdRemote *
 fu_release_get_remote(FuRelease *self) G_GNUC_NON_NULL(1);
-GInputStream *
+FuInputStream *
 fu_release_get_stream(FuRelease *self) G_GNUC_NON_NULL(1);
 void
-fu_release_set_stream(FuRelease *self, GInputStream *stream) G_GNUC_NON_NULL(1, 2);
+fu_release_set_stream(FuRelease *self, FuInputStream *stream) G_GNUC_NON_NULL(1, 2);
 FuEngineRequest *
 fu_release_get_request(FuRelease *self) G_GNUC_NON_NULL(1);
 GPtrArray *

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -5603,8 +5603,8 @@ fu_util_jcat_load_filename(FuUtil *self, const gchar *filename, GError **error)
 	g_autoptr(GFile) gfile = g_file_new_for_path(filename);
 
 	if (g_file_query_exists(gfile, self->cancellable)) {
-		g_autoptr(FuInputStream) istream = NULL;
-		istream = FU_INPUT_STREAM(g_file_read(gfile, self->cancellable, error));
+		g_autoptr(FuFileInputStream) istream = NULL;
+		istream = fu_file_input_stream_from_file(gfile, self->cancellable, error);
 		if (istream == NULL)
 			return NULL;
 		if (!fwupd_jcat_file_import_stream(file, G_INPUT_STREAM(istream), error))

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -2550,7 +2550,7 @@ fu_util_tpm_eventlog(FuUtil *self, gchar **values, GError **error)
 	blob = fu_bytes_get_contents(fn, error);
 	if (blob == NULL)
 		return FALSE;
-	stream = g_memory_input_stream_new_from_bytes(blob);
+	stream = fu_memory_input_stream_new_from_bytes(blob);
 	eventlog = fu_firmware_new_from_gtypes(stream,
 					       0x0,
 					       FU_FIRMWARE_PARSE_FLAG_NONE,

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -5607,7 +5607,7 @@ fu_util_jcat_load_filename(FuUtil *self, const gchar *filename, GError **error)
 		istream = FU_INPUT_STREAM(g_file_read(gfile, self->cancellable, error));
 		if (istream == NULL)
 			return NULL;
-		if (!fwupd_jcat_file_import_stream(file, istream, error))
+		if (!fwupd_jcat_file_import_stream(file, G_INPUT_STREAM(istream), error))
 			return NULL;
 	}
 

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -830,7 +830,7 @@ fu_util_get_details(FuUtil *self, gchar **values, GError **error)
 {
 	g_autoptr(GPtrArray) array = NULL;
 	g_autoptr(FuUtilNode) root = g_node_new(NULL);
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* load engine */
 	if (!fu_util_start_engine(self,
@@ -1084,7 +1084,7 @@ fu_util_install_blob(FuUtil *self, gchar **values, GError **error)
 	g_autofree gchar *firmware_basename = NULL;
 	g_autoptr(FuDevice) device = NULL;
 	g_autoptr(FuRelease) release = fu_release_new();
-	g_autoptr(GInputStream) stream_fw = NULL;
+	g_autoptr(FuInputStream) stream_fw = NULL;
 
 	/* progress */
 	fu_progress_set_id(self->progress, G_STRLOC);
@@ -1429,7 +1429,7 @@ fu_util_download_if_required(FuUtil *self, const gchar *perhapsfn, GError **erro
 
 static gboolean
 fu_util_install_stream(FuUtil *self,
-		       GInputStream *stream,
+		       FuInputStream *stream,
 		       GPtrArray *devices,
 		       FuProgress *progress,
 		       GError **error)
@@ -1526,7 +1526,7 @@ static gboolean
 fu_util_install(FuUtil *self, gchar **values, GError **error)
 {
 	g_autofree gchar *filename = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(GPtrArray) devices_possible = NULL;
 
 	/* progress */
@@ -2524,7 +2524,7 @@ fu_util_tpm_eventlog(FuUtil *self, gchar **values, GError **error)
 	g_autofree gchar *fn = NULL;
 	g_autoptr(FuFirmware) eventlog = NULL;
 	g_autoptr(GBytes) blob = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autoptr(GPtrArray) items = NULL;
 	g_autoptr(GString) str = g_string_new(NULL);
 
@@ -3296,7 +3296,7 @@ fu_util_firmware_parse(FuUtil *self, gchar **values, GError **error)
 	FuContext *ctx = fu_engine_get_context(self->engine);
 	GType gtype;
 	g_autoptr(FuFirmware) firmware = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	g_autofree gchar *firmware_type = NULL;
 	g_autofree gchar *str = NULL;
 
@@ -4572,7 +4572,7 @@ fu_util_emulation_save(FuUtil *self, gchar **values, GError **error)
 static gboolean
 fu_util_emulation_load(FuUtil *self, gchar **values, GError **error)
 {
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* check args */
 	if (g_strv_length(values) < 1) {
@@ -4607,7 +4607,7 @@ fu_util_emulation_load(FuUtil *self, gchar **values, GError **error)
 
 	/* "install" archive */
 	if (values[1] != NULL) {
-		g_autoptr(GInputStream) stream_cab = NULL;
+		g_autoptr(FuInputStream) stream_cab = NULL;
 		g_autoptr(GPtrArray) devices_possible = NULL;
 
 		stream_cab = fu_input_stream_from_path(values[1], error);
@@ -5603,8 +5603,8 @@ fu_util_jcat_load_filename(FuUtil *self, const gchar *filename, GError **error)
 	g_autoptr(GFile) gfile = g_file_new_for_path(filename);
 
 	if (g_file_query_exists(gfile, self->cancellable)) {
-		g_autoptr(GInputStream) istream = NULL;
-		istream = G_INPUT_STREAM(g_file_read(gfile, self->cancellable, error));
+		g_autoptr(FuInputStream) istream = NULL;
+		istream = FU_INPUT_STREAM(g_file_read(gfile, self->cancellable, error));
 		if (istream == NULL)
 			return NULL;
 		if (!fwupd_jcat_file_import_stream(file, istream, error))

--- a/src/fu-unix-seekable-input-stream-test.c
+++ b/src/fu-unix-seekable-input-stream-test.c
@@ -38,13 +38,13 @@ fu_unix_seekable_input_stream_func(void)
 	g_assert_nonnull(stream);
 
 	/* first chuck */
-	ret = g_input_stream_read(stream, buf, sizeof(buf) - 1, NULL, &error);
+	ret = g_input_stream_read(G_INPUT_STREAM(stream), buf, sizeof(buf) - 1, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(ret, ==, 5);
 	g_assert_cmpstr((const gchar *)buf, ==, "<?xml");
 
 	/* second chuck */
-	ret = g_input_stream_read(stream, buf, sizeof(buf) - 1, NULL, &error);
+	ret = g_input_stream_read(G_INPUT_STREAM(stream), buf, sizeof(buf) - 1, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(ret, ==, 5);
 	g_assert_cmpstr((const gchar *)buf, ==, " vers");
@@ -53,7 +53,7 @@ fu_unix_seekable_input_stream_func(void)
 	ret = g_seekable_seek(G_SEEKABLE(stream), 0, G_SEEK_SET, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(ret, ==, 1);
-	ret = g_input_stream_read(stream, buf, sizeof(buf) - 1, NULL, &error);
+	ret = g_input_stream_read(G_INPUT_STREAM(stream), buf, sizeof(buf) - 1, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(ret, ==, 5);
 	g_assert_cmpstr((const gchar *)buf, ==, "<?xml");

--- a/src/fu-unix-seekable-input-stream-test.c
+++ b/src/fu-unix-seekable-input-stream-test.c
@@ -14,6 +14,7 @@
 
 #include "fwupd-error.h"
 
+#include "fu-input-stream.h"
 #include "fu-unix-seekable-input-stream.h"
 
 static void
@@ -25,7 +26,7 @@ fu_unix_seekable_input_stream_func(void)
 	guint8 buf[6] = {0};
 	g_autofree gchar *fn = NULL;
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	fn = g_test_build_filename(G_TEST_DIST, "tests", "metadata.xml", NULL);
 	g_assert_nonnull(fn);
@@ -67,7 +68,7 @@ fu_unix_seekable_input_stream_non_regular_func(void)
 #ifdef HAVE_GIO_UNIX
 	g_autofd gint fd = -1;
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	fd = g_open("/dev/zero", O_RDONLY, 0);
 	g_assert_cmpint(fd, >=, 0);
@@ -87,7 +88,7 @@ fu_unix_seekable_input_stream_sealed_memfd_func(void)
 	gboolean ret;
 	g_autofd gint fd = -1;
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	const gchar data[] = "hello";
 
 	fd = memfd_create("fwupd-test", MFD_CLOEXEC | MFD_ALLOW_SEALING);
@@ -118,7 +119,7 @@ fu_unix_seekable_input_stream_unsealed_memfd_func(void)
 	gboolean ret;
 	g_autofd gint fd = -1;
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 	const gchar data[] = "hello";
 
 	fd = memfd_create("fwupd-test", MFD_CLOEXEC | MFD_ALLOW_SEALING);

--- a/src/fu-unix-seekable-input-stream.c
+++ b/src/fu-unix-seekable-input-stream.c
@@ -13,6 +13,7 @@
 
 #include "fwupd-error.h"
 
+#include "fu-input-stream.h"
 #include "fu-unix-seekable-input-stream.h"
 
 struct _FuUnixSeekableInputStream {
@@ -126,15 +127,15 @@ fu_unix_seekable_input_stream_seekable_iface_init(GSeekableIface *iface)
  *
  * NOTE: @fd has to point to a regular file on disk
  *
- * Returns: (transfer full): a #GInputStream
+ * Returns: (transfer full): a #FuInputStream
  *
  * Since: 2.1.2
  **/
-GInputStream *
+FuInputStream *
 fu_unix_seekable_input_stream_new(gint fd, gboolean close_fd, GError **error)
 {
 	GStatBuf st = {0};
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* create wrapper */
 	stream =

--- a/src/fu-unix-seekable-input-stream.h
+++ b/src/fu-unix-seekable-input-stream.h
@@ -8,6 +8,8 @@
 
 #include <gio/gunixinputstream.h>
 
+#include "fu-input-stream.h"
+
 #define FU_TYPE_UNIX_SEEKABLE_INPUT_STREAM (fu_unix_seekable_input_stream_get_type())
 
 G_DECLARE_FINAL_TYPE(FuUnixSeekableInputStream,
@@ -16,7 +18,7 @@ G_DECLARE_FINAL_TYPE(FuUnixSeekableInputStream,
 		     UNIX_SEEKABLE_INPUT_STREAM,
 		     GUnixInputStream)
 
-GInputStream *
+FuInputStream *
 fu_unix_seekable_input_stream_new(gint fd, gboolean close_fd, GError **error);
 gboolean
 fu_unix_seekable_input_stream_require_seal(FuUnixSeekableInputStream *stream, GError **error);

--- a/src/fu-usb-backend-test.c
+++ b/src/fu-usb-backend-test.c
@@ -39,7 +39,7 @@ fu_usb_backend_load_file(FuBackend *backend, const gchar *fn)
 	g_assert_no_error(error);
 	g_assert_nonnull(stream);
 	json_node = fwupd_json_parser_load_from_stream(json_parser,
-						       stream,
+						       G_INPUT_STREAM(stream),
 						       FWUPD_JSON_LOAD_FLAG_NONE,
 						       &error);
 	g_assert_no_error(error);

--- a/src/fu-usb-backend-test.c
+++ b/src/fu-usb-backend-test.c
@@ -27,7 +27,7 @@ fu_usb_backend_load_file(FuBackend *backend, const gchar *fn)
 	g_autoptr(FwupdJsonParser) json_parser = fwupd_json_parser_new();
 	g_autoptr(FwupdJsonNode) json_node = NULL;
 	g_autoptr(FwupdJsonObject) json_obj = NULL;
-	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	/* set appropriate limits */
 	fwupd_json_parser_set_max_depth(json_parser, 10);


### PR DESCRIPTION
This affects a lot of files but only in (mostly) mechanical replaces. The goal of this PR is to eventually be able to replace input streams provided by glib with our own wrappers. This patchset simply typedefs `GInputStream` to `FuInputStream` and adds equivalent `FuMemoryInputStream` and `FuFileInputStream` typedefs with the minimal API needed to make them look like custom types.

The rest of the PR is replacement to use those new types instead of the glib native ones. Getting this in first means we can implement our own types without having to rewrite the whole tree later.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
