### PR TITLE
Add a FuCompressorStream class for (de)compression

### DIFF
--- a/contrib/ci/check-source.py
+++ b/contrib/ci/check-source.py
@@ -857,6 +857,8 @@ class Checker:
                 "~g_memory_input_stream_new*": "Use fu_memory_input_stream_new*() instead",
                 "g_file_read": "Use fu_file_input_stream_from_file() instead",
                 "~g_file_input_stream_*": "Use fu_file_input_stream_*() instead",
+                "g_zlib_compressor_new": "Use fu_compressor_stream_new_compress() instead",
+                "g_zlib_decompressor_new": "Use fu_compressor_stream_new_decompress() instead",
             }.items():
                 idx = node.tokens.find_fuzzy([token, "("])
                 if idx != -1:

--- a/libfwupdplugin/fu-compressor-stream-test.c
+++ b/libfwupdplugin/fu-compressor-stream-test.c
@@ -1,0 +1,457 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include <fwupdplugin.h>
+
+static GBytes *
+fu_test_create_pattern(gsize sz)
+{
+	g_autoptr(GByteArray) buf = g_byte_array_new();
+	for (gsize i = 0; i < sz; i++) {
+		guint8 tmp = i % 251;
+		g_byte_array_append(buf, &tmp, 1);
+	}
+	return g_bytes_new(buf->data, buf->len);
+}
+
+static GBytes *
+fu_test_compress(GBytes *blob, FuCompressorFormat format, GError **error)
+{
+	g_autoptr(FuInputStream) source = fu_memory_input_stream_new_from_bytes(blob);
+	g_autoptr(FuInputStream) cstream = fu_compressor_stream_new_compress(source, format, error);
+	if (cstream == NULL)
+		return NULL;
+	return fu_input_stream_read_bytes(cstream, 0, G_MAXUINT32, NULL, error);
+}
+
+static GBytes *
+fu_test_decompress(GBytes *blob, FuCompressorFormat format, GError **error)
+{
+	g_autoptr(FuInputStream) source = fu_memory_input_stream_new_from_bytes(blob);
+	g_autoptr(FuInputStream) dstream =
+	    fu_compressor_stream_new_decompress(source, format, error);
+	if (dstream == NULL)
+		return NULL;
+	return fu_input_stream_read_bytes(dstream, 0, G_MAXUINT32, NULL, error);
+}
+
+static GBytes *
+fu_test_decompress_gconverter(GBytes *blob, FuCompressorFormat format, GError **error)
+{
+	GZlibCompressorFormat gformat;
+	gssize rc;
+	g_autoptr(GConverter) conv = NULL;
+	g_autoptr(GInputStream) base = NULL;		 /* nocheck:blocked */
+	g_autoptr(GInputStream) converter_stream = NULL; /* nocheck:blocked */
+	g_autoptr(GByteArray) buf = g_byte_array_new();
+	guint8 tmp[4096] = {0}; /* nocheck:zero-init */
+
+	if (format == FU_COMPRESSOR_FORMAT_RAW)
+		gformat = G_ZLIB_COMPRESSOR_FORMAT_RAW;
+	else if (format == FU_COMPRESSOR_FORMAT_GZIP)
+		gformat = G_ZLIB_COMPRESSOR_FORMAT_GZIP;
+	else
+		gformat = G_ZLIB_COMPRESSOR_FORMAT_ZLIB;
+
+	conv = G_CONVERTER(g_zlib_decompressor_new(gformat)); /* nocheck:blocked */
+	base = g_memory_input_stream_new_from_bytes(blob);    /* nocheck:blocked */
+	converter_stream = g_converter_input_stream_new(base, conv);
+
+	while (TRUE) {
+		rc = g_input_stream_read(converter_stream, tmp, sizeof(tmp), NULL, error);
+		if (rc < 0)
+			return NULL;
+		if (rc == 0)
+			break;
+		g_byte_array_append(buf, tmp, rc);
+	}
+
+	return g_bytes_new(buf->data, buf->len);
+}
+
+static void
+fu_compressor_stream_roundtrip_zlib_func(void)
+{
+	gboolean ret;
+	g_autoptr(GBytes) original = fu_test_create_pattern(10000);
+	g_autoptr(GBytes) compressed = NULL;
+	g_autoptr(GBytes) decompressed = NULL;
+	g_autoptr(GBytes) decompressed_gconv = NULL;
+	g_autoptr(GError) error = NULL;
+
+	compressed = fu_test_compress(original, FU_COMPRESSOR_FORMAT_ZLIB, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(compressed);
+
+	g_assert_cmpint(g_bytes_get_size(compressed), <, g_bytes_get_size(original));
+
+	decompressed = fu_test_decompress(compressed, FU_COMPRESSOR_FORMAT_ZLIB, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(decompressed);
+	ret = fu_bytes_compare(original, decompressed, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* verify we've actually compressed properly */
+	decompressed_gconv =
+	    fu_test_decompress_gconverter(compressed, FU_COMPRESSOR_FORMAT_ZLIB, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(decompressed_gconv);
+	ret = fu_bytes_compare(original, decompressed_gconv, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+}
+
+static void
+fu_compressor_stream_roundtrip_gzip_func(void)
+{
+	gboolean ret;
+	g_autoptr(GBytes) original = fu_test_create_pattern(10000);
+	g_autoptr(GBytes) compressed = NULL;
+	g_autoptr(GBytes) decompressed = NULL;
+	g_autoptr(GBytes) decompressed_gconv = NULL;
+	g_autoptr(GError) error = NULL;
+
+	compressed = fu_test_compress(original, FU_COMPRESSOR_FORMAT_GZIP, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(compressed);
+	g_assert_cmpint(g_bytes_get_size(compressed), <, g_bytes_get_size(original));
+
+	decompressed = fu_test_decompress(compressed, FU_COMPRESSOR_FORMAT_GZIP, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(decompressed);
+	ret = fu_bytes_compare(original, decompressed, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* verify we've actually compressed properly */
+	decompressed_gconv =
+	    fu_test_decompress_gconverter(compressed, FU_COMPRESSOR_FORMAT_GZIP, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(decompressed_gconv);
+	ret = fu_bytes_compare(original, decompressed_gconv, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+}
+
+static void
+fu_compressor_stream_roundtrip_raw_func(void)
+{
+	gboolean ret;
+	g_autoptr(GBytes) original = fu_test_create_pattern(10000);
+	g_autoptr(GBytes) compressed = NULL;
+	g_autoptr(GBytes) decompressed = NULL;
+	g_autoptr(GBytes) decompressed_gconv = NULL;
+	g_autoptr(GError) error = NULL;
+
+	compressed = fu_test_compress(original, FU_COMPRESSOR_FORMAT_RAW, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(compressed);
+	g_assert_cmpint(g_bytes_get_size(compressed), <, g_bytes_get_size(original));
+
+	decompressed = fu_test_decompress(compressed, FU_COMPRESSOR_FORMAT_RAW, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(decompressed);
+	ret = fu_bytes_compare(original, decompressed, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* verify we've actually compressed properly */
+	decompressed_gconv =
+	    fu_test_decompress_gconverter(compressed, FU_COMPRESSOR_FORMAT_RAW, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(decompressed_gconv);
+	ret = fu_bytes_compare(original, decompressed_gconv, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+}
+
+static void
+fu_compressor_stream_type_func(void)
+{
+	g_autoptr(GBytes) blob = g_bytes_new_static("ABCD", 4);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(FuInputStream) source = fu_memory_input_stream_new_from_bytes(blob);
+	g_autoptr(FuInputStream) stream =
+	    fu_compressor_stream_new_compress(source, FU_COMPRESSOR_FORMAT_ZLIB, &error);
+
+	g_assert_no_error(error);
+	g_assert_nonnull(stream);
+	g_assert_true(G_IS_INPUT_STREAM(stream));
+	g_assert_true(G_IS_SEEKABLE(stream));
+	g_assert_true(FU_IS_INPUT_STREAM(stream));
+	g_assert_true(FU_IS_STREAM_INPUT_STREAM(stream));
+	g_assert_true(FU_IS_COMPRESSOR_STREAM(stream));
+}
+
+static void
+fu_compressor_stream_read_func(void)
+{
+	gssize rc;
+	guint8 buf[1] = {0};
+	g_autoptr(GBytes) original = g_bytes_new_static("ABCDEFGH", 8);
+	g_autoptr(GBytes) compressed = NULL;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(FuInputStream) source = NULL;
+	g_autoptr(FuInputStream) dstream = NULL;
+	const guint8 *orig_data;
+	gsize orig_sz;
+
+	compressed = fu_test_compress(original, FU_COMPRESSOR_FORMAT_ZLIB, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(compressed);
+
+	source = fu_memory_input_stream_new_from_bytes(compressed);
+	dstream = fu_compressor_stream_new_decompress(source, FU_COMPRESSOR_FORMAT_ZLIB, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(dstream);
+
+	orig_data = g_bytes_get_data(original, &orig_sz);
+	for (gsize i = 0; i < orig_sz; i++) {
+		rc = g_input_stream_read(G_INPUT_STREAM(dstream), buf, 1, NULL, &error);
+		g_assert_no_error(error);
+		g_assert_cmpint(rc, ==, 1);
+		g_assert_cmpint(buf[0], ==, orig_data[i]);
+	}
+
+	/* EOF */
+	rc = g_input_stream_read(G_INPUT_STREAM(dstream), buf, 1, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_cmpint(rc, ==, 0);
+}
+
+static void
+fu_compressor_stream_decompress_invalid_func(void)
+{
+	gssize rc;
+	guint8 buf[64] = {0};
+	g_autoptr(GBytes) garbage = g_bytes_new_static("this is not compressed data!!", 28);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(FuInputStream) source = fu_memory_input_stream_new_from_bytes(garbage);
+	g_autoptr(FuInputStream) dstream =
+	    fu_compressor_stream_new_decompress(source, FU_COMPRESSOR_FORMAT_ZLIB, &error);
+
+	/* construction succeeds -- the error happens on read */
+	g_assert_no_error(error);
+	g_assert_nonnull(dstream);
+
+	rc = g_input_stream_read(G_INPUT_STREAM(dstream), buf, sizeof(buf), NULL, &error);
+	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA);
+	g_assert_cmpint(rc, ==, -1);
+}
+
+static void
+fu_compressor_stream_read_bytes_func(void)
+{
+	gboolean ret;
+	g_autoptr(GBytes) original = fu_test_create_pattern(1024);
+	g_autoptr(GBytes) compressed = NULL;
+	g_autoptr(GBytes) result = NULL;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(FuInputStream) source = NULL;
+	g_autoptr(FuInputStream) dstream = NULL;
+
+	compressed = fu_test_compress(original, FU_COMPRESSOR_FORMAT_GZIP, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(compressed);
+
+	source = fu_memory_input_stream_new_from_bytes(compressed);
+	dstream = fu_compressor_stream_new_decompress(source, FU_COMPRESSOR_FORMAT_GZIP, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(dstream);
+
+	result = fu_input_stream_read_bytes(dstream, 0, G_MAXUINT32, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(result);
+
+	ret = fu_bytes_compare(original, result, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+}
+
+static void
+fu_compressor_stream_truncate_func(void)
+{
+	gboolean ret;
+	g_autoptr(GBytes) blob = g_bytes_new_static("ABCD", 4);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(FuInputStream) source = fu_memory_input_stream_new_from_bytes(blob);
+	g_autoptr(FuInputStream) stream =
+	    fu_compressor_stream_new_compress(source, FU_COMPRESSOR_FORMAT_ZLIB, &error);
+
+	g_assert_no_error(error);
+	g_assert_nonnull(stream);
+	g_assert_false(g_seekable_can_truncate(G_SEEKABLE(stream)));
+
+	ret = g_seekable_truncate(G_SEEKABLE(stream), 2, NULL, &error);
+	g_assert_false(ret);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
+}
+
+static void
+fu_compressor_stream_empty_func(void)
+{
+	gssize rc;
+	guint8 buf[16] = {0};
+	g_autoptr(GBytes) empty = g_bytes_new_static("", 0);
+	g_autoptr(GBytes) compressed = NULL;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(FuInputStream) source = NULL;
+	g_autoptr(FuInputStream) dstream = NULL;
+
+	compressed = fu_test_compress(empty, FU_COMPRESSOR_FORMAT_ZLIB, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(compressed);
+
+	/* compressed empty stream should still have some header bytes */
+	g_assert_cmpint(g_bytes_get_size(compressed), >, 0);
+
+	/* decompressing should yield zero bytes */
+	source = fu_memory_input_stream_new_from_bytes(compressed);
+	dstream = fu_compressor_stream_new_decompress(source, FU_COMPRESSOR_FORMAT_ZLIB, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(dstream);
+
+	rc = g_input_stream_read(G_INPUT_STREAM(dstream), buf, sizeof(buf), NULL, &error);
+	g_assert_no_error(error);
+	g_assert_cmpint(rc, ==, 0);
+}
+
+static void
+fu_compressor_stream_format_mismatch_func(void)
+{
+	gssize rc;
+	guint8 buf[64] = {0};
+	g_autoptr(GBytes) original = fu_test_create_pattern(1000);
+	g_autoptr(GBytes) compressed = NULL;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(FuInputStream) source = NULL;
+	g_autoptr(FuInputStream) dstream = NULL;
+
+	compressed = fu_test_compress(original, FU_COMPRESSOR_FORMAT_GZIP, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(compressed);
+
+	/* compressed as GZIP, decompress as ZLIB -- expected to fail */
+	source = fu_memory_input_stream_new_from_bytes(compressed);
+	dstream = fu_compressor_stream_new_decompress(source, FU_COMPRESSOR_FORMAT_ZLIB, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(dstream);
+
+	rc = g_input_stream_read(G_INPUT_STREAM(dstream), buf, sizeof(buf), NULL, &error);
+	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA);
+	g_assert_cmpint(rc, ==, -1);
+}
+
+static void
+fu_compressor_stream_large_func(void)
+{
+	gboolean ret;
+	g_autoptr(GBytes) original = fu_test_create_pattern(256 * 1024);
+	g_autoptr(GBytes) compressed = NULL;
+	g_autoptr(GBytes) decompressed = NULL;
+	g_autoptr(GError) error = NULL;
+
+	compressed = fu_test_compress(original, FU_COMPRESSOR_FORMAT_GZIP, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(compressed);
+	g_assert_cmpint(g_bytes_get_size(compressed), <, g_bytes_get_size(original));
+
+	decompressed = fu_test_decompress(compressed, FU_COMPRESSOR_FORMAT_GZIP, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(decompressed);
+
+	ret = fu_bytes_compare(original, decompressed, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+}
+
+static void
+fu_compressor_stream_no_close_source_func(void)
+{
+	gssize rc;
+	guint8 buf[4] = {0};
+	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(FuInputStream) source = fu_memory_input_stream_new_from_bytes(blob);
+
+	/* create and destroy a compressor stream */
+	{
+		g_autoptr(FuInputStream) cstream =
+		    fu_compressor_stream_new_compress(source, FU_COMPRESSOR_FORMAT_ZLIB, &error);
+		g_assert_no_error(error);
+		g_assert_nonnull(cstream);
+	}
+
+	/* the source should still be readable after the compressor is finalized */
+	g_seekable_seek(G_SEEKABLE(source), 0, G_SEEK_SET, NULL, NULL);
+	rc = g_input_stream_read(G_INPUT_STREAM(source), buf, 4, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_cmpint(rc, ==, 4);
+	g_assert_cmpint(buf[0], ==, 'A');
+	g_assert_cmpint(buf[1], ==, 'B');
+	g_assert_cmpint(buf[2], ==, 'C');
+	g_assert_cmpint(buf[3], ==, 'D');
+}
+
+static void
+fu_compressor_stream_checksum_func(void)
+{
+	gboolean ret;
+	g_autoptr(GBytes) original = fu_test_create_pattern(4096);
+	g_autoptr(GBytes) compressed = NULL;
+	g_autoptr(GBytes) decompressed = NULL;
+	g_autoptr(GError) error = NULL;
+	g_autofree gchar *csum_original = NULL;
+	g_autofree gchar *csum_decompressed = NULL;
+
+	compressed = fu_test_compress(original, FU_COMPRESSOR_FORMAT_ZLIB, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(compressed);
+
+	decompressed = fu_test_decompress(compressed, FU_COMPRESSOR_FORMAT_ZLIB, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(decompressed);
+
+	/* compute checksums on the raw bytes and compare */
+	csum_original = g_compute_checksum_for_bytes(G_CHECKSUM_SHA256, original);
+	csum_decompressed = g_compute_checksum_for_bytes(G_CHECKSUM_SHA256, decompressed);
+	g_assert_cmpstr(csum_original, ==, csum_decompressed);
+
+	ret = fu_bytes_compare(original, decompressed, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+}
+
+int
+main(int argc, char **argv)
+{
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
+	g_test_init(&argc, &argv, NULL);
+	g_test_add_func("/fwupd/compressor-stream/type", fu_compressor_stream_type_func);
+	g_test_add_func("/fwupd/compressor-stream/read", fu_compressor_stream_read_func);
+	g_test_add_func("/fwupd/compressor-stream/roundtrip-zlib",
+			fu_compressor_stream_roundtrip_zlib_func);
+	g_test_add_func("/fwupd/compressor-stream/roundtrip-gzip",
+			fu_compressor_stream_roundtrip_gzip_func);
+	g_test_add_func("/fwupd/compressor-stream/roundtrip-raw",
+			fu_compressor_stream_roundtrip_raw_func);
+	g_test_add_func("/fwupd/compressor-stream/decompress-invalid",
+			fu_compressor_stream_decompress_invalid_func);
+	g_test_add_func("/fwupd/compressor-stream/read-bytes",
+			fu_compressor_stream_read_bytes_func);
+	g_test_add_func("/fwupd/compressor-stream/truncate", fu_compressor_stream_truncate_func);
+	g_test_add_func("/fwupd/compressor-stream/empty", fu_compressor_stream_empty_func);
+	g_test_add_func("/fwupd/compressor-stream/format-mismatch",
+			fu_compressor_stream_format_mismatch_func);
+	g_test_add_func("/fwupd/compressor-stream/large", fu_compressor_stream_large_func);
+	g_test_add_func("/fwupd/compressor-stream/no-close-source",
+			fu_compressor_stream_no_close_source_func);
+	g_test_add_func("/fwupd/compressor-stream/checksum", fu_compressor_stream_checksum_func);
+	return g_test_run();
+}

--- a/libfwupdplugin/fu-compressor-stream.c
+++ b/libfwupdplugin/fu-compressor-stream.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#define G_LOG_DOMAIN "FuCompressorStream"
+
+#include "config.h"
+
+#include "fu-compressor-stream.h"
+#include "fu-stream-input-stream-private.h"
+
+/**
+ * FuCompressorStream:
+ *
+ * An input stream that wraps a zlib compressor or decompressor around a
+ * source #FuInputStream. Use fu_compressor_stream_new_compress() to create
+ * a stream that compresses data on read, or fu_compressor_stream_new_decompress()
+ * to create a stream that decompresses data on read.
+ */
+
+struct _FuCompressorStream {
+	FuStreamInputStream parent_instance;
+	GConverter *conv;
+	GInputStream *converter_stream; /* nocheck:blocked */
+};
+
+G_DEFINE_TYPE(FuCompressorStream, fu_compressor_stream, FU_TYPE_STREAM_INPUT_STREAM)
+
+static GZlibCompressorFormat
+fu_compressor_stream_format_to_glib(FuCompressorFormat format)
+{
+	if (format == FU_COMPRESSOR_FORMAT_RAW)
+		return G_ZLIB_COMPRESSOR_FORMAT_RAW;
+	if (format == FU_COMPRESSOR_FORMAT_GZIP)
+		return G_ZLIB_COMPRESSOR_FORMAT_GZIP;
+	return G_ZLIB_COMPRESSOR_FORMAT_ZLIB;
+}
+
+static void
+fu_compressor_stream_finalize(GObject *object)
+{
+	FuCompressorStream *self = FU_COMPRESSOR_STREAM(object);
+	g_clear_object(&self->converter_stream);
+	g_clear_object(&self->conv);
+	G_OBJECT_CLASS(fu_compressor_stream_parent_class)->finalize(object);
+}
+
+static void
+fu_compressor_stream_class_init(FuCompressorStreamClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	object_class->finalize = fu_compressor_stream_finalize;
+}
+
+static void
+fu_compressor_stream_init(FuCompressorStream *self)
+{
+}
+
+/**
+ * fu_compressor_stream_new_decompress:
+ * @source: a #FuInputStream with compressed data
+ * @format: a #FuCompressorFormat, e.g. %FU_COMPRESSOR_FORMAT_GZIP
+ * @error: (nullable): optional return location for an error
+ *
+ * Creates a new stream that decompresses data from @source on read.
+ *
+ * Returns: (transfer full): a #FuInputStream, or %NULL on error
+ *
+ * Since: 2.0.7
+ **/
+FuInputStream *
+fu_compressor_stream_new_decompress(FuInputStream *source,
+				    FuCompressorFormat format,
+				    GError **error)
+{
+	g_autoptr(FuCompressorStream) self = NULL;
+
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(source), NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
+	self = g_object_new(FU_TYPE_COMPRESSOR_STREAM, NULL);
+
+	self->conv = G_CONVERTER(g_zlib_decompressor_new(
+	    fu_compressor_stream_format_to_glib(format))); /* nocheck:blocked */
+	self->converter_stream = g_converter_input_stream_new(G_INPUT_STREAM(source), self->conv);
+	g_filter_input_stream_set_close_base_stream(G_FILTER_INPUT_STREAM(self->converter_stream),
+						    FALSE);
+	fu_stream_input_stream_set_base_stream(FU_STREAM_INPUT_STREAM(self),
+					       self->converter_stream);
+
+	return FU_INPUT_STREAM(g_steal_pointer(&self));
+}
+
+/**
+ * fu_compressor_stream_new_compress:
+ * @source: a #FuInputStream with uncompressed data
+ * @format: a #FuCompressorFormat, e.g. %FU_COMPRESSOR_FORMAT_ZLIB
+ * @error: (nullable): optional return location for an error
+ *
+ * Creates a new stream that compresses data from @source on read.
+ *
+ * Returns: (transfer full): a #FuInputStream, or %NULL on error
+ *
+ * Since: 2.0.7
+ **/
+FuInputStream *
+fu_compressor_stream_new_compress(FuInputStream *source, FuCompressorFormat format, GError **error)
+{
+	g_autoptr(FuCompressorStream) self = NULL;
+
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(source), NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
+	self = g_object_new(FU_TYPE_COMPRESSOR_STREAM, NULL);
+
+	self->conv = G_CONVERTER(g_zlib_compressor_new(fu_compressor_stream_format_to_glib(format),
+						       -1)); /* nocheck:blocked */
+	self->converter_stream = g_converter_input_stream_new(G_INPUT_STREAM(source), self->conv);
+	g_filter_input_stream_set_close_base_stream(G_FILTER_INPUT_STREAM(self->converter_stream),
+						    FALSE);
+	fu_stream_input_stream_set_base_stream(FU_STREAM_INPUT_STREAM(self),
+					       self->converter_stream);
+
+	return FU_INPUT_STREAM(g_steal_pointer(&self));
+}

--- a/libfwupdplugin/fu-compressor-stream.h
+++ b/libfwupdplugin/fu-compressor-stream.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include "fu-compressor-struct.h"
+#include "fu-stream-input-stream.h"
+
+#define FU_TYPE_COMPRESSOR_STREAM (fu_compressor_stream_get_type())
+G_DECLARE_FINAL_TYPE(FuCompressorStream,
+		     fu_compressor_stream,
+		     FU,
+		     COMPRESSOR_STREAM,
+		     FuStreamInputStream)
+
+FuInputStream *
+fu_compressor_stream_new_decompress(FuInputStream *source,
+				    FuCompressorFormat format,
+				    GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1);
+FuInputStream *
+fu_compressor_stream_new_compress(FuInputStream *source,
+				  FuCompressorFormat format,
+				  GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-compressor.rs
+++ b/libfwupdplugin/fu-compressor.rs
@@ -1,0 +1,10 @@
+// Copyright 2026 Red Hat
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#[derive(ToString, FromString)]
+#[repr(u8)]
+enum FuCompressorFormat {
+    Raw,
+    Zlib,
+    Gzip,
+}

--- a/libfwupdplugin/fu-kernel.c
+++ b/libfwupdplugin/fu-kernel.c
@@ -14,6 +14,7 @@
 #include <sys/utsname.h>
 #endif
 
+#include "fu-compressor-stream.h"
 #include "fu-input-stream.h"
 #include "fu-kernel.h"
 #include "fu-path.h"
@@ -241,15 +242,16 @@ fu_kernel_get_config(FuPathStore *pstore, GError **error)
 	    fu_path_store_build_filename(pstore, NULL, FU_PATH_KIND_PROCFS, "config.gz", NULL);
 	if (config_fngz != NULL && g_file_test(config_fngz, G_FILE_TEST_EXISTS)) {
 		g_autoptr(GBytes) payload = NULL;
-		g_autoptr(GConverter) conv = NULL;
 		g_autoptr(FuInputStream) istream1 = NULL;
 		g_autoptr(FuInputStream) istream2 = NULL;
 
 		istream1 = fu_input_stream_from_path(config_fngz, error);
 		if (istream1 == NULL)
 			return NULL;
-		conv = G_CONVERTER(g_zlib_decompressor_new(G_ZLIB_COMPRESSOR_FORMAT_GZIP));
-		istream2 = g_converter_input_stream_new(G_INPUT_STREAM(istream1), conv);
+		istream2 =
+		    fu_compressor_stream_new_decompress(istream1, FU_COMPRESSOR_FORMAT_GZIP, error);
+		if (istream2 == NULL)
+			return NULL;
 		payload = fu_input_stream_read_bytes(istream2, 0, G_MAXSIZE, NULL, error);
 		if (payload == NULL)
 			return NULL;

--- a/libfwupdplugin/fu-stream-input-stream-private.h
+++ b/libfwupdplugin/fu-stream-input-stream-private.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include "fu-stream-input-stream.h"
+
+void
+fu_stream_input_stream_set_base_stream(FuStreamInputStream *self, GInputStream *base_stream)
+    G_GNUC_NON_NULL(1, 2);

--- a/libfwupdplugin/fu-stream-input-stream-test.c
+++ b/libfwupdplugin/fu-stream-input-stream-test.c
@@ -1,0 +1,366 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include <fwupdplugin.h>
+
+#include "fu-stream-input-stream-private.h"
+
+static void
+fu_stream_input_stream_read_func(void)
+{
+	gssize rc;
+	guint8 buf[8] = {0};
+	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+
+	/* read first 4 bytes */
+	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 4, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_cmpint(rc, ==, 4);
+	g_assert_cmpint(buf[0], ==, 'A');
+	g_assert_cmpint(buf[1], ==, 'B');
+	g_assert_cmpint(buf[2], ==, 'C');
+	g_assert_cmpint(buf[3], ==, 'D');
+
+	/* read next 4 bytes */
+	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 4, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_cmpint(rc, ==, 4);
+	g_assert_cmpint(buf[0], ==, 'E');
+	g_assert_cmpint(buf[1], ==, 'F');
+	g_assert_cmpint(buf[2], ==, 'G');
+	g_assert_cmpint(buf[3], ==, 'H');
+
+	/* reading past end returns 0 */
+	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 4, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_cmpint(rc, ==, 0);
+}
+
+static void
+fu_stream_input_stream_read_short_func(void)
+{
+	gssize rc;
+	guint8 buf[16] = {0};
+	g_autoptr(GBytes) blob = g_bytes_new_static("ABC", 3);
+	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+	g_autoptr(GError) error = NULL;
+
+	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, sizeof(buf), NULL, &error);
+	g_assert_no_error(error);
+	g_assert_cmpint(rc, ==, 3);
+	g_assert_cmpint(buf[0], ==, 'A');
+	g_assert_cmpint(buf[1], ==, 'B');
+	g_assert_cmpint(buf[2], ==, 'C');
+}
+
+static void
+fu_stream_input_stream_seek_func(void)
+{
+	gboolean ret;
+	gssize rc;
+	guint8 buf[2] = {0};
+	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+
+	/* can_seek should return TRUE for a seekable base stream */
+	g_assert_true(g_seekable_can_seek(G_SEEKABLE(stream)));
+
+	/* SEEK_SET to offset 4 */
+	ret = g_seekable_seek(G_SEEKABLE(stream), 4, G_SEEK_SET, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 4);
+
+	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 2, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_cmpint(rc, ==, 2);
+	g_assert_cmpint(buf[0], ==, 'E');
+	g_assert_cmpint(buf[1], ==, 'F');
+
+	/* SEEK_CUR forward by 1 (now at position 7) */
+	ret = g_seekable_seek(G_SEEKABLE(stream), 1, G_SEEK_CUR, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 7);
+
+	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 1, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_cmpint(rc, ==, 1);
+	g_assert_cmpint(buf[0], ==, 'H');
+
+	/* SEEK_END with negative offset */
+	ret = g_seekable_seek(G_SEEKABLE(stream), -2, G_SEEK_END, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 6);
+
+	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 2, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_cmpint(rc, ==, 2);
+	g_assert_cmpint(buf[0], ==, 'G');
+	g_assert_cmpint(buf[1], ==, 'H');
+
+	/* seek back to start */
+	ret = g_seekable_seek(G_SEEKABLE(stream), 0, G_SEEK_SET, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 0);
+}
+
+static void
+fu_stream_input_stream_tell_func(void)
+{
+	gboolean ret;
+	gssize rc;
+	guint8 buf[3] = {0};
+	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEF", 6);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+
+	/* initial position is 0 */
+	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 0);
+
+	/* read advances position */
+	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 3, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_cmpint(rc, ==, 3);
+	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 3);
+
+	/* position is mirrored on the base stream */
+	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(base_stream)), ==, 3);
+
+	/* seek the wrapper, verify base stream follows */
+	ret = g_seekable_seek(G_SEEKABLE(stream), 5, G_SEEK_SET, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 5);
+	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(base_stream)), ==, 5);
+}
+
+static void
+fu_stream_input_stream_truncate_func(void)
+{
+	gboolean ret;
+	g_autoptr(GBytes) blob = g_bytes_new_static("ABCD", 4);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+
+	g_assert_false(g_seekable_can_truncate(G_SEEKABLE(stream)));
+
+	ret = g_seekable_truncate(G_SEEKABLE(stream), 2, NULL, &error);
+	g_assert_false(ret);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
+}
+
+static void
+fu_stream_input_stream_read_bytes_func(void)
+{
+	const guint8 *data;
+	gsize sz = 0;
+	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+	g_autoptr(GBytes) result = NULL;
+
+	result = fu_input_stream_read_bytes(stream, 2, 4, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(result);
+	g_assert_cmpint(g_bytes_get_size(result), ==, 4);
+	data = g_bytes_get_data(result, &sz);
+	g_assert_cmpint(sz, ==, 4);
+	g_assert_cmpint(data[0], ==, 'C');
+	g_assert_cmpint(data[1], ==, 'D');
+	g_assert_cmpint(data[2], ==, 'E');
+	g_assert_cmpint(data[3], ==, 'F');
+}
+
+static void
+fu_stream_input_stream_size_func(void)
+{
+	gboolean ret;
+	gsize sz = 0;
+	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+
+	ret = fu_input_stream_size(stream, &sz, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_cmpint(sz, ==, 8);
+}
+
+static void
+fu_stream_input_stream_read_safe_func(void)
+{
+	gboolean ret;
+	guint8 buf[8] = {0};
+	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+
+	/* read 3 bytes from offset 2 in the stream, store at offset 0 in buf */
+	ret = fu_input_stream_read_safe(stream, buf, sizeof(buf), 0x0, 0x2, 3, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_cmpint(buf[0], ==, 'C');
+	g_assert_cmpint(buf[1], ==, 'D');
+	g_assert_cmpint(buf[2], ==, 'E');
+}
+
+static void
+fu_stream_input_stream_checksum_func(void)
+{
+	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+	g_autofree gchar *csum_wrapper = NULL;
+	g_autofree gchar *csum_expected = NULL;
+
+	csum_expected =
+	    g_compute_checksum_for_data(G_CHECKSUM_SHA256, (const guint8 *)"ABCDEFGH", 8);
+	csum_wrapper = fu_input_stream_compute_checksum(stream, G_CHECKSUM_SHA256, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(csum_wrapper);
+	g_assert_cmpstr(csum_wrapper, ==, csum_expected);
+}
+
+static void
+fu_stream_input_stream_empty_func(void)
+{
+	gboolean ret;
+	gssize rc;
+	gsize sz = 0;
+	guint8 buf[4] = {0};
+	g_autoptr(GBytes) blob = g_bytes_new_static("", 0);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+
+	/* size should be 0 */
+	ret = fu_input_stream_size(stream, &sz, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_cmpint(sz, ==, 0);
+
+	/* read should return 0 immediately */
+	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, sizeof(buf), NULL, &error);
+	g_assert_no_error(error);
+	g_assert_cmpint(rc, ==, 0);
+
+	/* tell should be at 0 */
+	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 0);
+}
+
+static void
+fu_stream_input_stream_closed_base_func(void)
+{
+	gboolean ret;
+	gssize rc;
+	guint8 buf[4] = {0};
+	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+
+	/* close the base stream */
+	ret = g_input_stream_close(G_INPUT_STREAM(base_stream), NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* reading through the wrapper should fail */
+	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, sizeof(buf), NULL, &error);
+	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_CLOSED);
+	g_assert_cmpint(rc, ==, -1);
+}
+
+static void
+fu_stream_input_stream_type_func(void)
+{
+	g_autoptr(GBytes) blob = g_bytes_new_static("ABCD", 4);
+	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+
+	g_assert_true(G_IS_INPUT_STREAM(stream));
+	g_assert_true(G_IS_SEEKABLE(stream));
+	g_assert_true(FU_IS_INPUT_STREAM(stream));
+	g_assert_true(FU_IS_STREAM_INPUT_STREAM(stream));
+}
+
+static void
+fu_stream_input_stream_seek_read_cycle_func(void)
+{
+	gboolean ret;
+	gssize rc;
+	guint8 buf[1] = {0};
+	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+
+	/* read each byte individually by seeking */
+	for (gsize i = 0; i < 8; i++) {
+		ret = g_seekable_seek(G_SEEKABLE(stream), (goffset)i, G_SEEK_SET, NULL, &error);
+		g_assert_no_error(error);
+		g_assert_true(ret);
+
+		rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 1, NULL, &error);
+		g_assert_no_error(error);
+		g_assert_cmpint(rc, ==, 1);
+		g_assert_cmpint(buf[0], ==, 'A' + (guint8)i);
+	}
+
+	/* seek backwards and re-read */
+	ret = g_seekable_seek(G_SEEKABLE(stream), 0, G_SEEK_SET, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 1, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_cmpint(rc, ==, 1);
+	g_assert_cmpint(buf[0], ==, 'A');
+}
+
+int
+main(int argc, char **argv)
+{
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
+	g_test_init(&argc, &argv, NULL);
+	g_test_add_func("/fwupd/stream-input-stream/type", fu_stream_input_stream_type_func);
+	g_test_add_func("/fwupd/stream-input-stream/read", fu_stream_input_stream_read_func);
+	g_test_add_func("/fwupd/stream-input-stream/read-short",
+			fu_stream_input_stream_read_short_func);
+	g_test_add_func("/fwupd/stream-input-stream/seek", fu_stream_input_stream_seek_func);
+	g_test_add_func("/fwupd/stream-input-stream/tell", fu_stream_input_stream_tell_func);
+	g_test_add_func("/fwupd/stream-input-stream/truncate",
+			fu_stream_input_stream_truncate_func);
+	g_test_add_func("/fwupd/stream-input-stream/read-bytes",
+			fu_stream_input_stream_read_bytes_func);
+	g_test_add_func("/fwupd/stream-input-stream/size", fu_stream_input_stream_size_func);
+	g_test_add_func("/fwupd/stream-input-stream/read-safe",
+			fu_stream_input_stream_read_safe_func);
+	g_test_add_func("/fwupd/stream-input-stream/checksum",
+			fu_stream_input_stream_checksum_func);
+	g_test_add_func("/fwupd/stream-input-stream/empty", fu_stream_input_stream_empty_func);
+	g_test_add_func("/fwupd/stream-input-stream/closed-base",
+			fu_stream_input_stream_closed_base_func);
+	g_test_add_func("/fwupd/stream-input-stream/seek-read-cycle",
+			fu_stream_input_stream_seek_read_cycle_func);
+	return g_test_run();
+}

--- a/libfwupdplugin/fu-stream-input-stream.c
+++ b/libfwupdplugin/fu-stream-input-stream.c
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#define G_LOG_DOMAIN "FuStreamInputStream"
+
+#include "config.h"
+
+#include "fu-stream-input-stream-private.h"
+#include "fu-stream-input-stream.h"
+
+/**
+ * FuStreamInputStream:
+ *
+ * An input stream that wraps a #GInputStream (or subclass) into the
+ * #FuInputStream type hierarchy.
+ */
+
+typedef struct {
+	GInputStream *base_stream; /* nocheck:blocked */
+} FuStreamInputStreamPrivate;
+
+static void
+fu_stream_input_stream_seekable_iface_init(GSeekableIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE(FuStreamInputStream,
+			fu_stream_input_stream,
+			FU_TYPE_INPUT_STREAM,
+			G_ADD_PRIVATE(FuStreamInputStream)
+			    G_IMPLEMENT_INTERFACE(G_TYPE_SEEKABLE,
+						  fu_stream_input_stream_seekable_iface_init))
+
+static gssize
+fu_stream_input_stream_read(GInputStream *stream,
+			    void *buffer,
+			    gsize count,
+			    GCancellable *cancellable,
+			    GError **error)
+{
+	FuStreamInputStream *self = FU_STREAM_INPUT_STREAM(stream);
+	FuStreamInputStreamPrivate *priv = fu_stream_input_stream_get_instance_private(self);
+
+	g_return_val_if_fail(priv->base_stream != NULL, -1);
+
+	return g_input_stream_read(priv->base_stream, buffer, count, cancellable, error);
+}
+
+static goffset
+fu_stream_input_stream_tell(GSeekable *seekable)
+{
+	FuStreamInputStream *self = FU_STREAM_INPUT_STREAM(seekable);
+	FuStreamInputStreamPrivate *priv = fu_stream_input_stream_get_instance_private(self);
+
+	if (!G_IS_SEEKABLE(priv->base_stream))
+		return 0;
+
+	return g_seekable_tell(G_SEEKABLE(priv->base_stream));
+}
+
+static gboolean
+fu_stream_input_stream_can_seek(GSeekable *seekable)
+{
+	FuStreamInputStream *self = FU_STREAM_INPUT_STREAM(seekable);
+	FuStreamInputStreamPrivate *priv = fu_stream_input_stream_get_instance_private(self);
+
+	if (!G_IS_SEEKABLE(priv->base_stream))
+		return FALSE;
+
+	return g_seekable_can_seek(G_SEEKABLE(priv->base_stream));
+}
+
+static gboolean
+fu_stream_input_stream_seek(GSeekable *seekable,
+			    goffset offset,
+			    GSeekType type,
+			    GCancellable *cancellable,
+			    GError **error)
+{
+	FuStreamInputStream *self = FU_STREAM_INPUT_STREAM(seekable);
+	FuStreamInputStreamPrivate *priv = fu_stream_input_stream_get_instance_private(self);
+
+	if (!G_IS_SEEKABLE(priv->base_stream)) {
+		g_set_error_literal(error,
+				    G_IO_ERROR,
+				    G_IO_ERROR_NOT_SUPPORTED,
+				    "base stream is not seekable"); /* nocheck:error */
+		return FALSE;
+	}
+
+	return g_seekable_seek(G_SEEKABLE(priv->base_stream), offset, type, cancellable, error);
+}
+
+static gboolean
+fu_stream_input_stream_can_truncate(GSeekable *seekable)
+{
+	return FALSE;
+}
+
+static gboolean
+fu_stream_input_stream_truncate(GSeekable *seekable,
+				goffset offset,
+				GCancellable *cancellable,
+				GError **error)
+{
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "cannot truncate FuStreamInputStream");
+	return FALSE;
+}
+
+static void
+fu_stream_input_stream_seekable_iface_init(GSeekableIface *iface)
+{
+	iface->tell = fu_stream_input_stream_tell;
+	iface->can_seek = fu_stream_input_stream_can_seek;
+	iface->seek = fu_stream_input_stream_seek;
+	iface->can_truncate = fu_stream_input_stream_can_truncate;
+	iface->truncate_fn = fu_stream_input_stream_truncate;
+}
+
+static void
+fu_stream_input_stream_finalize(GObject *object)
+{
+	FuStreamInputStream *self = FU_STREAM_INPUT_STREAM(object);
+	FuStreamInputStreamPrivate *priv = fu_stream_input_stream_get_instance_private(self);
+	g_clear_object(&priv->base_stream);
+	G_OBJECT_CLASS(fu_stream_input_stream_parent_class)->finalize(object);
+}
+
+static void
+fu_stream_input_stream_class_init(FuStreamInputStreamClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	GInputStreamClass *istream_class = G_INPUT_STREAM_CLASS(klass); /* nocheck:blocked */
+	object_class->finalize = fu_stream_input_stream_finalize;
+	istream_class->read_fn = fu_stream_input_stream_read;
+}
+
+static void
+fu_stream_input_stream_init(FuStreamInputStream *self)
+{
+}
+
+/**
+ * fu_stream_input_stream_set_base_stream:
+ * @self: a #FuStreamInputStream
+ * @base_stream: (transfer none): a #GInputStream
+ *
+ * Sets the underlying #GInputStream that this stream wraps.
+ * The @base_stream is reffed.
+ * This is intended for use by subclasses during construction.
+ *
+ * Since: 2.0.7
+ **/
+void
+fu_stream_input_stream_set_base_stream(FuStreamInputStream *self, GInputStream *base_stream)
+{
+	FuStreamInputStreamPrivate *priv = fu_stream_input_stream_get_instance_private(self);
+
+	g_return_if_fail(FU_IS_STREAM_INPUT_STREAM(self));
+	g_return_if_fail(G_IS_INPUT_STREAM(base_stream));
+
+	g_set_object(&priv->base_stream, base_stream);
+}
+
+/**
+ * fu_stream_input_stream_from_stream:
+ * @stream: (transfer none): a #GInputStream
+ *
+ * Wraps a #GInputStream and returns a #FuStreamInputStream. The @stream
+ * is reffed and future operations on this input stream apply to the
+ * underlying #GInputStream.
+ *
+ * Returns: (transfer full): a #FuStreamInputStream, or %NULL on error
+ *
+ * Since: 2.0.7
+ **/
+FuInputStream *
+fu_stream_input_stream_from_stream(GInputStream *stream)
+{
+	g_autoptr(FuStreamInputStream) self = NULL;
+
+	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), NULL);
+
+	self = g_object_new(FU_TYPE_STREAM_INPUT_STREAM, NULL);
+	fu_stream_input_stream_set_base_stream(self, stream);
+
+	return FU_INPUT_STREAM(g_steal_pointer(&self));
+}

--- a/libfwupdplugin/fu-stream-input-stream.h
+++ b/libfwupdplugin/fu-stream-input-stream.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include "fu-input-stream.h"
+
+#define FU_TYPE_STREAM_INPUT_STREAM (fu_stream_input_stream_get_type())
+G_DECLARE_DERIVABLE_TYPE(FuStreamInputStream,
+			 fu_stream_input_stream,
+			 FU,
+			 STREAM_INPUT_STREAM,
+			 FuInputStream)
+
+struct _FuStreamInputStreamClass {
+	FuInputStreamClass parent_class;
+};
+
+FuInputStream *
+fu_stream_input_stream_from_stream(GInputStream *stream) G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-uswid-firmware.c
+++ b/libfwupdplugin/fu-uswid-firmware.c
@@ -11,6 +11,7 @@
 #include "fu-byte-array.h"
 #include "fu-bytes.h"
 #include "fu-common.h"
+#include "fu-compressor-stream.h"
 #include "fu-coswid-firmware.h"
 #include "fu-input-stream.h"
 #include "fu-lzma-common.h"
@@ -152,10 +153,8 @@ fu_uswid_firmware_parse(FuFirmware *firmware,
 
 	/* zlib stream */
 	if (priv->compression == FU_USWID_PAYLOAD_COMPRESSION_ZLIB) {
-		g_autoptr(GConverter) conv = NULL;
 		g_autoptr(FuInputStream) istream1 = NULL;
 		g_autoptr(FuInputStream) istream2 = NULL;
-		conv = G_CONVERTER(g_zlib_decompressor_new(G_ZLIB_COMPRESSOR_FORMAT_ZLIB));
 		istream1 = fu_partial_input_stream_new(stream, hdrsz, payloadsz, error);
 		if (istream1 == NULL) {
 			g_prefix_error_literal(error, "failed to cut uSWID payload: ");
@@ -163,8 +162,10 @@ fu_uswid_firmware_parse(FuFirmware *firmware,
 		}
 		if (!g_seekable_seek(G_SEEKABLE(istream1), 0, G_SEEK_SET, NULL, error))
 			return FALSE;
-		istream2 = g_converter_input_stream_new(istream1, conv);
-		g_filter_input_stream_set_close_base_stream(G_FILTER_INPUT_STREAM(istream2), FALSE);
+		istream2 =
+		    fu_compressor_stream_new_decompress(istream1, FU_COMPRESSOR_FORMAT_ZLIB, error);
+		if (istream2 == NULL)
+			return FALSE;
 		payload = fu_input_stream_read_bytes(istream2, 0, payloadsz_max + 1, NULL, error);
 		if (payload == NULL)
 			return FALSE;
@@ -266,13 +267,14 @@ fu_uswid_firmware_write(FuFirmware *firmware, GError **error)
 
 	/* compression format */
 	if (priv->compression == FU_USWID_PAYLOAD_COMPRESSION_ZLIB) {
-		g_autoptr(GConverter) conv = NULL;
 		g_autoptr(FuInputStream) istream1 = NULL;
 		g_autoptr(FuInputStream) istream2 = NULL;
 
-		conv = G_CONVERTER(g_zlib_compressor_new(G_ZLIB_COMPRESSOR_FORMAT_ZLIB, -1));
 		istream1 = fu_memory_input_stream_new_from_data(payload->data, payload->len, NULL);
-		istream2 = g_converter_input_stream_new(G_INPUT_STREAM(istream1), conv);
+		istream2 =
+		    fu_compressor_stream_new_compress(istream1, FU_COMPRESSOR_FORMAT_ZLIB, error);
+		if (istream2 == NULL)
+			return NULL;
 		payload_blob = fu_input_stream_read_bytes(istream2, 0, G_MAXSIZE, NULL, error);
 		if (payload_blob == NULL)
 			return NULL;

--- a/libfwupdplugin/fu-zip-firmware.c
+++ b/libfwupdplugin/fu-zip-firmware.c
@@ -10,6 +10,7 @@
 
 #include "fu-byte-array.h"
 #include "fu-common.h"
+#include "fu-compressor-stream.h"
 #include "fu-input-stream.h"
 #include "fu-memory-input-stream.h"
 #include "fu-partial-input-stream.h"
@@ -222,17 +223,17 @@ fu_zip_firmware_parse_lfh(FuZipFirmware *self,
 			return NULL;
 	} else if (compression == FU_ZIP_COMPRESSION_DEFLATE) {
 		g_autoptr(GBytes) blob_raw = NULL;
-		g_autoptr(GConverter) conv = NULL;
-		g_autoptr(FuInputStream) stream_deflate = NULL;
+		g_autoptr(FuInputStream) fustream = NULL;
 
-		conv = G_CONVERTER(g_zlib_decompressor_new(G_ZLIB_COMPRESSOR_FORMAT_RAW));
 		if (!g_seekable_seek(G_SEEKABLE(stream_compressed), 0, G_SEEK_SET, NULL, error))
 			return NULL;
-		stream_deflate = g_converter_input_stream_new(stream_compressed, conv);
-		g_filter_input_stream_set_close_base_stream(G_FILTER_INPUT_STREAM(stream_deflate),
-							    FALSE);
-		blob_raw =
-		    fu_input_stream_read_bytes(stream_deflate, 0, uncompressed_size, NULL, error);
+
+		fustream = fu_compressor_stream_new_decompress(stream_compressed,
+							       FU_COMPRESSOR_FORMAT_RAW,
+							       error);
+		if (fustream == NULL)
+			return NULL;
+		blob_raw = fu_input_stream_read_bytes(fustream, 0, uncompressed_size, NULL, error);
 		if (blob_raw == NULL) {
 			g_prefix_error_literal(error, "failed to read compressed stream: ");
 			return NULL;
@@ -454,18 +455,16 @@ fu_zip_firmware_write(FuFirmware *firmware, GError **error)
 		if (compression == FU_ZIP_COMPRESSION_NONE) {
 			blob_compressed = g_bytes_ref(blob);
 		} else if (compression == FU_ZIP_COMPRESSION_DEFLATE) {
-			g_autoptr(GConverter) conv = NULL;
 			g_autoptr(FuInputStream) istream_raw = NULL;
-			g_autoptr(FuInputStream) istream_compressed = NULL;
-			conv = G_CONVERTER(g_zlib_compressor_new(G_ZLIB_COMPRESSOR_FORMAT_RAW, -1));
+			g_autoptr(FuInputStream) istream_out = NULL;
 			istream_raw = fu_memory_input_stream_new_from_bytes(blob);
-			istream_compressed =
-			    g_converter_input_stream_new(G_INPUT_STREAM(istream_raw), conv);
-			blob_compressed = fu_input_stream_read_bytes(istream_compressed,
-								     0,
-								     G_MAXSIZE,
-								     NULL,
-								     error);
+			istream_out = fu_compressor_stream_new_compress(istream_raw,
+									FU_COMPRESSOR_FORMAT_RAW,
+									error);
+			if (istream_out == NULL)
+				return NULL;
+			blob_compressed =
+			    fu_input_stream_read_bytes(istream_out, 0, G_MAXSIZE, NULL, error);
 			if (blob_compressed == NULL) {
 				g_prefix_error_literal(error, "failed to read compressed stream: ");
 				return NULL;

--- a/libfwupdplugin/fwupdplugin.h
+++ b/libfwupdplugin/fwupdplugin.h
@@ -27,6 +27,7 @@
 #include <libfwupdplugin/fu-common-guid.h>
 #include <libfwupdplugin/fu-common.h>
 #include <libfwupdplugin/fu-composite-input-stream.h>
+#include <libfwupdplugin/fu-compressor-stream.h>
 #include <libfwupdplugin/fu-config.h>
 #include <libfwupdplugin/fu-context-helper.h>
 #include <libfwupdplugin/fu-context.h>

--- a/libfwupdplugin/fwupdplugin.h
+++ b/libfwupdplugin/fwupdplugin.h
@@ -125,6 +125,7 @@
 #include <libfwupdplugin/fu-serio-device.h>
 #include <libfwupdplugin/fu-smbios.h>
 #include <libfwupdplugin/fu-srec-firmware.h>
+#include <libfwupdplugin/fu-stream-input-stream.h>
 #include <libfwupdplugin/fu-string.h>
 #include <libfwupdplugin/fu-sum.h>
 #include <libfwupdplugin/fu-temporary-directory.h>

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -202,6 +202,7 @@ fwupdplugin_src = [
   'fu-serio-device.c',
   'fu-smbios.c', # fuzzing
   'fu-srec-firmware.c', # fuzzing
+  'fu-stream-input-stream.c', # fuzzing
   'fu-string.c', # fuzzing
   'fu-sum.c', # fuzzing
   'fu-temporary-directory.c', # fuzzing
@@ -370,6 +371,8 @@ fwupdplugin_headers = [
   'fu-smbios.h',
   'fu-smbios-private.h',
   'fu-srec-firmware.h',
+  'fu-stream-input-stream.h',
+  'fu-stream-input-stream-private.h',
   'fu-string.h',
   'fu-sum.h',
   'fu-temporary-directory.h',
@@ -546,6 +549,7 @@ if get_option('tests')
     'security-attrs',
     'smbios',
     'srec-firmware',
+    'stream-input-stream',
     'string',
     'struct',
     'temporary-directory',

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -9,6 +9,7 @@ fwupdplugin_structs = [
   'fu-cfu.rs', # fuzzing
   'fu-cfu-firmware.rs', # fuzzing
   'fu-config.rs', # fuzzing
+  'fu-compressor.rs', # fuzzing
   'fu-coswid.rs', # fuzzing
   'fu-context.rs', # fuzzing
   'fu-device.rs', # fuzzing
@@ -95,6 +96,7 @@ fwupdplugin_src = [
   'fu-common.c', # fuzzing
   'fu-common-guid.c',
   'fu-composite-input-stream.c', # fuzzing
+  'fu-compressor-stream.c', # fuzzing
   'fu-config.c', # fuzzing
   'fu-context.c', # fuzzing
   'fu-context-helper.c',
@@ -267,6 +269,7 @@ fwupdplugin_headers = [
   'fu-chunk-array.h',
   'fu-common-guid.h',
   'fu-common.h',
+  'fu-compressor-stream.h',
   'fu-composite-input-stream.h',
   'fu-config.h',
   'fu-config-private.h',
@@ -517,6 +520,7 @@ if get_option('tests')
     'cbor',
     'chunk-array',
     'common',
+    'compressor-stream',
     'composite-input-stream',
     'config',
     'context',

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -4348,12 +4348,13 @@ fu_engine_builder_cabinet_adapter_cb(XbBuilderSource *source,
 {
 	FuEngine *self = FU_ENGINE(user_data);
 	GInputStream *stream = xb_builder_source_ctx_get_stream(ctx); /* nocheck:blocked */
+	g_autoptr(FuInputStream) fustream = fu_stream_input_stream_from_stream(stream);
 	g_autoptr(FuCabinet) cabinet = NULL;
 	g_autoptr(XbSilo) silo = NULL;
 	g_autofree gchar *xml = NULL;
 
 	/* convert the CAB into metadata XML */
-	cabinet = fu_engine_build_cabinet_from_stream(self, stream, error);
+	cabinet = fu_engine_build_cabinet_from_stream(self, fustream, error);
 	if (cabinet == NULL)
 		return NULL;
 	silo = fu_cabinet_get_silo(cabinet, error);
@@ -7712,14 +7713,16 @@ fu_engine_load_host_emulation(FuEngine *self, const gchar *fn, GError **error)
 	if (istream_raw == NULL)
 		return FALSE;
 	if (g_str_has_suffix(fn, ".gz")) {
-		g_autoptr(GConverter) conv =
-		    G_CONVERTER(g_zlib_decompressor_new(G_ZLIB_COMPRESSOR_FORMAT_GZIP));
-		istream_json = g_converter_input_stream_new(istream_raw, conv);
+		istream_json = fu_compressor_stream_new_decompress(istream_raw,
+								   FU_COMPRESSOR_FORMAT_GZIP,
+								   error);
+		if (istream_json == NULL)
+			return FALSE;
 	} else {
 		istream_json = g_object_ref(istream_raw);
 	}
 	json_node = fwupd_json_parser_load_from_stream(json_parser,
-						       istream_json,
+						       G_INPUT_STREAM(istream_json),
 						       FWUPD_JSON_LOAD_FLAG_NONE,
 						       error);
 	if (json_node == NULL)


### PR DESCRIPTION
This is the next step after #10653, this time with a real type. It removes the uses of `GConverter` and replaces them with a custom stream instead. No real functional changes yet
since it's all still `GInputStream`s anyway but this is another step towards abstracting streams so we can, eventually, maybe implement those in Rust.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
