### PR TITLE
config: Do not fail when a pre-group comment has no keys set

### DIFF
--- a/libfwupdplugin/fu-config-test.c
+++ b/libfwupdplugin/fu-config-test.c
@@ -94,10 +94,51 @@ fu_config_func(void)
 	g_assert_true(g_strstr_len(composite_data, -1, "# key comment") != NULL);
 }
 
+/* verifies that a pre-group comment in a config file with no keys set does not
+ * prevent the daemon from starting, see https://github.com/fwupd/fwupd/issues/10656 */
+static void
+fu_config_comment_no_keys_func(void)
+{
+	gboolean ret;
+	g_autofree gchar *sysconfdir = NULL;
+	g_autofree gchar *fn = NULL;
+	g_autoptr(FuPathStore) pstore = fu_path_store_new();
+	g_autoptr(FuConfig) config = fu_config_new(pstore);
+	g_autoptr(FuTemporaryDirectory) tmpdir = NULL;
+	g_autoptr(GError) error = NULL;
+
+	/* set up test harness */
+	tmpdir = fu_temporary_directory_new("config", &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(tmpdir);
+	sysconfdir = fu_temporary_directory_build(tmpdir, "etc", "fwupd", NULL);
+	fu_path_store_set_path(pstore, FU_PATH_KIND_SYSCONFDIR_PKG, sysconfdir);
+
+	/* a config stub with a comment before the group and no keys set */
+	fn = g_build_filename(sysconfdir, "fwupd.conf", NULL);
+	g_assert_nonnull(fn);
+	ret = fu_path_mkdir_parent(fn, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	ret = g_file_set_contents(fn,
+				  "# Ansible managed\n"
+				  "[fwupd]\n"
+				  "# use `man 5 fwupd.conf` for documentation\n",
+				  -1,
+				  &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	ret = fu_config_load(config, FU_CONFIG_LOAD_FLAG_NONE, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+}
+
 int
 main(int argc, char **argv)
 {
 	g_test_init(&argc, &argv, NULL);
 	g_test_add_func("/fwupd/config", fu_config_func);
+	g_test_add_func("/fwupd/config{comment-no-keys}", fu_config_comment_no_keys_func);
 	return g_test_run();
 }

--- a/libfwupdplugin/fu-config.c
+++ b/libfwupdplugin/fu-config.c
@@ -146,7 +146,8 @@ fu_config_load_bytes_replace(FuConfig *self, GBytes *blob, GError **error)
 			}
 		}
 		comment_group = g_key_file_get_comment(kf, groups[i], NULL, NULL);
-		if (comment_group != NULL && comment_group[0] != '\0') {
+		if (comment_group != NULL && comment_group[0] != '\0' &&
+		    g_key_file_has_group(priv->keyfile, groups[i])) {
 			if (!g_key_file_set_comment(priv->keyfile,
 						    groups[i],
 						    NULL,


### PR DESCRIPTION
fu_config_load_bytes_replace() copies a group's key comments before the group-level comment, and creating a group in the merged keyfile only happens as a side effect of copying a key. A config file with a comment before the [fwupd] header but no keys set, e.g. an Ansible-managed stub:

    # Ansible managed
    [fwupd]

therefore never creates the group, and g_key_file_set_comment() fails with "Key file does not have group", aborting config load and preventing the daemon from starting.

Only set the group comment when the group actually exists in the merged keyfile. This matches fu_config_migrate_keyfile(), which already discards groups that have no keys left.

Fixes: https://github.com/fwupd/fwupd/issues/10656

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
