### PR TITLE
trivial: Disallow Qt short keywords in the Qt thread test

### DIFF
--- a/contrib/ci/qt5-thread-test/meson.build
+++ b/contrib/ci/qt5-thread-test/meson.build
@@ -2,6 +2,8 @@ project('qt5-thread-test', 'cpp',
   license: 'LGPL-2.1-or-later',
 )
 add_project_arguments('-fPIC', language: 'cpp')
+# Prevent conflicts between Qt 'signals' define and GLib 'signals' identifiers
+add_project_arguments('-DQT_NO_KEYWORDS', language: 'cpp')
 qt5core = dependency('Qt5Core')
 qt5concurrent = dependency('Qt5Concurrent')
 glib2 = dependency('glib-2.0')

--- a/contrib/ci/qt5-thread-test/qt-thread-test.cpp
+++ b/contrib/ci/qt5-thread-test/qt-thread-test.cpp
@@ -4,11 +4,10 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
-#include <fwupd.h>
-
 #include <QCoreApplication>
 #include <QFutureWatcher>
 #include <QtConcurrentRun>
+#include <fwupd.h>
 
 int
 main(int argc, char **argv)


### PR DESCRIPTION
clang-format wants to shuffle the header down to below the Qt includes, resulting in a compiler error:
```
In file included from /usr/include/qt5/QtCore/qobject.h:46,
                 from /usr/include/qt5/QtCore/qcoreapplication.h:46,
                 from /usr/include/qt5/QtCore/QCoreApplication:1,
                 from ../qt-thread-test.cpp:10:
/usr/include/qt5/QtCore/qobjectdefs.h:93:20: error: expected unqualified-id before ‘public’
   93 | # define Q_SIGNALS public QT_ANNOTATE_ACCESS_SPECIFIER(qt_signal)
      |                    ^~~~~~
/usr/include/qt5/QtCore/qobjectdefs.h:89:22: note: in expansion of macro ‘Q_SIGNALS’
   89 | #     define signals Q_SIGNALS
      |                      ^~~~~~~~~
/usr/include/glib-2.0/gio/gdbusintrospection.h:157:25: note: in expansion of macro ‘signals’
  157 |   GDBusSignalInfo     **signals;
```
The error is caused by Qt defining `signals` and GLib getting confused by that #define. Since this is only a test anyway prevent Qt from defining those short keywords, we're not actually using them anyway.

With this is in place we can now keep the clang-format header order.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

