### PR TITLE
trivial: ci: Update python packaging dependencies

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -22,8 +22,20 @@
     <distro id="freebsd">
       <package variant="amd64" />
     </distro>
-  </dependency>
-  <dependency id="pesign">
+   </dependency>
+   <dependency id="7zip">
+     <distro id="debian">
+       <control>
+         <exclusive>s390x</exclusive>
+       </control>
+     </distro>
+     <distro id="ubuntu">
+       <control />
+       <package variant="x86_64" />
+       <package variant="aarch64" />
+     </distro>
+   </dependency>
+   <dependency id="pesign">
     <distro id="centos">
       <package variant="x86_64" />
     </distro>
@@ -914,6 +926,17 @@
       <package variant="x86_64" />
     </distro>
   </dependency>
+  <dependency id="gir1.2-glib-2.0">
+    <distro id="debian">
+      <control />
+      <multi-arch />
+    </distro>
+    <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+      <package variant="aarch64" />
+    </distro>
+  </dependency>
   <dependency id="gir1.2-pango-1.0">
     <distro id="centos">
       <package variant="x86_64">pango-devel</package>
@@ -1108,6 +1131,27 @@
       <package>py312-virtualenv</package>
     </distro>
   </dependency>
+  <dependency id="python3-dbus">
+    <distro id="debian">
+      <control />
+      <native />
+    </distro>
+    <distro id="arch">
+      <package variant="x86_64">python-dbus</package>
+    </distro>
+    <distro id="centos">
+      <package variant="x86_64" />
+    </distro>
+    <distro id="fedora">
+      <package variant="x86_64" />
+      <package variant="aarch64" />
+    </distro>
+    <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+      <package variant="aarch64" />
+    </distro>
+  </dependency>
   <dependency id="python3-dbusmock">
     <distro id="debian" />
     <distro id="arch">
@@ -1129,6 +1173,27 @@
       <package variant="x86_64" />
       <package variant="aarch64" />
       <package variant="mingw64" />
+    </distro>
+  </dependency>
+  <dependency id="python3-gi">
+    <distro id="debian">
+      <control />
+      <native />
+    </distro>
+    <distro id="arch">
+      <package variant="x86_64">python-gobject</package>
+    </distro>
+    <distro id="centos">
+      <package variant="x86_64">python3-gobject</package>
+    </distro>
+    <distro id="fedora">
+      <package variant="x86_64">python3-gobject</package>
+      <package variant="aarch64">python3-gobject</package>
+    </distro>
+    <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+      <package variant="aarch64" />
     </distro>
   </dependency>
   <dependency id="python3-gi-cairo">
@@ -1278,7 +1343,7 @@
       <package>py312-pygobject</package>
     </distro>
   </dependency>
-  <dependency id="python3-requests">
+  <dependency id="python3-flask">
     <distro id="centos">
       <package variant="x86_64" />
     </distro>
@@ -1287,7 +1352,9 @@
       <package variant="aarch64" />
     </distro>
     <distro id="debian">
-      <control />
+      <control>
+        <exclusive>s390x</exclusive>
+      </control>
     </distro>
     <distro id="ubuntu">
       <control />

--- a/contrib/debian/control.in
+++ b/contrib/debian/control.in
@@ -42,7 +42,12 @@ Recommends: python3,
 	    udisks2,
 	    fwupd-signed,
 	    jq
-Suggests: gir1.2-fwupd-2.0
+Suggests: 7zip,
+	  gir1.2-fwupd-2.0,
+	  gir1.2-glib-2.0,
+	  python3-dbus,
+	  python3-gi,
+	  python3-jinja2
 Provides: fwupdate,
 	  ${gir:Provides}
 Conflicts: fwupdate-amd64-signed,
@@ -76,8 +81,8 @@ Depends: ${misc:Depends},
          ieee-data,
          polkitd | policykit-1,
          python3,
-         python3-gi,
-         python3-requests,
+         python3-flask,
+         python3-gi
 Breaks: fwupd (<< 0.9.4-1)
 Replaces: fwupd (<< 0.9.4-1)
 Multi-Arch: foreign
@@ -111,11 +116,11 @@ Package: libfwupd-dev
 Architecture: linux-any
 Multi-Arch: same
 Depends: libfwupd3 (= ${binary:Version}),
-	 gir1.2-fwupd-2.0 (= ${binary:Version}),
-	 libcurl4-gnutls-dev,
-	 libglib2.0-dev (>= 2.45.8),
-	 libjcat-dev,
-	 ${misc:Depends}
+         gir1.2-fwupd-2.0 (= ${binary:Version}),
+         libcurl4-gnutls-dev,
+         libglib2.0-dev (>= 2.45.8),
+         libjcat-dev,
+         ${misc:Depends}
 Breaks: fwupd-dev (<< 0.5.4-2~)
 Replaces: fwupd-dev (<< 0.5.4-2~)
 Section: libdevel


### PR DESCRIPTION
	the scripts of fwupd's Firmware Packager [1] in /usr/share/fwupd/ depend
	on the Python modules dbus, gi and jinja2 as well as the introspection
	file GLib-2.0.typelib next to Fwupd-2.0.typelib.  In addition, 7zip is
	used to unpack self-extracting firmware archives.  Could you please add
	the missing dependencies in debian/control.
	/usr/share/installed-tests/fwupd/tests/snapd.py does no longer use the
	Python module requests, it uses corresponding functionality from Flask,
	so could you please replace python3-requests by python3-flask in
	debian/control.

Thanks Thomas Uhle, for the patch.

Closes: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1141944

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
