### PR TITLE
Allow overriding basic methods in FwupdClient

### DIFF
--- a/data/bash-completion/fwupdmgr
+++ b/data/bash-completion/fwupdmgr
@@ -35,6 +35,7 @@ _fwupdmgr_cmd_list=(
 	'local-install'
 	'modify-config'
 	'modify-remote'
+	'monitor'
 	'quit'
 	'reinstall'
 	'refresh'

--- a/data/fish-completion/fwupdmgr.fish
+++ b/data/fish-completion/fwupdmgr.fish
@@ -47,6 +47,7 @@ function __fish_fwupdmgr_subcommands --description 'Get fwupdmgr subcommands'
         local-install 'Install a firmware file in cabinet format on this hardware' \
         modify-config 'Modifies a daemon configuration value' \
         modify-remote 'Modifies a given remote' \
+        monitor 'Monitor the daemon for events' \
         clean-remote 'Clean a given remote' \
         quit 'Asks the daemon to quit' \
         refresh 'Refresh metadata from remote server' \

--- a/libfwupd/fwupd-client-private.h
+++ b/libfwupd/fwupd-client-private.h
@@ -12,6 +12,134 @@
 #include <gio/gunixinputstream.h>
 #endif
 
+/* allow overrides for synchronous clients that are not using DBus */
+struct FwupdClientSyncImpl {
+	gboolean (*activate)(FwupdClient *self,
+			     const gchar *device_id,
+			     gpointer user_data,
+			     GCancellable *cancellable,
+			     GError **error);
+	gboolean (*connect)(FwupdClient *self,
+			    gpointer user_data,
+			    GCancellable *cancellable,
+			    GError **error);
+	gboolean (*emulation_load)(FwupdClient *self,
+				   const gchar *filename,
+				   gpointer user_data,
+				   GCancellable *cancellable,
+				   GError **error);
+	gboolean (*emulation_save)(FwupdClient *self,
+				   const gchar *filename,
+				   gpointer user_data,
+				   GCancellable *cancellable,
+				   GError **error);
+	GPtrArray *(*get_bios_settings)(FwupdClient *self,
+					gpointer user_data,
+					GCancellable *cancellable,
+					GError **error);
+	GPtrArray *(*get_details)(FwupdClient *self,
+				  const gchar *filename,
+				  gpointer user_data,
+				  GCancellable *cancellable,
+				  GError **error);
+	GPtrArray *(*get_devices)(FwupdClient *self,
+				  gpointer user_data,
+				  GCancellable *cancellable,
+				  GError **error);
+	GPtrArray *(*get_devices_by_guid)(FwupdClient *self,
+					  const gchar *guid,
+					  gpointer user_data,
+					  GCancellable *cancellable,
+					  GError **error);
+	FwupdDevice *(*get_device_by_id)(FwupdClient *self,
+					 const gchar *device_id,
+					 gpointer user_data,
+					 GCancellable *cancellable,
+					 GError **error);
+	GPtrArray *(*get_history)(FwupdClient *self,
+				  gpointer user_data,
+				  GCancellable *cancellable,
+				  GError **error);
+	GPtrArray *(*get_host_security_attrs)(FwupdClient *self,
+					      gpointer user_data,
+					      GCancellable *cancellable,
+					      GError **error);
+	GPtrArray *(*get_host_security_events)(FwupdClient *self,
+					       guint limit,
+					       gpointer user_data,
+					       GCancellable *cancellable,
+					       GError **error);
+	GPtrArray *(*get_releases)(FwupdClient *self,
+				   const gchar *device_id,
+				   gpointer user_data,
+				   GCancellable *cancellable,
+				   GError **error);
+	FwupdDevice *(*get_results)(FwupdClient *self,
+				    const gchar *device_id,
+				    gpointer user_data,
+				    GCancellable *cancellable,
+				    GError **error);
+	GPtrArray *(*get_upgrades)(FwupdClient *self,
+				   const gchar *device_id,
+				   gpointer user_data,
+				   GCancellable *cancellable,
+				   GError **error);
+	GPtrArray *(*get_plugins)(FwupdClient *self,
+				  gpointer user_data,
+				  GCancellable *cancellable,
+				  GError **error);
+	GPtrArray *(*get_remotes)(FwupdClient *self,
+				  gpointer user_data,
+				  GCancellable *cancellable,
+				  GError **error);
+	GHashTable *(*get_report_metadata)(FwupdClient *self,
+					   gpointer user_data,
+					   GCancellable *cancellable,
+					   GError **error);
+	FwupdRemote *(*get_remote_by_id)(FwupdClient *self,
+					 const gchar *remote_id,
+					 gpointer user_data,
+					 GCancellable *cancellable,
+					 GError **error);
+	gboolean (*modify_bios_setting)(FwupdClient *self,
+					GHashTable *settings,
+					gpointer user_data,
+					GCancellable *cancellable,
+					GError **error);
+	gboolean (*modify_config)(FwupdClient *self,
+				  const gchar *section,
+				  const gchar *key,
+				  const gchar *value,
+				  gpointer user_data,
+				  GCancellable *cancellable,
+				  GError **error);
+	gboolean (*modify_remote)(FwupdClient *self,
+				  const gchar *remote_id,
+				  const gchar *key,
+				  const gchar *value,
+				  gpointer user_data,
+				  GCancellable *cancellable,
+				  GError **error);
+	gboolean (*reset_config)(FwupdClient *self,
+				 const gchar *section,
+				 gpointer user_data,
+				 GCancellable *cancellable,
+				 GError **error);
+	GPtrArray *(*search)(FwupdClient *self,
+			     const gchar *token,
+			     gpointer user_data,
+			     GCancellable *cancellable,
+			     GError **error);
+	gboolean (*set_feature_flags)(FwupdClient *self,
+				      FwupdFeatureFlags feature_flags,
+				      gpointer user_data,
+				      GCancellable *cancellable,
+				      GError **error);
+};
+
+const FwupdClientSyncImpl *
+fwupd_client_get_sync_impl(FwupdClient *self, gpointer *impl_userdata) G_GNUC_NON_NULL(1);
+
 void
 fwupd_client_download_bytes2_async(FwupdClient *self,
 				   GPtrArray *urls,

--- a/libfwupd/fwupd-client-sync-private.h
+++ b/libfwupd/fwupd-client-sync-private.h
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include "fwupd-client-sync.h"
+
+G_BEGIN_DECLS
+
+gboolean
+fwupd_client_sync_impl_activate(FwupdClient *self,
+				const gchar *device_id,
+				gpointer user_data,
+				GCancellable *cancellable,
+				GError **error);
+gboolean
+fwupd_client_sync_impl_connect(FwupdClient *self,
+			       gpointer user_data,
+			       GCancellable *cancellable,
+			       GError **error);
+gboolean
+fwupd_client_sync_impl_emulation_load(FwupdClient *self,
+				      const gchar *filename,
+				      gpointer user_data,
+				      GCancellable *cancellable,
+				      GError **error);
+gboolean
+fwupd_client_sync_impl_emulation_save(FwupdClient *self,
+				      const gchar *filename,
+				      gpointer user_data,
+				      GCancellable *cancellable,
+				      GError **error);
+GPtrArray *
+fwupd_client_sync_impl_get_bios_settings(FwupdClient *self,
+					 gpointer user_data,
+					 GCancellable *cancellable,
+					 GError **error);
+GPtrArray *
+fwupd_client_sync_impl_get_details(FwupdClient *self,
+				   const gchar *filename,
+				   gpointer user_data,
+				   GCancellable *cancellable,
+				   GError **error);
+GPtrArray *
+fwupd_client_sync_impl_get_devices(FwupdClient *self,
+				   gpointer user_data,
+				   GCancellable *cancellable,
+				   GError **error);
+FwupdDevice *
+fwupd_client_sync_impl_get_device_by_id(FwupdClient *self,
+					const gchar *device_id,
+					gpointer user_data,
+					GCancellable *cancellable,
+					GError **error);
+GPtrArray *
+fwupd_client_sync_impl_get_devices_by_guid(FwupdClient *self,
+					   const gchar *guid,
+					   gpointer user_data,
+					   GCancellable *cancellable,
+					   GError **error);
+GPtrArray *
+fwupd_client_sync_impl_get_plugins(FwupdClient *self,
+				   gpointer user_data,
+				   GCancellable *cancellable,
+				   GError **error);
+GPtrArray *
+fwupd_client_sync_impl_get_history(FwupdClient *self,
+				   gpointer user_data,
+				   GCancellable *cancellable,
+				   GError **error);
+GPtrArray *
+fwupd_client_sync_impl_get_host_security_attrs(FwupdClient *self,
+					       gpointer user_data,
+					       GCancellable *cancellable,
+					       GError **error);
+GPtrArray *
+fwupd_client_sync_impl_get_host_security_events(FwupdClient *self,
+						guint limit,
+						gpointer user_data,
+						GCancellable *cancellable,
+						GError **error);
+GPtrArray *
+fwupd_client_sync_impl_get_releases(FwupdClient *self,
+				    const gchar *device_id,
+				    gpointer user_data,
+				    GCancellable *cancellable,
+				    GError **error);
+FwupdDevice *
+fwupd_client_sync_impl_get_results(FwupdClient *self,
+				   const gchar *device_id,
+				   gpointer user_data,
+				   GCancellable *cancellable,
+				   GError **error);
+GPtrArray *
+fwupd_client_sync_impl_get_upgrades(FwupdClient *self,
+				    const gchar *device_id,
+				    gpointer user_data,
+				    GCancellable *cancellable,
+				    GError **error);
+GPtrArray *
+fwupd_client_sync_impl_get_remotes(FwupdClient *self,
+				   gpointer user_data,
+				   GCancellable *cancellable,
+				   GError **error);
+FwupdRemote *
+fwupd_client_sync_impl_get_remote_by_id(FwupdClient *self,
+					const gchar *remote_id,
+					gpointer user_data,
+					GCancellable *cancellable,
+					GError **error);
+GHashTable *
+fwupd_client_sync_impl_get_report_metadata(FwupdClient *self,
+					   gpointer user_data,
+					   GCancellable *cancellable,
+					   GError **error);
+gboolean
+fwupd_client_sync_impl_modify_bios_setting(FwupdClient *self,
+					   GHashTable *settings,
+					   gpointer user_data,
+					   GCancellable *cancellable,
+					   GError **error);
+gboolean
+fwupd_client_sync_impl_modify_config(FwupdClient *self,
+				     const gchar *section,
+				     const gchar *key,
+				     const gchar *value,
+				     gpointer user_data,
+				     GCancellable *cancellable,
+				     GError **error);
+gboolean
+fwupd_client_sync_impl_modify_remote(FwupdClient *self,
+				     const gchar *remote_id,
+				     const gchar *key,
+				     const gchar *value,
+				     gpointer user_data,
+				     GCancellable *cancellable,
+				     GError **error);
+gboolean
+fwupd_client_sync_impl_reset_config(FwupdClient *self,
+				    const gchar *section,
+				    gpointer user_data,
+				    GCancellable *cancellable,
+				    GError **error);
+GPtrArray *
+fwupd_client_sync_impl_search(FwupdClient *self,
+			      const gchar *token,
+			      gpointer user_data,
+			      GCancellable *cancellable,
+			      GError **error);
+gboolean
+fwupd_client_sync_impl_set_feature_flags(FwupdClient *self,
+					 FwupdFeatureFlags feature_flags,
+					 gpointer user_data,
+					 GCancellable *cancellable,
+					 GError **error);
+
+G_END_DECLS

--- a/libfwupd/fwupd-client-sync.c
+++ b/libfwupd/fwupd-client-sync.c
@@ -11,7 +11,7 @@
 #endif
 
 #include "fwupd-client-private.h"
-#include "fwupd-client-sync.h"
+#include "fwupd-client-sync-private.h"
 #include "fwupd-client.h"
 #include "fwupd-common-private.h"
 #include "fwupd-error.h"
@@ -75,6 +75,24 @@ fwupd_client_connect_cb(GObject *source, GAsyncResult *res, gpointer user_data)
 	g_main_loop_quit(helper->loop);
 }
 
+gboolean
+fwupd_client_sync_impl_connect(FwupdClient *self,
+			       gpointer user_data,
+			       GCancellable *cancellable,
+			       GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new(self);
+
+	/* call async version and run loop until complete */
+	fwupd_client_connect_async(self, cancellable, fwupd_client_connect_cb, helper);
+	g_main_loop_run(helper->loop);
+	if (!helper->ret) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return FALSE;
+	}
+	return TRUE;
+}
+
 /**
  * fwupd_client_connect: (skip)
  * @self: a #FwupdClient
@@ -92,21 +110,21 @@ fwupd_client_connect_cb(GObject *source, GAsyncResult *res, gpointer user_data)
 gboolean
 fwupd_client_connect(FwupdClient *self, GCancellable *cancellable, GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), FALSE);
 	g_return_val_if_fail(cancellable == NULL || G_IS_CANCELLABLE(cancellable), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	/* call async version and run loop until complete */
-	helper = fwupd_client_helper_new(self);
-	fwupd_client_connect_async(self, cancellable, fwupd_client_connect_cb, helper);
-	g_main_loop_run(helper->loop);
-	if (!helper->ret) {
-		g_propagate_error(error, g_steal_pointer(&helper->error));
+	if (impl->connect == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->connect");
 		return FALSE;
 	}
-	return TRUE;
+	return impl->connect(self, impl_userdata, cancellable, error);
 }
 
 static void
@@ -159,6 +177,24 @@ fwupd_client_get_devices_cb(GObject *source, GAsyncResult *res, gpointer user_da
 	g_main_loop_quit(helper->loop);
 }
 
+GPtrArray *
+fwupd_client_sync_impl_get_devices(FwupdClient *self,
+				   gpointer user_data,
+				   GCancellable *cancellable,
+				   GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new(self);
+
+	/* call async version and run loop until complete */
+	fwupd_client_get_devices_async(self, cancellable, fwupd_client_get_devices_cb, helper);
+	g_main_loop_run(helper->loop);
+	if (helper->array == NULL) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return NULL;
+	}
+	return g_steal_pointer(&helper->array);
+}
+
 /**
  * fwupd_client_get_devices:
  * @self: a #FwupdClient
@@ -174,7 +210,8 @@ fwupd_client_get_devices_cb(GObject *source, GAsyncResult *res, gpointer user_da
 GPtrArray *
 fwupd_client_get_devices(FwupdClient *self, GCancellable *cancellable, GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), NULL);
 	g_return_val_if_fail(cancellable == NULL || G_IS_CANCELLABLE(cancellable), NULL);
@@ -184,15 +221,14 @@ fwupd_client_get_devices(FwupdClient *self, GCancellable *cancellable, GError **
 	if (!fwupd_client_connect(self, cancellable, error))
 		return NULL;
 
-	/* call async version and run loop until complete */
-	helper = fwupd_client_helper_new(self);
-	fwupd_client_get_devices_async(self, cancellable, fwupd_client_get_devices_cb, helper);
-	g_main_loop_run(helper->loop);
-	if (helper->array == NULL) {
-		g_propagate_error(error, g_steal_pointer(&helper->error));
+	if (impl->get_devices == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->get_devices");
 		return NULL;
 	}
-	return g_steal_pointer(&helper->array);
+	return impl->get_devices(self, impl_userdata, cancellable, error);
 }
 
 static void
@@ -201,6 +237,24 @@ fwupd_client_get_plugins_cb(GObject *source, GAsyncResult *res, gpointer user_da
 	FwupdClientHelper *helper = (FwupdClientHelper *)user_data;
 	helper->array = fwupd_client_get_plugins_finish(FWUPD_CLIENT(source), res, &helper->error);
 	g_main_loop_quit(helper->loop);
+}
+
+GPtrArray *
+fwupd_client_sync_impl_get_plugins(FwupdClient *self,
+				   gpointer user_data,
+				   GCancellable *cancellable,
+				   GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new(self);
+
+	/* call async version and run loop until complete */
+	fwupd_client_get_plugins_async(self, cancellable, fwupd_client_get_plugins_cb, helper);
+	g_main_loop_run(helper->loop);
+	if (helper->array == NULL) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return NULL;
+	}
+	return g_steal_pointer(&helper->array);
 }
 
 /**
@@ -218,7 +272,8 @@ fwupd_client_get_plugins_cb(GObject *source, GAsyncResult *res, gpointer user_da
 GPtrArray *
 fwupd_client_get_plugins(FwupdClient *self, GCancellable *cancellable, GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), NULL);
 	g_return_val_if_fail(cancellable == NULL || G_IS_CANCELLABLE(cancellable), NULL);
@@ -228,15 +283,14 @@ fwupd_client_get_plugins(FwupdClient *self, GCancellable *cancellable, GError **
 	if (!fwupd_client_connect(self, cancellable, error))
 		return NULL;
 
-	/* call async version and run loop until complete */
-	helper = fwupd_client_helper_new(self);
-	fwupd_client_get_plugins_async(self, cancellable, fwupd_client_get_plugins_cb, helper);
-	g_main_loop_run(helper->loop);
-	if (helper->array == NULL) {
-		g_propagate_error(error, g_steal_pointer(&helper->error));
+	if (impl->get_plugins == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->get_plugins");
 		return NULL;
 	}
-	return g_steal_pointer(&helper->array);
+	return impl->get_plugins(self, impl_userdata, cancellable, error);
 }
 
 static void
@@ -245,6 +299,24 @@ fwupd_client_get_history_cb(GObject *source, GAsyncResult *res, gpointer user_da
 	FwupdClientHelper *helper = (FwupdClientHelper *)user_data;
 	helper->array = fwupd_client_get_history_finish(FWUPD_CLIENT(source), res, &helper->error);
 	g_main_loop_quit(helper->loop);
+}
+
+GPtrArray *
+fwupd_client_sync_impl_get_history(FwupdClient *self,
+				   gpointer user_data,
+				   GCancellable *cancellable,
+				   GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new(self);
+
+	/* call async version and run loop until complete */
+	fwupd_client_get_history_async(self, cancellable, fwupd_client_get_history_cb, helper);
+	g_main_loop_run(helper->loop);
+	if (helper->array == NULL) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return NULL;
+	}
+	return g_steal_pointer(&helper->array);
 }
 
 /**
@@ -262,7 +334,8 @@ fwupd_client_get_history_cb(GObject *source, GAsyncResult *res, gpointer user_da
 GPtrArray *
 fwupd_client_get_history(FwupdClient *self, GCancellable *cancellable, GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), NULL);
 	g_return_val_if_fail(cancellable == NULL || G_IS_CANCELLABLE(cancellable), NULL);
@@ -272,15 +345,14 @@ fwupd_client_get_history(FwupdClient *self, GCancellable *cancellable, GError **
 	if (!fwupd_client_connect(self, cancellable, error))
 		return NULL;
 
-	/* call async version and run loop until complete */
-	helper = fwupd_client_helper_new(self);
-	fwupd_client_get_history_async(self, cancellable, fwupd_client_get_history_cb, helper);
-	g_main_loop_run(helper->loop);
-	if (helper->array == NULL) {
-		g_propagate_error(error, g_steal_pointer(&helper->error));
+	if (impl->get_history == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->get_history");
 		return NULL;
 	}
-	return g_steal_pointer(&helper->array);
+	return impl->get_history(self, impl_userdata, cancellable, error);
 }
 
 static void
@@ -289,6 +361,29 @@ fwupd_client_get_releases_cb(GObject *source, GAsyncResult *res, gpointer user_d
 	FwupdClientHelper *helper = (FwupdClientHelper *)user_data;
 	helper->array = fwupd_client_get_releases_finish(FWUPD_CLIENT(source), res, &helper->error);
 	g_main_loop_quit(helper->loop);
+}
+
+GPtrArray *
+fwupd_client_sync_impl_get_releases(FwupdClient *self,
+				    const gchar *device_id,
+				    gpointer user_data,
+				    GCancellable *cancellable,
+				    GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new(self);
+
+	/* call async version and run loop until complete */
+	fwupd_client_get_releases_async(self,
+					device_id,
+					cancellable,
+					fwupd_client_get_releases_cb,
+					helper);
+	g_main_loop_run(helper->loop);
+	if (helper->array == NULL) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return NULL;
+	}
+	return g_steal_pointer(&helper->array);
 }
 
 /**
@@ -310,7 +405,8 @@ fwupd_client_get_releases(FwupdClient *self,
 			  GCancellable *cancellable,
 			  GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), NULL);
 	g_return_val_if_fail(device_id != NULL, NULL);
@@ -321,19 +417,14 @@ fwupd_client_get_releases(FwupdClient *self,
 	if (!fwupd_client_connect(self, cancellable, error))
 		return NULL;
 
-	/* call async version and run loop until complete */
-	helper = fwupd_client_helper_new(self);
-	fwupd_client_get_releases_async(self,
-					device_id,
-					cancellable,
-					fwupd_client_get_releases_cb,
-					helper);
-	g_main_loop_run(helper->loop);
-	if (helper->array == NULL) {
-		g_propagate_error(error, g_steal_pointer(&helper->error));
+	if (impl->get_releases == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->get_releases");
 		return NULL;
 	}
-	return g_steal_pointer(&helper->array);
+	return impl->get_releases(self, device_id, impl_userdata, cancellable, error);
 }
 
 static void
@@ -342,6 +433,25 @@ fwupd_client_search_cb(GObject *source, GAsyncResult *res, gpointer user_data)
 	FwupdClientHelper *helper = (FwupdClientHelper *)user_data;
 	helper->array = fwupd_client_search_finish(FWUPD_CLIENT(source), res, &helper->error);
 	g_main_loop_quit(helper->loop);
+}
+
+GPtrArray *
+fwupd_client_sync_impl_search(FwupdClient *self,
+			      const gchar *token,
+			      gpointer user_data,
+			      GCancellable *cancellable,
+			      GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new(self);
+
+	/* call async version and run loop until complete */
+	fwupd_client_search_async(self, token, cancellable, fwupd_client_search_cb, helper);
+	g_main_loop_run(helper->loop);
+	if (helper->array == NULL) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return NULL;
+	}
+	return g_steal_pointer(&helper->array);
 }
 
 /**
@@ -363,7 +473,8 @@ fwupd_client_search(FwupdClient *self,
 		    GCancellable *cancellable,
 		    GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), NULL);
 	g_return_val_if_fail(token != NULL, NULL);
@@ -374,15 +485,14 @@ fwupd_client_search(FwupdClient *self,
 	if (!fwupd_client_connect(self, cancellable, error))
 		return NULL;
 
-	/* call async version and run loop until complete */
-	helper = fwupd_client_helper_new(self);
-	fwupd_client_search_async(self, token, cancellable, fwupd_client_search_cb, helper);
-	g_main_loop_run(helper->loop);
-	if (helper->array == NULL) {
-		g_propagate_error(error, g_steal_pointer(&helper->error));
+	if (impl->search == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->search");
 		return NULL;
 	}
-	return g_steal_pointer(&helper->array);
+	return impl->search(self, token, impl_userdata, cancellable, error);
 }
 
 static void
@@ -447,6 +557,29 @@ fwupd_client_get_upgrades_cb(GObject *source, GAsyncResult *res, gpointer user_d
 	g_main_loop_quit(helper->loop);
 }
 
+GPtrArray *
+fwupd_client_sync_impl_get_upgrades(FwupdClient *self,
+				    const gchar *device_id,
+				    gpointer user_data,
+				    GCancellable *cancellable,
+				    GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new(self);
+
+	/* call async version and run loop until complete */
+	fwupd_client_get_upgrades_async(self,
+					device_id,
+					cancellable,
+					fwupd_client_get_upgrades_cb,
+					helper);
+	g_main_loop_run(helper->loop);
+	if (helper->array == NULL) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return NULL;
+	}
+	return g_steal_pointer(&helper->array);
+}
+
 /**
  * fwupd_client_get_upgrades:
  * @self: a #FwupdClient
@@ -466,7 +599,8 @@ fwupd_client_get_upgrades(FwupdClient *self,
 			  GCancellable *cancellable,
 			  GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), NULL);
 	g_return_val_if_fail(device_id != NULL, NULL);
@@ -477,19 +611,14 @@ fwupd_client_get_upgrades(FwupdClient *self,
 	if (!fwupd_client_connect(self, cancellable, error))
 		return NULL;
 
-	/* call async version and run loop until complete */
-	helper = fwupd_client_helper_new(self);
-	fwupd_client_get_upgrades_async(self,
-					device_id,
-					cancellable,
-					fwupd_client_get_upgrades_cb,
-					helper);
-	g_main_loop_run(helper->loop);
-	if (helper->array == NULL) {
-		g_propagate_error(error, g_steal_pointer(&helper->error));
+	if (impl->get_upgrades == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->get_upgrades");
 		return NULL;
 	}
-	return g_steal_pointer(&helper->array);
+	return impl->get_upgrades(self, device_id, impl_userdata, cancellable, error);
 }
 
 static void
@@ -557,6 +686,41 @@ fwupd_client_get_details_cb(GObject *source, GAsyncResult *res, gpointer user_da
 }
 #endif
 
+GPtrArray *
+fwupd_client_sync_impl_get_details(FwupdClient *self,
+				   const gchar *filename,
+				   gpointer user_data,
+				   GCancellable *cancellable,
+				   GError **error)
+{
+#ifdef HAVE_GIO_UNIX
+	g_autoptr(GUnixInputStream) istr = NULL;
+	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new(self);
+
+	/* call async version and run loop until complete */
+	istr = fwupd_unix_input_stream_from_fn(filename, error);
+	if (istr == NULL)
+		return NULL;
+	fwupd_client_get_details_stream_async(self,
+					      istr,
+					      cancellable,
+					      fwupd_client_get_details_cb,
+					      helper);
+	g_main_loop_run(helper->loop);
+	if (helper->array == NULL) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return NULL;
+	}
+	return g_steal_pointer(&helper->array);
+#else
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "Get Details only supported on Linux");
+	return NULL;
+#endif
+}
+
 /**
  * fwupd_client_get_details:
  * @self: a #FwupdClient
@@ -576,9 +740,8 @@ fwupd_client_get_details(FwupdClient *self,
 			 GCancellable *cancellable,
 			 GError **error)
 {
-#ifdef HAVE_GIO_UNIX
-	g_autoptr(GUnixInputStream) istr = NULL;
-	g_autoptr(FwupdClientHelper) helper = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), NULL);
 	g_return_val_if_fail(filename != NULL, NULL);
@@ -589,29 +752,14 @@ fwupd_client_get_details(FwupdClient *self,
 	if (!fwupd_client_connect(self, cancellable, error))
 		return NULL;
 
-	/* call async version and run loop until complete */
-	istr = fwupd_unix_input_stream_from_fn(filename, error);
-	if (istr == NULL)
-		return NULL;
-	helper = fwupd_client_helper_new(self);
-	fwupd_client_get_details_stream_async(self,
-					      istr,
-					      cancellable,
-					      fwupd_client_get_details_cb,
-					      helper);
-	g_main_loop_run(helper->loop);
-	if (helper->array == NULL) {
-		g_propagate_error(error, g_steal_pointer(&helper->error));
+	if (impl->get_details == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->get_details");
 		return NULL;
 	}
-	return g_steal_pointer(&helper->array);
-#else
-	g_set_error_literal(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_NOT_SUPPORTED,
-			    "Get Details only supported on Linux");
-	return NULL;
-#endif
+	return impl->get_details(self, filename, impl_userdata, cancellable, error);
 }
 
 static void
@@ -879,6 +1027,33 @@ fwupd_client_modify_config_cb(GObject *source, GAsyncResult *res, gpointer user_
 	g_main_loop_quit(helper->loop);
 }
 
+gboolean
+fwupd_client_sync_impl_modify_config(FwupdClient *self,
+				     const gchar *section,
+				     const gchar *key,
+				     const gchar *value,
+				     gpointer user_data,
+				     GCancellable *cancellable,
+				     GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new(self);
+
+	/* call async version and run loop until complete */
+	fwupd_client_modify_config_async(self,
+					 section,
+					 key,
+					 value,
+					 cancellable,
+					 fwupd_client_modify_config_cb,
+					 helper);
+	g_main_loop_run(helper->loop);
+	if (!helper->ret) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return FALSE;
+	}
+	return TRUE;
+}
+
 /**
  * fwupd_client_modify_config
  * @self: a #FwupdClient
@@ -903,7 +1078,8 @@ fwupd_client_modify_config(FwupdClient *self,
 			   GCancellable *cancellable,
 			   GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), FALSE);
 	g_return_val_if_fail(section != NULL, FALSE);
@@ -916,21 +1092,14 @@ fwupd_client_modify_config(FwupdClient *self,
 	if (!fwupd_client_connect(self, cancellable, error))
 		return FALSE;
 
-	/* call async version and run loop until complete */
-	helper = fwupd_client_helper_new(self);
-	fwupd_client_modify_config_async(self,
-					 section,
-					 key,
-					 value,
-					 cancellable,
-					 fwupd_client_modify_config_cb,
-					 helper);
-	g_main_loop_run(helper->loop);
-	if (!helper->ret) {
-		g_propagate_error(error, g_steal_pointer(&helper->error));
+	if (impl->modify_config == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->modify_config");
 		return FALSE;
 	}
-	return TRUE;
+	return impl->modify_config(self, section, key, value, impl_userdata, cancellable, error);
 }
 
 static void
@@ -939,6 +1108,29 @@ fwupd_client_reset_config_cb(GObject *source, GAsyncResult *res, gpointer user_d
 	FwupdClientHelper *helper = (FwupdClientHelper *)user_data;
 	helper->ret = fwupd_client_reset_config_finish(FWUPD_CLIENT(source), res, &helper->error);
 	g_main_loop_quit(helper->loop);
+}
+
+gboolean
+fwupd_client_sync_impl_reset_config(FwupdClient *self,
+				    const gchar *section,
+				    gpointer user_data,
+				    GCancellable *cancellable,
+				    GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new(self);
+
+	/* call async version and run loop until complete */
+	fwupd_client_reset_config_async(self,
+					section,
+					cancellable,
+					fwupd_client_reset_config_cb,
+					helper);
+	g_main_loop_run(helper->loop);
+	if (!helper->ret) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return FALSE;
+	}
+	return TRUE;
 }
 
 /**
@@ -961,7 +1153,8 @@ fwupd_client_reset_config(FwupdClient *self,
 			  GCancellable *cancellable,
 			  GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), FALSE);
 	g_return_val_if_fail(section != NULL, FALSE);
@@ -972,19 +1165,14 @@ fwupd_client_reset_config(FwupdClient *self,
 	if (!fwupd_client_connect(self, cancellable, error))
 		return FALSE;
 
-	/* call async version and run loop until complete */
-	helper = fwupd_client_helper_new(self);
-	fwupd_client_reset_config_async(self,
-					section,
-					cancellable,
-					fwupd_client_reset_config_cb,
-					helper);
-	g_main_loop_run(helper->loop);
-	if (!helper->ret) {
-		g_propagate_error(error, g_steal_pointer(&helper->error));
+	if (impl->reset_config == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->reset_config");
 		return FALSE;
 	}
-	return TRUE;
+	return impl->reset_config(self, section, impl_userdata, cancellable, error);
 }
 
 static void
@@ -993,6 +1181,25 @@ fwupd_client_activate_cb(GObject *source, GAsyncResult *res, gpointer user_data)
 	FwupdClientHelper *helper = (FwupdClientHelper *)user_data;
 	helper->ret = fwupd_client_activate_finish(FWUPD_CLIENT(source), res, &helper->error);
 	g_main_loop_quit(helper->loop);
+}
+
+gboolean
+fwupd_client_sync_impl_activate(FwupdClient *self,
+				const gchar *device_id,
+				gpointer user_data,
+				GCancellable *cancellable,
+				GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new(self);
+
+	/* call async version and run loop until complete */
+	fwupd_client_activate_async(self, device_id, cancellable, fwupd_client_activate_cb, helper);
+	g_main_loop_run(helper->loop);
+	if (!helper->ret) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return FALSE;
+	}
+	return TRUE;
 }
 
 /**
@@ -1015,7 +1222,8 @@ fwupd_client_activate(FwupdClient *self,
 		      const gchar *device_id, /* yes, this is the wrong way around :/ */
 		      GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), FALSE);
 	g_return_val_if_fail(device_id != NULL, FALSE);
@@ -1026,15 +1234,14 @@ fwupd_client_activate(FwupdClient *self,
 	if (!fwupd_client_connect(self, cancellable, error))
 		return FALSE;
 
-	/* call async version and run loop until complete */
-	helper = fwupd_client_helper_new(self);
-	fwupd_client_activate_async(self, device_id, cancellable, fwupd_client_activate_cb, helper);
-	g_main_loop_run(helper->loop);
-	if (!helper->ret) {
-		g_propagate_error(error, g_steal_pointer(&helper->error));
+	if (impl->activate == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->activate");
 		return FALSE;
 	}
-	return TRUE;
+	return impl->activate(self, device_id, impl_userdata, cancellable, error);
 }
 
 static void
@@ -1098,6 +1305,29 @@ fwupd_client_get_results_cb(GObject *source, GAsyncResult *res, gpointer user_da
 	g_main_loop_quit(helper->loop);
 }
 
+FwupdDevice *
+fwupd_client_sync_impl_get_results(FwupdClient *self,
+				   const gchar *device_id,
+				   gpointer user_data,
+				   GCancellable *cancellable,
+				   GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new(self);
+
+	/* call async version and run loop until complete */
+	fwupd_client_get_results_async(self,
+				       device_id,
+				       cancellable,
+				       fwupd_client_get_results_cb,
+				       helper);
+	g_main_loop_run(helper->loop);
+	if (helper->device == NULL) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return NULL;
+	}
+	return g_steal_pointer(&helper->device);
+}
+
 /**
  * fwupd_client_get_results:
  * @self: a #FwupdClient
@@ -1117,7 +1347,8 @@ fwupd_client_get_results(FwupdClient *self,
 			 GCancellable *cancellable,
 			 GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), NULL);
 	g_return_val_if_fail(device_id != NULL, NULL);
@@ -1128,19 +1359,14 @@ fwupd_client_get_results(FwupdClient *self,
 	if (!fwupd_client_connect(self, cancellable, error))
 		return NULL;
 
-	/* call async version and run loop until complete */
-	helper = fwupd_client_helper_new(self);
-	fwupd_client_get_results_async(self,
-				       device_id,
-				       cancellable,
-				       fwupd_client_get_results_cb,
-				       helper);
-	g_main_loop_run(helper->loop);
-	if (helper->device == NULL) {
-		g_propagate_error(error, g_steal_pointer(&helper->error));
+	if (impl->get_results == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->get_results");
 		return NULL;
 	}
-	return g_steal_pointer(&helper->device);
+	return impl->get_results(self, device_id, impl_userdata, cancellable, error);
 }
 
 static void
@@ -1150,6 +1376,29 @@ fwupd_client_modify_bios_setting_cb(GObject *source, GAsyncResult *res, gpointer
 	helper->ret =
 	    fwupd_client_modify_bios_setting_finish(FWUPD_CLIENT(source), res, &helper->error);
 	g_main_loop_quit(helper->loop);
+}
+
+gboolean
+fwupd_client_sync_impl_modify_bios_setting(FwupdClient *self,
+					   GHashTable *settings,
+					   gpointer user_data,
+					   GCancellable *cancellable,
+					   GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new(self);
+
+	/* call async version and run loop until complete */
+	fwupd_client_modify_bios_setting_async(self,
+					       settings,
+					       cancellable,
+					       fwupd_client_modify_bios_setting_cb,
+					       helper);
+	g_main_loop_run(helper->loop);
+	if (!helper->ret) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return FALSE;
+	}
+	return TRUE;
 }
 
 /**
@@ -1172,7 +1421,8 @@ fwupd_client_modify_bios_setting(FwupdClient *self,
 				 GCancellable *cancellable,
 				 GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), FALSE);
 	g_return_val_if_fail(settings != NULL, FALSE);
@@ -1183,19 +1433,14 @@ fwupd_client_modify_bios_setting(FwupdClient *self,
 	if (!fwupd_client_connect(self, cancellable, error))
 		return FALSE;
 
-	/* call async version and run loop until complete */
-	helper = fwupd_client_helper_new(self);
-	fwupd_client_modify_bios_setting_async(self,
-					       settings,
-					       cancellable,
-					       fwupd_client_modify_bios_setting_cb,
-					       helper);
-	g_main_loop_run(helper->loop);
-	if (!helper->ret) {
-		g_propagate_error(error, g_steal_pointer(&helper->error));
+	if (impl->modify_bios_setting == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->modify_bios_setting");
 		return FALSE;
 	}
-	return TRUE;
+	return impl->modify_bios_setting(self, settings, impl_userdata, cancellable, error);
 }
 
 static void
@@ -1205,6 +1450,27 @@ fwupd_client_get_bios_settings_cb(GObject *source, GAsyncResult *res, gpointer u
 	helper->array =
 	    fwupd_client_get_bios_settings_finish(FWUPD_CLIENT(source), res, &helper->error);
 	g_main_loop_quit(helper->loop);
+}
+
+GPtrArray *
+fwupd_client_sync_impl_get_bios_settings(FwupdClient *self,
+					 gpointer user_data,
+					 GCancellable *cancellable,
+					 GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new(self);
+
+	/* call async version and run loop until complete */
+	fwupd_client_get_bios_settings_async(self,
+					     cancellable,
+					     fwupd_client_get_bios_settings_cb,
+					     helper);
+	g_main_loop_run(helper->loop);
+	if (helper->array == NULL) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return NULL;
+	}
+	return g_steal_pointer(&helper->array);
 }
 
 /**
@@ -1222,7 +1488,8 @@ fwupd_client_get_bios_settings_cb(GObject *source, GAsyncResult *res, gpointer u
 GPtrArray *
 fwupd_client_get_bios_settings(FwupdClient *self, GCancellable *cancellable, GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), NULL);
 	g_return_val_if_fail(cancellable == NULL || G_IS_CANCELLABLE(cancellable), NULL);
@@ -1232,18 +1499,14 @@ fwupd_client_get_bios_settings(FwupdClient *self, GCancellable *cancellable, GEr
 	if (!fwupd_client_connect(self, cancellable, error))
 		return NULL;
 
-	/* call async version and run loop until complete */
-	helper = fwupd_client_helper_new(self);
-	fwupd_client_get_bios_settings_async(self,
-					     cancellable,
-					     fwupd_client_get_bios_settings_cb,
-					     helper);
-	g_main_loop_run(helper->loop);
-	if (helper->array == NULL) {
-		g_propagate_error(error, g_steal_pointer(&helper->error));
+	if (impl->get_bios_settings == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->get_bios_settings");
 		return NULL;
 	}
-	return g_steal_pointer(&helper->array);
+	return impl->get_bios_settings(self, impl_userdata, cancellable, error);
 }
 
 static void
@@ -1253,6 +1516,27 @@ fwupd_client_get_host_security_attrs_cb(GObject *source, GAsyncResult *res, gpoi
 	helper->array =
 	    fwupd_client_get_host_security_attrs_finish(FWUPD_CLIENT(source), res, &helper->error);
 	g_main_loop_quit(helper->loop);
+}
+
+GPtrArray *
+fwupd_client_sync_impl_get_host_security_attrs(FwupdClient *self,
+					       gpointer user_data,
+					       GCancellable *cancellable,
+					       GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new(self);
+
+	/* call async version and run loop until complete */
+	fwupd_client_get_host_security_attrs_async(self,
+						   cancellable,
+						   fwupd_client_get_host_security_attrs_cb,
+						   helper);
+	g_main_loop_run(helper->loop);
+	if (helper->array == NULL) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return NULL;
+	}
+	return g_steal_pointer(&helper->array);
 }
 
 /**
@@ -1270,7 +1554,8 @@ fwupd_client_get_host_security_attrs_cb(GObject *source, GAsyncResult *res, gpoi
 GPtrArray *
 fwupd_client_get_host_security_attrs(FwupdClient *self, GCancellable *cancellable, GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), NULL);
 	g_return_val_if_fail(cancellable == NULL || G_IS_CANCELLABLE(cancellable), NULL);
@@ -1280,18 +1565,14 @@ fwupd_client_get_host_security_attrs(FwupdClient *self, GCancellable *cancellabl
 	if (!fwupd_client_connect(self, cancellable, error))
 		return NULL;
 
-	/* call async version and run loop until complete */
-	helper = fwupd_client_helper_new(self);
-	fwupd_client_get_host_security_attrs_async(self,
-						   cancellable,
-						   fwupd_client_get_host_security_attrs_cb,
-						   helper);
-	g_main_loop_run(helper->loop);
-	if (helper->array == NULL) {
-		g_propagate_error(error, g_steal_pointer(&helper->error));
+	if (impl->get_host_security_attrs == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->get_host_security_attrs");
 		return NULL;
 	}
-	return g_steal_pointer(&helper->array);
+	return impl->get_host_security_attrs(self, impl_userdata, cancellable, error);
 }
 
 static void
@@ -1301,6 +1582,29 @@ fwupd_client_get_host_security_events_cb(GObject *source, GAsyncResult *res, gpo
 	helper->array =
 	    fwupd_client_get_host_security_events_finish(FWUPD_CLIENT(source), res, &helper->error);
 	g_main_loop_quit(helper->loop);
+}
+
+GPtrArray *
+fwupd_client_sync_impl_get_host_security_events(FwupdClient *self,
+						guint limit,
+						gpointer user_data,
+						GCancellable *cancellable,
+						GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new(self);
+
+	/* call async version and run loop until complete */
+	fwupd_client_get_host_security_events_async(self,
+						    limit,
+						    cancellable,
+						    fwupd_client_get_host_security_events_cb,
+						    helper);
+	g_main_loop_run(helper->loop);
+	if (helper->array == NULL) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return NULL;
+	}
+	return g_steal_pointer(&helper->array);
 }
 
 /**
@@ -1322,7 +1626,8 @@ fwupd_client_get_host_security_events(FwupdClient *self,
 				      GCancellable *cancellable,
 				      GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), NULL);
 	g_return_val_if_fail(cancellable == NULL || G_IS_CANCELLABLE(cancellable), NULL);
@@ -1332,19 +1637,14 @@ fwupd_client_get_host_security_events(FwupdClient *self,
 	if (!fwupd_client_connect(self, cancellable, error))
 		return NULL;
 
-	/* call async version and run loop until complete */
-	helper = fwupd_client_helper_new(self);
-	fwupd_client_get_host_security_events_async(self,
-						    limit,
-						    cancellable,
-						    fwupd_client_get_host_security_events_cb,
-						    helper);
-	g_main_loop_run(helper->loop);
-	if (helper->array == NULL) {
-		g_propagate_error(error, g_steal_pointer(&helper->error));
+	if (impl->get_host_security_events == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->get_host_security_events");
 		return NULL;
 	}
-	return g_steal_pointer(&helper->array);
+	return impl->get_host_security_events(self, limit, impl_userdata, cancellable, error);
 }
 
 static void
@@ -1354,6 +1654,29 @@ fwupd_client_get_device_by_id_cb(GObject *source, GAsyncResult *res, gpointer us
 	helper->device =
 	    fwupd_client_get_device_by_id_finish(FWUPD_CLIENT(source), res, &helper->error);
 	g_main_loop_quit(helper->loop);
+}
+
+FwupdDevice *
+fwupd_client_sync_impl_get_device_by_id(FwupdClient *self,
+					const gchar *device_id,
+					gpointer user_data,
+					GCancellable *cancellable,
+					GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new(self);
+
+	/* call async version and run loop until complete */
+	fwupd_client_get_device_by_id_async(self,
+					    device_id,
+					    cancellable,
+					    fwupd_client_get_device_by_id_cb,
+					    helper);
+	g_main_loop_run(helper->loop);
+	if (helper->device == NULL) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return NULL;
+	}
+	return g_steal_pointer(&helper->device);
 }
 
 /**
@@ -1375,7 +1698,8 @@ fwupd_client_get_device_by_id(FwupdClient *self,
 			      GCancellable *cancellable,
 			      GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), NULL);
 	g_return_val_if_fail(device_id != NULL, NULL);
@@ -1386,19 +1710,14 @@ fwupd_client_get_device_by_id(FwupdClient *self,
 	if (!fwupd_client_connect(self, cancellable, error))
 		return NULL;
 
-	/* call async version and run loop until complete */
-	helper = fwupd_client_helper_new(self);
-	fwupd_client_get_device_by_id_async(self,
-					    device_id,
-					    cancellable,
-					    fwupd_client_get_device_by_id_cb,
-					    helper);
-	g_main_loop_run(helper->loop);
-	if (helper->device == NULL) {
-		g_propagate_error(error, g_steal_pointer(&helper->error));
+	if (impl->get_device_by_id == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->get_device_by_id");
 		return NULL;
 	}
-	return g_steal_pointer(&helper->device);
+	return impl->get_device_by_id(self, device_id, impl_userdata, cancellable, error);
 }
 
 static void
@@ -1408,6 +1727,29 @@ fwupd_client_get_devices_by_guid_cb(GObject *source, GAsyncResult *res, gpointer
 	helper->array =
 	    fwupd_client_get_devices_by_guid_finish(FWUPD_CLIENT(source), res, &helper->error);
 	g_main_loop_quit(helper->loop);
+}
+
+GPtrArray *
+fwupd_client_sync_impl_get_devices_by_guid(FwupdClient *self,
+					   const gchar *guid,
+					   gpointer user_data,
+					   GCancellable *cancellable,
+					   GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new(self);
+
+	/* call async version and run loop until complete */
+	fwupd_client_get_devices_by_guid_async(self,
+					       guid,
+					       cancellable,
+					       fwupd_client_get_devices_by_guid_cb,
+					       helper);
+	g_main_loop_run(helper->loop);
+	if (helper->array == NULL) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return NULL;
+	}
+	return g_steal_pointer(&helper->array);
 }
 
 /**
@@ -1430,7 +1772,8 @@ fwupd_client_get_devices_by_guid(FwupdClient *self,
 				 GCancellable *cancellable,
 				 GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), NULL);
 	g_return_val_if_fail(guid != NULL, NULL);
@@ -1441,19 +1784,14 @@ fwupd_client_get_devices_by_guid(FwupdClient *self,
 	if (!fwupd_client_connect(self, cancellable, error))
 		return NULL;
 
-	/* call async version and run loop until complete */
-	helper = fwupd_client_helper_new(self);
-	fwupd_client_get_devices_by_guid_async(self,
-					       guid,
-					       cancellable,
-					       fwupd_client_get_devices_by_guid_cb,
-					       helper);
-	g_main_loop_run(helper->loop);
-	if (helper->array == NULL) {
-		g_propagate_error(error, g_steal_pointer(&helper->error));
+	if (impl->get_devices_by_guid == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->get_devices_by_guid");
 		return NULL;
 	}
-	return g_steal_pointer(&helper->array);
+	return impl->get_devices_by_guid(self, guid, impl_userdata, cancellable, error);
 }
 
 #ifdef HAVE_GIO_UNIX
@@ -1869,6 +2207,33 @@ fwupd_client_modify_remote_cb(GObject *source, GAsyncResult *res, gpointer user_
 	g_main_loop_quit(helper->loop);
 }
 
+gboolean
+fwupd_client_sync_impl_modify_remote(FwupdClient *self,
+				     const gchar *remote_id,
+				     const gchar *key,
+				     const gchar *value,
+				     gpointer user_data,
+				     GCancellable *cancellable,
+				     GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new(self);
+
+	/* call async version and run loop until complete */
+	fwupd_client_modify_remote_async(self,
+					 remote_id,
+					 key,
+					 value,
+					 cancellable,
+					 fwupd_client_modify_remote_cb,
+					 helper);
+	g_main_loop_run(helper->loop);
+	if (!helper->ret) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return FALSE;
+	}
+	return TRUE;
+}
+
 /**
  * fwupd_client_modify_remote:
  * @self: a #FwupdClient
@@ -1894,7 +2259,8 @@ fwupd_client_modify_remote(FwupdClient *self,
 			   GCancellable *cancellable,
 			   GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), FALSE);
 	g_return_val_if_fail(remote_id != NULL, FALSE);
@@ -1907,21 +2273,14 @@ fwupd_client_modify_remote(FwupdClient *self,
 	if (!fwupd_client_connect(self, cancellable, error))
 		return FALSE;
 
-	/* call async version and run loop until complete */
-	helper = fwupd_client_helper_new(self);
-	fwupd_client_modify_remote_async(self,
-					 remote_id,
-					 key,
-					 value,
-					 cancellable,
-					 fwupd_client_modify_remote_cb,
-					 helper);
-	g_main_loop_run(helper->loop);
-	if (!helper->ret) {
-		g_propagate_error(error, g_steal_pointer(&helper->error));
+	if (impl->modify_remote == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->modify_remote");
 		return FALSE;
 	}
-	return TRUE;
+	return impl->modify_remote(self, remote_id, key, value, impl_userdata, cancellable, error);
 }
 
 static void
@@ -1988,6 +2347,27 @@ fwupd_client_get_report_metadata_cb(GObject *source, GAsyncResult *res, gpointer
 	g_main_loop_quit(helper->loop);
 }
 
+GHashTable *
+fwupd_client_sync_impl_get_report_metadata(FwupdClient *self,
+					   gpointer user_data,
+					   GCancellable *cancellable,
+					   GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new(self);
+
+	/* call async version and run loop until complete */
+	fwupd_client_get_report_metadata_async(self,
+					       cancellable,
+					       fwupd_client_get_report_metadata_cb,
+					       helper);
+	g_main_loop_run(helper->loop);
+	if (helper->hash == NULL) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return NULL;
+	}
+	return g_steal_pointer(&helper->hash);
+}
+
 /**
  * fwupd_client_get_report_metadata:
  * @self: a #FwupdClient
@@ -2003,7 +2383,8 @@ fwupd_client_get_report_metadata_cb(GObject *source, GAsyncResult *res, gpointer
 GHashTable *
 fwupd_client_get_report_metadata(FwupdClient *self, GCancellable *cancellable, GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), NULL);
 	g_return_val_if_fail(cancellable == NULL || G_IS_CANCELLABLE(cancellable), NULL);
@@ -2013,18 +2394,14 @@ fwupd_client_get_report_metadata(FwupdClient *self, GCancellable *cancellable, G
 	if (!fwupd_client_connect(self, cancellable, error))
 		return NULL;
 
-	/* call async version and run loop until complete */
-	helper = fwupd_client_helper_new(self);
-	fwupd_client_get_report_metadata_async(self,
-					       cancellable,
-					       fwupd_client_get_report_metadata_cb,
-					       helper);
-	g_main_loop_run(helper->loop);
-	if (helper->hash == NULL) {
-		g_propagate_error(error, g_steal_pointer(&helper->error));
+	if (impl->get_report_metadata == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->get_report_metadata");
 		return NULL;
 	}
-	return g_steal_pointer(&helper->hash);
+	return impl->get_report_metadata(self, impl_userdata, cancellable, error);
 }
 
 static void
@@ -2099,6 +2476,24 @@ fwupd_client_get_remotes_cb(GObject *source, GAsyncResult *res, gpointer user_da
 	g_main_loop_quit(helper->loop);
 }
 
+GPtrArray *
+fwupd_client_sync_impl_get_remotes(FwupdClient *self,
+				   gpointer user_data,
+				   GCancellable *cancellable,
+				   GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new(self);
+
+	/* call async version and run loop until complete */
+	fwupd_client_get_remotes_async(self, cancellable, fwupd_client_get_remotes_cb, helper);
+	g_main_loop_run(helper->loop);
+	if (helper->array == NULL) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return NULL;
+	}
+	return g_steal_pointer(&helper->array);
+}
+
 /**
  * fwupd_client_get_remotes:
  * @self: a #FwupdClient
@@ -2114,7 +2509,8 @@ fwupd_client_get_remotes_cb(GObject *source, GAsyncResult *res, gpointer user_da
 GPtrArray *
 fwupd_client_get_remotes(FwupdClient *self, GCancellable *cancellable, GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), NULL);
 	g_return_val_if_fail(cancellable == NULL || G_IS_CANCELLABLE(cancellable), NULL);
@@ -2124,15 +2520,14 @@ fwupd_client_get_remotes(FwupdClient *self, GCancellable *cancellable, GError **
 	if (!fwupd_client_connect(self, cancellable, error))
 		return NULL;
 
-	/* call async version and run loop until complete */
-	helper = fwupd_client_helper_new(self);
-	fwupd_client_get_remotes_async(self, cancellable, fwupd_client_get_remotes_cb, helper);
-	g_main_loop_run(helper->loop);
-	if (helper->array == NULL) {
-		g_propagate_error(error, g_steal_pointer(&helper->error));
+	if (impl->get_remotes == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->get_remotes");
 		return NULL;
 	}
-	return g_steal_pointer(&helper->array);
+	return impl->get_remotes(self, impl_userdata, cancellable, error);
 }
 
 static FwupdRemote *
@@ -2144,6 +2539,34 @@ fwupd_client_get_remote_by_id_noref(GPtrArray *remotes, const gchar *remote_id)
 			return remote;
 	}
 	return NULL;
+}
+
+FwupdRemote *
+fwupd_client_sync_impl_get_remote_by_id(FwupdClient *self,
+					const gchar *remote_id,
+					gpointer user_data,
+					GCancellable *cancellable,
+					GError **error)
+{
+	FwupdRemote *remote;
+	g_autoptr(GPtrArray) remotes = NULL;
+
+	/* find remote in list */
+	remotes = fwupd_client_get_remotes(self, cancellable, error);
+	if (remotes == NULL)
+		return NULL;
+	remote = fwupd_client_get_remote_by_id_noref(remotes, remote_id);
+	if (remote == NULL) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
+			    "No remote '%s' found in search paths",
+			    remote_id);
+		return NULL;
+	}
+
+	/* success */
+	return g_object_ref(remote);
 }
 
 /**
@@ -2165,30 +2588,26 @@ fwupd_client_get_remote_by_id(FwupdClient *self,
 			      GCancellable *cancellable,
 			      GError **error)
 {
-	FwupdRemote *remote;
-	g_autoptr(GPtrArray) remotes = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), NULL);
 	g_return_val_if_fail(remote_id != NULL, NULL);
 	g_return_val_if_fail(cancellable == NULL || G_IS_CANCELLABLE(cancellable), NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
-	/* find remote in list */
-	remotes = fwupd_client_get_remotes(self, cancellable, error);
-	if (remotes == NULL)
+	/* connect */
+	if (!fwupd_client_connect(self, cancellable, error))
 		return NULL;
-	remote = fwupd_client_get_remote_by_id_noref(remotes, remote_id);
-	if (remote == NULL) {
-		g_set_error(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_NOT_FOUND,
-			    "No remote '%s' found in search paths",
-			    remote_id);
+
+	if (impl->get_remote_by_id == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->get_remote_by_id");
 		return NULL;
 	}
-
-	/* success */
-	return g_object_ref(remote);
+	return impl->get_remote_by_id(self, remote_id, impl_userdata, cancellable, error);
 }
 
 static void
@@ -2362,6 +2781,29 @@ fwupd_client_set_feature_flags_cb(GObject *source, GAsyncResult *res, gpointer u
 	g_main_loop_quit(helper->loop);
 }
 
+gboolean
+fwupd_client_sync_impl_set_feature_flags(FwupdClient *self,
+					 FwupdFeatureFlags feature_flags,
+					 gpointer user_data,
+					 GCancellable *cancellable,
+					 GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new(self);
+
+	/* call async version and run loop until complete */
+	fwupd_client_set_feature_flags_async(self,
+					     feature_flags,
+					     cancellable,
+					     fwupd_client_set_feature_flags_cb,
+					     helper);
+	g_main_loop_run(helper->loop);
+	if (!helper->ret) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return FALSE;
+	}
+	return TRUE;
+}
+
 /**
  * fwupd_client_set_feature_flags:
  * @self: a #FwupdClient
@@ -2385,7 +2827,8 @@ fwupd_client_set_feature_flags(FwupdClient *self,
 			       GCancellable *cancellable,
 			       GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), FALSE);
 	g_return_val_if_fail(cancellable == NULL || G_IS_CANCELLABLE(cancellable), FALSE);
@@ -2395,19 +2838,14 @@ fwupd_client_set_feature_flags(FwupdClient *self,
 	if (!fwupd_client_connect(self, cancellable, error))
 		return FALSE;
 
-	/* call async version and run loop until complete */
-	helper = fwupd_client_helper_new(self);
-	fwupd_client_set_feature_flags_async(self,
-					     feature_flags,
-					     cancellable,
-					     fwupd_client_set_feature_flags_cb,
-					     helper);
-	g_main_loop_run(helper->loop);
-	if (!helper->ret) {
-		g_propagate_error(error, g_steal_pointer(&helper->error));
+	if (impl->set_feature_flags == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->set_feature_flags");
 		return FALSE;
 	}
-	return TRUE;
+	return impl->set_feature_flags(self, feature_flags, impl_userdata, cancellable, error);
 }
 
 static void
@@ -2708,6 +3146,29 @@ fwupd_client_emulation_load_cb(GObject *source, GAsyncResult *res, gpointer user
 	g_main_loop_quit(helper->loop);
 }
 
+gboolean
+fwupd_client_sync_impl_emulation_load(FwupdClient *self,
+				      const gchar *filename,
+				      gpointer user_data,
+				      GCancellable *cancellable,
+				      GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new(self);
+
+	/* call async version and run loop until complete */
+	fwupd_client_emulation_load_async(self,
+					  filename,
+					  cancellable,
+					  fwupd_client_emulation_load_cb,
+					  helper);
+	g_main_loop_run(helper->loop);
+	if (!helper->ret) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return FALSE;
+	}
+	return TRUE;
+}
+
 /**
  * fwupd_client_emulation_load
  * @self: a #FwupdClient
@@ -2729,7 +3190,8 @@ fwupd_client_emulation_load(FwupdClient *self,
 			    GCancellable *cancellable,
 			    GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), FALSE);
 	g_return_val_if_fail(filename != NULL, FALSE);
@@ -2740,19 +3202,14 @@ fwupd_client_emulation_load(FwupdClient *self,
 	if (!fwupd_client_connect(self, cancellable, error))
 		return FALSE;
 
-	/* call async version and run loop until complete */
-	helper = fwupd_client_helper_new(self);
-	fwupd_client_emulation_load_async(self,
-					  filename,
-					  cancellable,
-					  fwupd_client_emulation_load_cb,
-					  helper);
-	g_main_loop_run(helper->loop);
-	if (!helper->ret) {
-		g_propagate_error(error, g_steal_pointer(&helper->error));
+	if (impl->emulation_load == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->emulation_load");
 		return FALSE;
 	}
-	return TRUE;
+	return impl->emulation_load(self, filename, impl_userdata, cancellable, error);
 }
 
 static void
@@ -2761,6 +3218,29 @@ fwupd_client_emulation_save_cb(GObject *source, GAsyncResult *res, gpointer user
 	FwupdClientHelper *helper = (FwupdClientHelper *)user_data;
 	helper->ret = fwupd_client_emulation_save_finish(FWUPD_CLIENT(source), res, &helper->error);
 	g_main_loop_quit(helper->loop);
+}
+
+gboolean
+fwupd_client_sync_impl_emulation_save(FwupdClient *self,
+				      const gchar *filename,
+				      gpointer user_data,
+				      GCancellable *cancellable,
+				      GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new(self);
+
+	/* call async version and run loop until complete */
+	fwupd_client_emulation_save_async(self,
+					  filename,
+					  cancellable,
+					  fwupd_client_emulation_save_cb,
+					  helper);
+	g_main_loop_run(helper->loop);
+	if (!helper->ret) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return FALSE;
+	}
+	return TRUE;
 }
 
 /**
@@ -2789,7 +3269,8 @@ fwupd_client_emulation_save(FwupdClient *self,
 			    GCancellable *cancellable,
 			    GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = NULL;
+	gpointer impl_userdata = NULL;
+	const FwupdClientSyncImpl *impl = fwupd_client_get_sync_impl(self, &impl_userdata);
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), FALSE);
 	g_return_val_if_fail(cancellable == NULL || G_IS_CANCELLABLE(cancellable), FALSE);
@@ -2799,19 +3280,14 @@ fwupd_client_emulation_save(FwupdClient *self,
 	if (!fwupd_client_connect(self, cancellable, error))
 		return FALSE;
 
-	/* call async version and run loop until complete */
-	helper = fwupd_client_helper_new(self);
-	fwupd_client_emulation_save_async(self,
-					  filename,
-					  cancellable,
-					  fwupd_client_emulation_save_cb,
-					  helper);
-	g_main_loop_run(helper->loop);
-	if (!helper->ret) {
-		g_propagate_error(error, g_steal_pointer(&helper->error));
+	if (impl->emulation_save == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no FwupdClientSyncImpl->emulation_save");
 		return FALSE;
 	}
-	return TRUE;
+	return impl->emulation_save(self, filename, impl_userdata, cancellable, error);
 }
 
 static void

--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -23,6 +23,7 @@
 
 #include "fwupd-bios-setting.h"
 #include "fwupd-client-private.h"
+#include "fwupd-client-sync-private.h"
 #include "fwupd-codec.h"
 #include "fwupd-common-private.h"
 #include "fwupd-device-private.h"
@@ -90,6 +91,9 @@ typedef struct {
 	GStrv hwid_values;
 	GMutex download_items_mutex; /* for @download_items */
 	GPtrArray *download_items;   /* element-type FwupdClientDownloadItem */
+	FwupdClientSyncImpl impl;
+	gpointer impl_userdata;
+	GDestroyNotify impl_userdata_destroy; /* nullable */
 } FwupdClientPrivate;
 
 typedef struct {
@@ -7542,6 +7546,47 @@ fwupd_client_build_report_security(FwupdClient *self,
 	return g_string_free(g_steal_pointer(&data), FALSE);
 }
 
+/**
+ * fwupd_client_set_sync_impl:
+ * @self: a #FwupdClient
+ * @impl: (not nullable): a #FwupdClientSyncImpl
+ * @userdata: (nullable): userdata to use with the #FwupdClientSyncImpl
+ * @userdata_destroy: (nullable): function to destroy @user_data when @self is finalized
+ *
+ * Sets an override for synchronous client functionality.
+ *
+ * Since: 2.1.7
+ **/
+void
+fwupd_client_set_sync_impl(FwupdClient *self,
+			   const FwupdClientSyncImpl *impl,
+			   gpointer userdata,
+			   GDestroyNotify userdata_destroy)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE(self);
+
+	g_return_if_fail(FWUPD_IS_CLIENT(self));
+	g_return_if_fail(impl != NULL);
+
+	if (priv->impl_userdata_destroy != NULL)
+		priv->impl_userdata_destroy(priv->impl_userdata);
+	/* nocheck:blocked */
+	memcpy(&priv->impl, impl, sizeof(priv->impl));
+	priv->impl_userdata = userdata;
+	priv->impl_userdata_destroy = userdata_destroy;
+}
+
+/* private */
+const FwupdClientSyncImpl *
+fwupd_client_get_sync_impl(FwupdClient *self, gpointer *impl_userdata)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE(self);
+	g_return_val_if_fail(FWUPD_IS_CLIENT(self), NULL);
+	if (impl_userdata != NULL)
+		*impl_userdata = priv->impl_userdata;
+	return &priv->impl;
+}
+
 static void
 fwupd_client_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
 {
@@ -7988,6 +8033,34 @@ static void
 fwupd_client_init(FwupdClient *self)
 {
 	FwupdClientPrivate *priv = GET_PRIVATE(self);
+	static FwupdClientSyncImpl impl = {
+	    .activate = fwupd_client_sync_impl_activate,
+	    .connect = fwupd_client_sync_impl_connect,
+	    .emulation_load = fwupd_client_sync_impl_emulation_load,
+	    .emulation_save = fwupd_client_sync_impl_emulation_save,
+	    .get_bios_settings = fwupd_client_sync_impl_get_bios_settings,
+	    .get_details = fwupd_client_sync_impl_get_details,
+	    .get_devices = fwupd_client_sync_impl_get_devices,
+	    .get_devices_by_guid = fwupd_client_sync_impl_get_devices_by_guid,
+	    .get_device_by_id = fwupd_client_sync_impl_get_device_by_id,
+	    .get_history = fwupd_client_sync_impl_get_history,
+	    .get_host_security_attrs = fwupd_client_sync_impl_get_host_security_attrs,
+	    .get_host_security_events = fwupd_client_sync_impl_get_host_security_events,
+	    .get_releases = fwupd_client_sync_impl_get_releases,
+	    .get_results = fwupd_client_sync_impl_get_results,
+	    .get_upgrades = fwupd_client_sync_impl_get_upgrades,
+	    .get_plugins = fwupd_client_sync_impl_get_plugins,
+	    .get_remotes = fwupd_client_sync_impl_get_remotes,
+	    .get_remote_by_id = fwupd_client_sync_impl_get_remote_by_id,
+	    .get_report_metadata = fwupd_client_sync_impl_get_report_metadata,
+	    .modify_bios_setting = fwupd_client_sync_impl_modify_bios_setting,
+	    .modify_config = fwupd_client_sync_impl_modify_config,
+	    .modify_remote = fwupd_client_sync_impl_modify_remote,
+	    .reset_config = fwupd_client_sync_impl_reset_config,
+	    .search = fwupd_client_sync_impl_search,
+	    .set_feature_flags = fwupd_client_sync_impl_set_feature_flags,
+	};
+	fwupd_client_set_sync_impl(self, &impl, NULL, NULL);
 	priv->percentage = FWUPD_PERCENTAGE_UNKNOWN;
 	g_mutex_init(&priv->proxy_mutex);
 	g_mutex_init(&priv->idle_mutex);
@@ -8037,6 +8110,8 @@ fwupd_client_finalize(GObject *object)
 	g_mutex_clear(&priv->proxy_mutex);
 	if (priv->proxy != NULL)
 		g_object_unref(priv->proxy);
+	if (priv->impl_userdata_destroy != NULL)
+		priv->impl_userdata_destroy(priv->impl_userdata);
 
 	G_OBJECT_CLASS(fwupd_client_parent_class)->finalize(object);
 }

--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -468,7 +468,16 @@ fwupd_client_set_host_machine_id(FwupdClient *self, const gchar *host_machine_id
 	fwupd_client_object_notify(self, "host-machine-id");
 }
 
-static void
+/**
+ * fwupd_client_set_host_security_id:
+ * @self: a #FwupdClient
+ * @host_security_id: A semantic version, e.g. "1.2.3"
+ *
+ * Sets the string that represents the host machine ID.
+ *
+ * Since: 2.1.7
+ **/
+void
 fwupd_client_set_host_security_id(FwupdClient *self, const gchar *host_security_id)
 {
 	FwupdClientPrivate *priv = GET_PRIVATE(self);

--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -87,8 +87,7 @@ typedef struct {
 	gchar *user_agent;
 	GHashTable *hints;		/* str:str */
 	GHashTable *immediate_requests; /* str:FwupdRequest */
-	GStrv hwid_keys;
-	GStrv hwid_values;
+	GPtrArray *hwids;		/* FwupdClientHwid */
 	GMutex download_items_mutex; /* for @download_items */
 	GPtrArray *download_items;   /* element-type FwupdClientDownloadItem */
 	FwupdClientSyncImpl impl;
@@ -102,6 +101,11 @@ typedef struct {
 	curl_mime *mime;
 	struct curl_slist *headers;
 } FwupdCurlHelper;
+
+typedef struct {
+	gchar *key;
+	gchar *value;
+} FwupdClientHwid;
 
 enum {
 	SIGNAL_CHANGED,
@@ -140,6 +144,14 @@ G_DEFINE_TYPE_WITH_PRIVATE(FwupdClient, fwupd_client, G_TYPE_OBJECT)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(CURLU, curl_url_cleanup)
 typedef char CURLSTR;
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(CURLSTR, curl_free)
+
+static void
+fwupd_client_hwid_free(FwupdClientHwid *hwid)
+{
+	g_free(hwid->key);
+	g_free(hwid->value);
+	g_free(hwid);
+}
 
 static void
 fwupd_client_curl_helper_free(FwupdCurlHelper *helper)
@@ -983,6 +995,31 @@ fwupd_client_set_hints_cb(GObject *source, GAsyncResult *res, gpointer user_data
 	g_task_return_boolean(task, TRUE);
 }
 
+/**
+ * fwupd_client_add_hwid:
+ * @self: a #FwupdClient
+ * @key: (not nullable): the key
+ * @value: (nullable): the value
+ *
+ * Adds a HwID entry.
+ *
+ * Since: 2.1.7
+ **/
+void
+fwupd_client_add_hwid(FwupdClient *self, const gchar *key, const gchar *value)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE(self);
+	FwupdClientHwid *hwid;
+
+	g_return_if_fail(FWUPD_IS_CLIENT(self));
+	g_return_if_fail(key != NULL);
+
+	hwid = g_new0(FwupdClientHwid, 1);
+	hwid->key = g_strdup(key);
+	hwid->value = g_strdup(value);
+	g_ptr_array_add(priv->hwids, hwid);
+}
+
 static void
 fwupd_client_connect_get_proxy_cb(GObject *source, GAsyncResult *res, gpointer user_data)
 {
@@ -1071,14 +1108,11 @@ fwupd_client_connect_get_proxy_cb(GObject *source, GAsyncResult *res, gpointer u
 	val_hwids = g_dbus_proxy_get_cached_property(priv->proxy, "Hwids");
 	if (val_hwids != NULL) {
 		guint size = g_variant_n_children(val_hwids);
-		priv->hwid_keys = g_new0(gchar *, size + 1);
-		priv->hwid_values = g_new0(gchar *, size + 1);
 		for (guint i = 0; i < size; i++) {
 			const gchar *hwid_value;
 			const gchar *hwid_key;
 			g_variant_get_child(val_hwids, i, "(&s&s)", &hwid_key, &hwid_value);
-			priv->hwid_keys[i] = g_strdup(hwid_key);
-			priv->hwid_values[i] = g_strdup(hwid_value);
+			fwupd_client_add_hwid(self, hwid_key, hwid_value);
 		}
 	}
 
@@ -4293,10 +4327,20 @@ fwupd_client_get_hwids(FwupdClient *self, GStrv *keys, GStrv *values)
 {
 	FwupdClientPrivate *priv = GET_PRIVATE(self);
 	g_return_if_fail(FWUPD_IS_CLIENT(self));
-	if (keys != NULL)
-		*keys = g_strdupv(priv->hwid_keys);
-	if (values != NULL)
-		*values = g_strdupv(priv->hwid_values);
+	if (keys != NULL) {
+		*keys = g_new0(gchar *, priv->hwids->len + 1);
+		for (guint i = 0; i < priv->hwids->len; i++) {
+			FwupdClientHwid *hwid = g_ptr_array_index(priv->hwids, i);
+			(*keys)[i] = g_strdup(hwid->key);
+		}
+	}
+	if (values != NULL) {
+		*values = g_new0(gchar *, priv->hwids->len + 1);
+		for (guint i = 0; i < priv->hwids->len; i++) {
+			FwupdClientHwid *hwid = g_ptr_array_index(priv->hwids, i);
+			(*values)[i] = g_strdup(hwid->value);
+		}
+	}
 }
 
 /**
@@ -8075,6 +8119,7 @@ fwupd_client_init(FwupdClient *self)
 	priv->battery_threshold = FWUPD_BATTERY_LEVEL_INVALID;
 	priv->immediate_requests =
 	    g_hash_table_new_full(g_str_hash, g_str_equal, g_free, (GDestroyNotify)g_object_unref);
+	priv->hwids = g_ptr_array_new_with_free_func((GDestroyNotify)fwupd_client_hwid_free);
 
 	/* we get this one for free */
 	fwupd_client_add_hint(self, "locale", g_getenv("LANG"));
@@ -8086,8 +8131,7 @@ fwupd_client_finalize(GObject *object)
 	FwupdClient *self = FWUPD_CLIENT(object);
 	FwupdClientPrivate *priv = GET_PRIVATE(self);
 
-	g_strfreev(priv->hwid_keys);
-	g_strfreev(priv->hwid_values);
+	g_ptr_array_unref(priv->hwids);
 	g_clear_pointer(&priv->main_ctx, g_main_context_unref);
 	g_free(priv->user_agent);
 	g_free(priv->package_name);

--- a/libfwupd/fwupd-client.h
+++ b/libfwupd/fwupd-client.h
@@ -487,6 +487,9 @@ const gchar *
 fwupd_client_get_host_security_id(FwupdClient *self) G_GNUC_NON_NULL(1);
 void
 fwupd_client_get_hwids(FwupdClient *self, GStrv *keys, GStrv *values) G_GNUC_NON_NULL(1);
+void
+fwupd_client_add_hwid(FwupdClient *self, const gchar *key, const gchar *value)
+    G_GNUC_NON_NULL(1, 2);
 guint32
 fwupd_client_get_battery_level(FwupdClient *self) G_GNUC_NON_NULL(1);
 guint32

--- a/libfwupd/fwupd-client.h
+++ b/libfwupd/fwupd-client.h
@@ -486,6 +486,9 @@ fwupd_client_get_host_machine_id(FwupdClient *self) G_GNUC_NON_NULL(1);
 const gchar *
 fwupd_client_get_host_security_id(FwupdClient *self) G_GNUC_NON_NULL(1);
 void
+fwupd_client_set_host_security_id(FwupdClient *self, const gchar *host_security_id)
+    G_GNUC_NON_NULL(1);
+void
 fwupd_client_get_hwids(FwupdClient *self, GStrv *keys, GStrv *values) G_GNUC_NON_NULL(1);
 void
 fwupd_client_add_hwid(FwupdClient *self, const gchar *key, const gchar *value)

--- a/libfwupd/fwupd-client.h
+++ b/libfwupd/fwupd-client.h
@@ -647,4 +647,12 @@ fwupd_client_build_report_security(FwupdClient *self,
 				   GHashTable *metadata,
 				   GError **error) G_GNUC_NON_NULL(1, 2, 3);
 
+/* only needed when not using D-Bus in in-tree CLIs */
+typedef struct FwupdClientSyncImpl FwupdClientSyncImpl;
+void
+fwupd_client_set_sync_impl(FwupdClient *self,
+			   const FwupdClientSyncImpl *impl,
+			   gpointer userdata,
+			   GDestroyNotify userdata_destroy) G_GNUC_NON_NULL(1);
+
 G_END_DECLS

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -1208,6 +1208,7 @@ LIBFWUPD_2.1.7 {
     fwupd_bios_setting_get_icon;
     fwupd_bios_setting_set_appstream_id;
     fwupd_bios_setting_set_icon;
+    fwupd_client_set_sync_impl;
     fwupd_device_get_id_display;
   local: *;
 } LIBFWUPD_2.1.6;

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -1209,6 +1209,7 @@ LIBFWUPD_2.1.7 {
     fwupd_bios_setting_set_appstream_id;
     fwupd_bios_setting_set_icon;
     fwupd_client_add_hwid;
+    fwupd_client_set_host_security_id;
     fwupd_client_set_sync_impl;
     fwupd_device_get_id_display;
   local: *;

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -1208,6 +1208,7 @@ LIBFWUPD_2.1.7 {
     fwupd_bios_setting_get_icon;
     fwupd_bios_setting_set_appstream_id;
     fwupd_bios_setting_set_icon;
+    fwupd_client_add_hwid;
     fwupd_client_set_sync_impl;
     fwupd_device_get_id_display;
   local: *;

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -3090,95 +3090,6 @@ fu_util_self_sign(FuUtil *self, gchar **values, GError **error)
 	return TRUE;
 }
 
-static void
-fu_util_device_added_cb(FwupdClient *client, FwupdDevice *device, gpointer user_data)
-{
-	FuUtil *self = (FuUtil *)user_data;
-	g_autofree gchar *tmp = NULL;
-
-	if (self->as_json)
-		return;
-
-	tmp = fu_util_device_to_string(self->client, device, 0);
-
-	/* TRANSLATORS: this is when a device is hotplugged */
-	fu_console_print(self->console, "%s\n%s", _("Device added:"), tmp);
-}
-
-static void
-fu_util_device_removed_cb(FwupdClient *client, FwupdDevice *device, gpointer user_data)
-{
-	FuUtil *self = (FuUtil *)user_data;
-	g_autofree gchar *tmp = NULL;
-
-	if (self->as_json)
-		return;
-
-	tmp = fu_util_device_to_string(self->client, device, 0);
-
-	/* TRANSLATORS: this is when a device is hotplugged */
-	fu_console_print(self->console, "%s\n%s", _("Device removed:"), tmp);
-}
-
-static void
-fu_util_device_changed_cb(FwupdClient *client, FwupdDevice *device, gpointer user_data)
-{
-	FuUtil *self = (FuUtil *)user_data;
-	g_autofree gchar *tmp = NULL;
-
-	if (self->as_json)
-		return;
-
-	tmp = fu_util_device_to_string(self->client, device, 0);
-
-	/* TRANSLATORS: this is when a device has been updated */
-	fu_console_print(self->console, "%s\n%s", _("Device changed:"), tmp);
-}
-
-static void
-fu_util_changed_cb(FwupdClient *client, gpointer user_data)
-{
-	FuUtil *self = (FuUtil *)user_data;
-
-	if (self->as_json)
-		return;
-
-	/* TRANSLATORS: this is when the daemon state changes */
-	fu_console_print_literal(self->console, _("Changed"));
-}
-
-static gboolean
-fu_util_monitor(FuUtil *self, gchar **values, GError **error)
-{
-	/* get all the devices */
-	if (!fwupd_client_connect(self->client, self->cancellable, error))
-		return FALSE;
-
-	/* watch for any hotplugged device */
-	g_signal_connect(FWUPD_CLIENT(self->client),
-			 "changed",
-			 G_CALLBACK(fu_util_changed_cb),
-			 self);
-	g_signal_connect(FWUPD_CLIENT(self->client),
-			 "device-added",
-			 G_CALLBACK(fu_util_device_added_cb),
-			 self);
-	g_signal_connect(FWUPD_CLIENT(self->client),
-			 "device-removed",
-			 G_CALLBACK(fu_util_device_removed_cb),
-			 self);
-	g_signal_connect(FWUPD_CLIENT(self->client),
-			 "device-changed",
-			 G_CALLBACK(fu_util_device_changed_cb),
-			 self);
-	g_signal_connect(G_CANCELLABLE(self->cancellable),
-			 "cancelled",
-			 G_CALLBACK(fu_util_cancelled_cb),
-			 self);
-	g_main_loop_run(self->loop);
-	return TRUE;
-}
-
 static gboolean
 fu_util_get_firmware_types(FuUtil *self, gchar **values, GError **error)
 {
@@ -6833,12 +6744,6 @@ main(int argc, char *argv[])
 			      /* TRANSLATORS: command description */
 			      _("Save a file that allows generation of hardware IDs"),
 			      fu_util_export_hwids);
-	fu_util_cmd_array_add(cmd_array,
-			      "monitor",
-			      NULL,
-			      /* TRANSLATORS: command description */
-			      _("Monitor the daemon for events"),
-			      fu_util_monitor);
 	fu_util_cmd_array_add(cmd_array,
 			      "update,upgrade",
 			      /* TRANSLATORS: command argument: uppercase, spaces->dashes */

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#include "fwupd-client-private.h"
 #include "fwupd-enums-private.h"
 #include "fwupd-jcat-file.h"
 #include "fwupd-remote-private.h"
@@ -110,13 +111,13 @@ static void
 fu_util_show_plugin_warnings(FuUtil *self)
 {
 	FwupdPluginFlags flags = FWUPD_PLUGIN_FLAG_NONE;
-	GPtrArray *plugins;
+	g_autoptr(GPtrArray) plugins = NULL;
 
 	if (self->as_json)
 		return;
 
 	/* get a superset so we do not show the same message more than once */
-	plugins = fu_engine_get_plugins(self->engine);
+	plugins = fwupd_client_get_plugins(self->client, self->cancellable, NULL);
 	for (guint i = 0; i < plugins->len; i++) {
 		FwupdPlugin *plugin = g_ptr_array_index(plugins, i);
 		if (fwupd_plugin_has_flag(plugin, FWUPD_PLUGIN_FLAG_DISABLED))
@@ -437,20 +438,20 @@ fu_util_update_device_request_cb(FwupdClient *client, FwupdRequest *request, FuU
 }
 
 static void
-fu_util_engine_device_added_cb(FuEngine *engine, FuDevice *device, FuUtil *self)
+fu_util_engine_device_added_cb(FuEngine *engine, FwupdDevice *device, FuUtil *self)
 {
 	if (g_log_get_debug_enabled()) {
-		g_autofree gchar *tmp = fu_device_to_string(device);
+		g_autofree gchar *tmp = fwupd_codec_to_string(FWUPD_CODEC(device));
 		/* nocheck:print */
 		g_debug("ADDED:\n%s", tmp);
 	}
 }
 
 static void
-fu_util_engine_device_removed_cb(FuEngine *engine, FuDevice *device, FuUtil *self)
+fu_util_engine_device_removed_cb(FuEngine *engine, FwupdDevice *device, FuUtil *self)
 {
 	if (g_log_get_debug_enabled()) {
-		g_autofree gchar *tmp = fu_device_to_string(device);
+		g_autofree gchar *tmp = fwupd_codec_to_string(FWUPD_CODEC(device));
 		/* nocheck:print */
 		g_debug("REMOVED:\n%s", tmp);
 	}
@@ -536,19 +537,12 @@ fu_util_get_verfmts(FuUtil *self, gchar **values, GError **error)
 static gboolean
 fu_util_get_plugins(FuUtil *self, gchar **values, GError **error)
 {
-	GPtrArray *plugins;
-
-	/* load engine */
-	if (!fu_util_start_engine(
-		self,
-		FU_ENGINE_LOAD_FLAG_COLDPLUG | FU_ENGINE_LOAD_FLAG_EXTERNAL_PLUGINS |
-		    FU_ENGINE_LOAD_FLAG_BUILTIN_PLUGINS | FU_ENGINE_LOAD_FLAG_HWINFO,
-		self->progress,
-		error))
-		return FALSE;
+	g_autoptr(GPtrArray) plugins = NULL;
 
 	/* print */
-	plugins = fu_engine_get_plugins(self->engine);
+	plugins = fwupd_client_get_plugins(self->client, self->cancellable, error);
+	if (plugins == NULL)
+		return FALSE;
 	g_ptr_array_sort(plugins, (GCompareFunc)fu_util_plugin_name_sort_cb);
 	if (self->as_json) {
 		g_autoptr(FwupdJsonObject) json_obj = fwupd_json_object_new();
@@ -572,7 +566,7 @@ fu_util_get_devices_with_filter(FuUtil *self, GError **error)
 {
 	g_autoptr(GPtrArray) devices = NULL;
 
-	devices = fu_engine_get_devices(self->engine, error);
+	devices = fwupd_client_get_devices(self->client, self->cancellable, error);
 	if (devices == NULL)
 		return NULL;
 	return fu_util_device_array_filter(devices,
@@ -583,10 +577,10 @@ fu_util_get_devices_with_filter(FuUtil *self, GError **error)
 					   error);
 }
 
-static FuDevice *
+static FwupdDevice *
 fu_util_prompt_for_device(FuUtil *self, GPtrArray *devices_opt, GError **error)
 {
-	FuDevice *dev;
+	FwupdDevice *dev;
 	guint idx;
 	g_autoptr(GPtrArray) devices = NULL;
 
@@ -626,8 +620,8 @@ fu_util_prompt_for_device(FuUtil *self, GPtrArray *devices_opt, GError **error)
 	/* TRANSLATORS: this is to abort the interactive prompt */
 	fu_console_print(self->console, "0.\t%s", _("Cancel"));
 	for (guint i = 0; i < devices->len; i++) {
-		FuDevice *device_tmp = g_ptr_array_index(devices, i);
-		g_autofree gchar *id_display = fu_device_get_id_display(device_tmp);
+		FwupdDevice *device_tmp = g_ptr_array_index(devices, i);
+		g_autofree gchar *id_display = fwupd_device_get_id_display(device_tmp);
 		fu_console_print(self->console, "%u.\t%s", i + 1, id_display);
 	}
 
@@ -644,12 +638,13 @@ fu_util_prompt_for_device(FuUtil *self, GPtrArray *devices_opt, GError **error)
 	return g_object_ref(dev);
 }
 
-static FuDevice *
+static FwupdDevice *
 fu_util_get_device(FuUtil *self, const gchar *id, GError **error)
 {
 	if (fwupd_guid_is_valid(id)) {
 		g_autoptr(GPtrArray) devices = NULL;
-		devices = fu_engine_get_devices_by_guid(self->engine, id, error);
+		devices =
+		    fwupd_client_get_devices_by_guid(self->client, id, self->cancellable, error);
 		if (devices == NULL)
 			return NULL;
 		return fu_util_prompt_for_device(self, devices, error);
@@ -665,7 +660,7 @@ fu_util_get_device(FuUtil *self, const gchar *id, GError **error)
 			return NULL;
 		}
 	}
-	return fu_engine_get_device(self->engine, id, error);
+	return fwupd_client_get_device_by_id(self->client, id, self->cancellable, error);
 }
 
 static gboolean
@@ -683,10 +678,10 @@ fu_util_get_updates_as_json(FuUtil *self, GPtrArray *devices, GError **error)
 			continue;
 
 		/* get the releases for this device and filter for validity */
-		rels = fu_engine_get_upgrades(self->engine,
-					      self->request,
-					      fwupd_device_get_id(dev),
-					      &error_local);
+		rels = fwupd_client_get_upgrades(self->client,
+						 fwupd_device_get_id(dev),
+						 self->cancellable,
+						 &error_local);
 		if (rels == NULL) {
 			g_debug("no upgrades: %s", error_local->message);
 			continue;
@@ -733,7 +728,7 @@ fu_util_get_updates(FuUtil *self, gchar **values, GError **error)
 	} else {
 		devices = g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
 		for (guint idx = 0; idx < g_strv_length(values); idx++) {
-			FuDevice *device = fu_util_get_device(self, values[idx], error);
+			FwupdDevice *device = fu_util_get_device(self, values[idx], error);
 			if (device == NULL) {
 				g_set_error(error,
 					    FWUPD_ERROR,
@@ -768,10 +763,10 @@ fu_util_get_updates(FuUtil *self, gchar **values, GError **error)
 		}
 
 		/* get the releases for this device and filter for validity */
-		rels = fu_engine_get_upgrades(self->engine,
-					      self->request,
-					      fwupd_device_get_id(dev),
-					      &error_local);
+		rels = fwupd_client_get_upgrades(self->client,
+						 fwupd_device_get_id(dev),
+						 self->cancellable,
+						 &error_local);
 		if (rels == NULL) {
 			g_ptr_array_add(devices_no_upgrades, dev);
 			/* discard the actual reason from user, but leave for debugging */
@@ -905,10 +900,10 @@ fu_util_get_device_flags(FuUtil *self, gchar **values, GError **error)
 }
 
 static void
-fu_util_build_device_tree(FuUtil *self, FuUtilNode *root, GPtrArray *devs, FuDevice *dev)
+fu_util_build_device_tree(FuUtil *self, FuUtilNode *root, GPtrArray *devs, FwupdDevice *dev)
 {
 	for (guint i = 0; i < devs->len; i++) {
-		FuDevice *dev_tmp = g_ptr_array_index(devs, i);
+		FwupdDevice *dev_tmp = g_ptr_array_index(devs, i);
 		if (!fwupd_device_match_flags(FWUPD_DEVICE(dev_tmp),
 					      self->filter_device_include,
 					      self->filter_device_exclude))
@@ -919,7 +914,7 @@ fu_util_build_device_tree(FuUtil *self, FuUtilNode *root, GPtrArray *devs, FuDev
 			continue;
 		if (!self->show_all && !fu_util_is_interesting_device(devs, FWUPD_DEVICE(dev_tmp)))
 			continue;
-		if (fu_device_get_parent_internal(dev_tmp) == dev) {
+		if (fwupd_device_get_parent(dev_tmp) == dev) {
 			FuUtilNode *child = g_node_append_data(root, g_object_ref(dev_tmp));
 			fu_util_build_device_tree(self, child, devs, dev_tmp);
 		}
@@ -932,7 +927,7 @@ fu_util_get_devices_as_json(FuUtil *self, GPtrArray *devs, GError **error)
 	g_autoptr(FwupdJsonObject) json_obj = fwupd_json_object_new();
 	g_autoptr(FwupdJsonArray) json_arr = fwupd_json_array_new();
 	for (guint i = 0; i < devs->len; i++) {
-		FuDevice *dev = g_ptr_array_index(devs, i);
+		FwupdDevice *dev = g_ptr_array_index(devs, i);
 		g_autoptr(GPtrArray) rels = NULL;
 		g_autoptr(GError) error_local = NULL;
 		g_autoptr(FwupdJsonObject) json_obj_tmp = fwupd_json_object_new();
@@ -940,7 +935,7 @@ fu_util_get_devices_as_json(FuUtil *self, GPtrArray *devs, GError **error)
 		/* add all releases that could be applied */
 		rels = fu_engine_get_releases_for_device(self->engine,
 							 self->request,
-							 dev,
+							 FU_DEVICE(dev),
 							 &error_local);
 		if (rels == NULL) {
 			g_debug("not adding releases to device: %s", error_local->message);
@@ -984,7 +979,7 @@ fu_util_get_devices(FuUtil *self, gchar **values, GError **error)
 	if (g_strv_length(values) > 0) {
 		devs = g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
 		for (guint i = 0; values[i] != NULL; i++) {
-			FuDevice *device = fu_util_get_device(self, values[i], error);
+			FwupdDevice *device = fu_util_get_device(self, values[i], error);
 			if (device == NULL)
 				return FALSE;
 			g_ptr_array_add(devs, device);
@@ -1082,7 +1077,7 @@ static gboolean
 fu_util_install_blob(FuUtil *self, gchar **values, GError **error)
 {
 	g_autofree gchar *firmware_basename = NULL;
-	g_autoptr(FuDevice) device = NULL;
+	g_autoptr(FwupdDevice) device = NULL;
 	g_autoptr(FuRelease) release = fu_release_new();
 	g_autoptr(FuInputStream) stream_fw = NULL;
 
@@ -1160,7 +1155,7 @@ fu_util_install_blob(FuUtil *self, gchar **values, GError **error)
 	}
 	self->flags |= FWUPD_INSTALL_FLAG_NO_HISTORY;
 	if (!fu_engine_install_blob(self->engine,
-				    device,
+				    FU_DEVICE(device),
 				    release,
 				    fu_progress_get_child(self->progress),
 				    self->flags,
@@ -1171,7 +1166,7 @@ fu_util_install_blob(FuUtil *self, gchar **values, GError **error)
 
 	/* cleanup */
 	if (self->cleanup_blob) {
-		g_autoptr(FuDevice) device_new = NULL;
+		g_autoptr(FwupdDevice) device_new = NULL;
 		g_autoptr(GError) error_local = NULL;
 
 		/* get the possibly new device from the old ID */
@@ -1241,7 +1236,7 @@ fu_util_firmware_sign(FuUtil *self, gchar **values, GError **error)
 static gboolean
 fu_util_firmware_dump(FuUtil *self, gchar **values, GError **error)
 {
-	g_autoptr(FuDevice) device = NULL;
+	g_autoptr(FwupdDevice) device = NULL;
 	g_autoptr(GBytes) blob_empty = g_bytes_new(NULL, 0);
 	g_autoptr(GBytes) blob_fw = NULL;
 
@@ -1302,7 +1297,7 @@ fu_util_firmware_dump(FuUtil *self, gchar **values, GError **error)
 
 	/* dump firmware */
 	blob_fw = fu_engine_firmware_dump(self->engine,
-					  device,
+					  FU_DEVICE(device),
 					  fu_progress_get_child(self->progress),
 					  self->flags,
 					  error);
@@ -1315,7 +1310,7 @@ fu_util_firmware_dump(FuUtil *self, gchar **values, GError **error)
 static gboolean
 fu_util_firmware_read(FuUtil *self, gchar **values, GError **error)
 {
-	g_autoptr(FuDevice) device = NULL;
+	g_autoptr(FwupdDevice) device = NULL;
 	g_autoptr(FuFirmware) fw = NULL;
 	g_autoptr(GBytes) blob_empty = g_bytes_new(NULL, 0);
 	g_autoptr(GBytes) blob_fw = NULL;
@@ -1379,7 +1374,7 @@ fu_util_firmware_read(FuUtil *self, gchar **values, GError **error)
 
 	/* read firmware into the container format */
 	fw = fu_engine_firmware_read(self->engine,
-				     device,
+				     FU_DEVICE(device),
 				     fu_progress_get_child(self->progress),
 				     self->flags,
 				     error);
@@ -1454,12 +1449,12 @@ fu_util_install_stream(FuUtil *self,
 
 		/* do any devices pass the requirements */
 		for (guint j = 0; j < devices->len; j++) {
-			FuDevice *device = g_ptr_array_index(devices, j);
+			FwupdDevice *device = g_ptr_array_index(devices, j);
 			g_autoptr(FuRelease) release = fu_release_new();
 			g_autoptr(GError) error_local = NULL;
 
 			/* is this component valid for the device */
-			fu_release_set_device(release, device);
+			fu_release_set_device(release, FU_DEVICE(device));
 			fu_release_set_request(release, self->request);
 			if (!fu_engine_load_release(self->engine,
 						    release,
@@ -1488,8 +1483,8 @@ fu_util_install_stream(FuUtil *self,
 			}
 
 			/* if component should have an update message from CAB */
-			fu_device_ensure_from_component(device, component);
-			fu_device_incorporate_from_component(device, component);
+			fu_device_ensure_from_component(FU_DEVICE(device), component);
+			fu_device_incorporate_from_component(FU_DEVICE(device), component);
 
 			/* success */
 			g_ptr_array_add(releases, g_steal_pointer(&release));
@@ -1553,7 +1548,7 @@ fu_util_install(FuUtil *self, gchar **values, GError **error)
 			return FALSE;
 		fwupd_device_array_ensure_parents(devices_possible);
 	} else if (g_strv_length(values) == 2) {
-		FuDevice *device = fu_util_get_device(self, values[1], error);
+		FwupdDevice *device = fu_util_get_device(self, values[1], error);
 		if (device == NULL)
 			return FALSE;
 		if (!self->no_safety_check) {
@@ -1661,7 +1656,7 @@ fu_util_install_release(FuUtil *self, FwupdDevice *dev, FwupdRelease *rel, GErro
 		return FALSE;
 	}
 
-	remote = fu_engine_get_remote_by_id(self->engine, remote_id, error);
+	remote = fwupd_client_get_remote_by_id(self->client, remote_id, self->cancellable, error);
 	if (remote == NULL)
 		return FALSE;
 
@@ -1731,7 +1726,7 @@ fu_util_update(FuUtil *self, gchar **values, GError **error)
 
 	self->current_operation = FU_UTIL_OPERATION_UPDATE;
 
-	devices = fu_engine_get_devices(self->engine, error);
+	devices = fwupd_client_get_devices(self->client, self->cancellable, error);
 	if (devices == NULL)
 		return FALSE;
 	fwupd_device_array_ensure_parents(devices);
@@ -1774,7 +1769,10 @@ fu_util_update(FuUtil *self, gchar **values, GError **error)
 						   self->filter_protocols_exclude))
 			continue;
 
-		rels = fu_engine_get_upgrades(self->engine, self->request, device_id, &error_local);
+		rels = fwupd_client_get_upgrades(self->client,
+						 device_id,
+						 self->cancellable,
+						 &error_local);
 		if (rels == NULL) {
 			g_ptr_array_add(devices_latest, dev);
 			/* discard the actual reason from user, but leave for debugging */
@@ -1792,8 +1790,8 @@ fu_util_update(FuUtil *self, gchar **values, GError **error)
 		if (!self->no_safety_check) {
 			g_autofree gchar *title =
 			    g_strdup_printf("%s %s",
-					    fu_engine_get_host_vendor(self->engine),
-					    fu_engine_get_host_product(self->engine));
+					    fwupd_client_get_host_vendor(self->client),
+					    fwupd_client_get_host_product(self->client));
 			if (!fu_util_prompt_warning(self->console, dev, rel, title, &error_local)) {
 				if (g_error_matches(error_local,
 						    FWUPD_ERROR,
@@ -1871,7 +1869,7 @@ fu_util_reinstall(FuUtil *self, gchar **values, GError **error)
 {
 	g_autoptr(FwupdRelease) rel = NULL;
 	g_autoptr(GPtrArray) rels = NULL;
-	g_autoptr(FuDevice) dev = NULL;
+	g_autoptr(FwupdDevice) dev = NULL;
 
 	if (g_strv_length(values) != 1) {
 		g_set_error_literal(error,
@@ -1895,7 +1893,8 @@ fu_util_reinstall(FuUtil *self, gchar **values, GError **error)
 		return FALSE;
 
 	/* try to lookup/match release from client */
-	rels = fu_engine_get_releases_for_device(self->engine, self->request, dev, error);
+	rels =
+	    fu_engine_get_releases_for_device(self->engine, self->request, FU_DEVICE(dev), error);
 	if (rels == NULL)
 		return FALSE;
 
@@ -1945,7 +1944,7 @@ fu_util_reinstall(FuUtil *self, gchar **values, GError **error)
 static gboolean
 fu_util_detach(FuUtil *self, gchar **values, GError **error)
 {
-	g_autoptr(FuDevice) device = NULL;
+	g_autoptr(FwupdDevice) device = NULL;
 	g_autoptr(FuDeviceLocker) locker = NULL;
 
 	/* progress */
@@ -1976,10 +1975,10 @@ fu_util_detach(FuUtil *self, gchar **values, GError **error)
 	}
 
 	/* run vfunc */
-	locker = fu_device_locker_new(device, error);
+	locker = fu_device_locker_new(FU_DEVICE(device), error);
 	if (locker == NULL)
 		return FALSE;
-	if (!fu_device_detach_full(device, fu_progress_get_child(self->progress), error))
+	if (!fu_device_detach_full(FU_DEVICE(device), fu_progress_get_child(self->progress), error))
 		return FALSE;
 	fu_progress_step_done(self->progress);
 	return TRUE;
@@ -1988,7 +1987,7 @@ fu_util_detach(FuUtil *self, gchar **values, GError **error)
 static gboolean
 fu_util_unbind_driver(FuUtil *self, gchar **values, GError **error)
 {
-	g_autoptr(FuDevice) device = NULL;
+	g_autoptr(FwupdDevice) device = NULL;
 	g_autoptr(FuDeviceLocker) locker = NULL;
 
 	/* load engine */
@@ -2010,16 +2009,16 @@ fu_util_unbind_driver(FuUtil *self, gchar **values, GError **error)
 		return FALSE;
 
 	/* run vfunc */
-	locker = fu_device_locker_new(device, error);
+	locker = fu_device_locker_new(FU_DEVICE(device), error);
 	if (locker == NULL)
 		return FALSE;
-	return fu_device_unbind_driver(device, error);
+	return fu_device_unbind_driver(FU_DEVICE(device), error);
 }
 
 static gboolean
 fu_util_bind_driver(FuUtil *self, gchar **values, GError **error)
 {
-	g_autoptr(FuDevice) device = NULL;
+	g_autoptr(FwupdDevice) device = NULL;
 	g_autoptr(FuDeviceLocker) locker = NULL;
 
 	/* load engine */
@@ -2049,16 +2048,16 @@ fu_util_bind_driver(FuUtil *self, gchar **values, GError **error)
 	}
 
 	/* run vfunc */
-	locker = fu_device_locker_new(device, error);
+	locker = fu_device_locker_new(FU_DEVICE(device), error);
 	if (locker == NULL)
 		return FALSE;
-	return fu_device_bind_driver(device, values[0], values[1], error);
+	return fu_device_bind_driver(FU_DEVICE(device), values[0], values[1], error);
 }
 
 static gboolean
 fu_util_attach(FuUtil *self, gchar **values, GError **error)
 {
-	g_autoptr(FuDevice) device = NULL;
+	g_autoptr(FwupdDevice) device = NULL;
 	g_autoptr(FuDeviceLocker) locker = NULL;
 
 	/* progress */
@@ -2090,10 +2089,10 @@ fu_util_attach(FuUtil *self, gchar **values, GError **error)
 	}
 
 	/* run vfunc */
-	locker = fu_device_locker_new(device, error);
+	locker = fu_device_locker_new(FU_DEVICE(device), error);
 	if (locker == NULL)
 		return FALSE;
-	if (!fu_device_attach_full(device, fu_progress_get_child(self->progress), error))
+	if (!fu_device_attach_full(FU_DEVICE(device), fu_progress_get_child(self->progress), error))
 		return FALSE;
 	fu_progress_step_done(self->progress);
 
@@ -2116,14 +2115,14 @@ fu_util_report_metadata_to_string(GHashTable *metadata, guint idt, GString *str)
 static gboolean
 fu_util_get_report_metadata_as_json(FuUtil *self, FwupdJsonObject *json_obj, GError **error)
 {
-	GPtrArray *plugins;
 	g_autoptr(FwupdJsonArray) json_array_devices = fwupd_json_array_new();
 	g_autoptr(FwupdJsonArray) json_array_plugins = fwupd_json_array_new();
 	g_autoptr(GHashTable) metadata = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
+	g_autoptr(GPtrArray) plugins = NULL;
 
 	/* daemon metadata */
-	metadata = fu_engine_get_report_metadata(self->engine, error);
+	metadata = fwupd_client_get_report_metadata(self->client, self->cancellable, error);
 	if (metadata == NULL)
 		return FALSE;
 	fwupd_json_object_add_object_map(json_obj, "daemon", metadata);
@@ -2133,18 +2132,18 @@ fu_util_get_report_metadata_as_json(FuUtil *self, FwupdJsonObject *json_obj, GEr
 	if (devices == NULL)
 		return FALSE;
 	for (guint i = 0; i < devices->len; i++) {
-		FuDevice *device = g_ptr_array_index(devices, i);
+		FwupdDevice *device = g_ptr_array_index(devices, i);
 		g_autoptr(FuDeviceLocker) locker = NULL;
 		g_autoptr(GHashTable) metadata_post = NULL;
 		g_autoptr(GHashTable) metadata_pre = NULL;
 		g_autoptr(FwupdJsonArray) json_arr = fwupd_json_array_new();
 		g_autoptr(FwupdJsonObject) json_object_device = fwupd_json_object_new();
 
-		locker = fu_device_locker_new(device, error);
+		locker = fu_device_locker_new(FU_DEVICE(device), error);
 		if (locker == NULL)
 			return FALSE;
-		metadata_pre = fu_device_report_metadata_pre(device);
-		metadata_post = fu_device_report_metadata_post(device);
+		metadata_pre = fu_device_report_metadata_pre(FU_DEVICE(device));
+		metadata_post = fu_device_report_metadata_post(FU_DEVICE(device));
 		if (metadata_pre == NULL && metadata_post == NULL)
 			continue;
 
@@ -2164,7 +2163,9 @@ fu_util_get_report_metadata_as_json(FuUtil *self, FwupdJsonObject *json_obj, GEr
 	fwupd_json_object_add_array(json_obj, "devices", json_array_devices);
 
 	/* plugin metadata */
-	plugins = fu_engine_get_plugins(self->engine);
+	plugins = fwupd_client_get_plugins(self->client, self->cancellable, error);
+	if (plugins == NULL)
+		return FALSE;
 	for (guint i = 0; i < plugins->len; i++) {
 		FuPlugin *plugin = g_ptr_array_index(plugins, i);
 		g_autoptr(FwupdJsonObject) json_obj_tmp = fwupd_json_object_new();
@@ -2186,9 +2187,9 @@ fu_util_get_report_metadata_as_json(FuUtil *self, FwupdJsonObject *json_obj, GEr
 static gboolean
 fu_util_get_report_metadata(FuUtil *self, gchar **values, GError **error)
 {
-	GPtrArray *plugins;
 	g_autoptr(GHashTable) metadata = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
+	g_autoptr(GPtrArray) plugins = NULL;
 	g_autoptr(GString) str = g_string_new(NULL);
 
 	/* progress */
@@ -2214,7 +2215,7 @@ fu_util_get_report_metadata(FuUtil *self, gchar **values, GError **error)
 	}
 
 	/* daemon metadata */
-	metadata = fu_engine_get_report_metadata(self->engine, error);
+	metadata = fwupd_client_get_report_metadata(self->client, self->cancellable, error);
 	if (metadata == NULL)
 		return FALSE;
 	fu_util_report_metadata_to_string(metadata, 0, str);
@@ -2224,16 +2225,16 @@ fu_util_get_report_metadata(FuUtil *self, gchar **values, GError **error)
 	if (devices == NULL)
 		return FALSE;
 	for (guint i = 0; i < devices->len; i++) {
-		FuDevice *device = g_ptr_array_index(devices, i);
+		FwupdDevice *device = g_ptr_array_index(devices, i);
 		g_autoptr(FuDeviceLocker) locker = NULL;
 		g_autoptr(GHashTable) metadata_post = NULL;
 		g_autoptr(GHashTable) metadata_pre = NULL;
 
-		locker = fu_device_locker_new(device, error);
+		locker = fu_device_locker_new(FU_DEVICE(device), error);
 		if (locker == NULL)
 			return FALSE;
-		metadata_pre = fu_device_report_metadata_pre(device);
-		metadata_post = fu_device_report_metadata_post(device);
+		metadata_pre = fu_device_report_metadata_pre(FU_DEVICE(device));
+		metadata_post = fu_device_report_metadata_post(FU_DEVICE(device));
 		if (metadata_pre != NULL || metadata_post != NULL) {
 			fwupd_codec_string_append(str,
 						  0,
@@ -2251,7 +2252,9 @@ fu_util_get_report_metadata(FuUtil *self, gchar **values, GError **error)
 	}
 
 	/* plugin metadata */
-	plugins = fu_engine_get_plugins(self->engine);
+	plugins = fwupd_client_get_plugins(self->client, self->cancellable, error);
+	if (plugins == NULL)
+		return FALSE;
 	for (guint i = 0; i < plugins->len; i++) {
 		FuPlugin *plugin = g_ptr_array_index(plugins, i);
 		if (fu_plugin_has_flag(plugin, FWUPD_PLUGIN_FLAG_DISABLED))
@@ -2273,16 +2276,22 @@ fu_util_get_report_metadata(FuUtil *self, gchar **values, GError **error)
 static gboolean
 fu_util_modify_config(FuUtil *self, gchar **values, GError **error)
 {
-	/* start engine */
-	if (!fu_util_start_engine(self, FU_ENGINE_LOAD_FLAG_HWINFO, self->progress, error))
-		return FALSE;
-
 	/* check args */
 	if (g_strv_length(values) == 3) {
-		if (!fu_engine_modify_config(self->engine, values[0], values[1], values[2], error))
+		if (!fwupd_client_modify_config(self->client,
+						values[0],
+						values[1],
+						values[2],
+						self->cancellable,
+						error))
 			return FALSE;
 	} else if (g_strv_length(values) == 2) {
-		if (!fu_engine_modify_config(self->engine, "fwupd", values[0], values[1], error))
+		if (!fwupd_client_modify_config(self->client,
+						"fwupd",
+						values[0],
+						values[1],
+						self->cancellable,
+						error))
 			return FALSE;
 	} else {
 		g_set_error_literal(error,
@@ -2346,15 +2355,15 @@ fu_util_remote_modify(FuUtil *self, gchar **values, GError **error)
 				  error))
 		return FALSE;
 
-	remote = fu_engine_get_remote_by_id(self->engine, values[0], error);
+	remote = fwupd_client_get_remote_by_id(self->client, values[0], self->cancellable, error);
 	if (remote == NULL)
 		return FALSE;
-
-	if (!fu_engine_modify_remote(self->engine,
-				     fwupd_remote_get_id(remote),
-				     values[1],
-				     values[2],
-				     error))
+	if (!fwupd_client_modify_remote(self->client,
+					fwupd_remote_get_id(remote),
+					values[1],
+					values[2],
+					self->cancellable,
+					error))
 		return FALSE;
 
 	if (self->as_json)
@@ -2377,13 +2386,7 @@ fu_util_remote_clean(FuUtil *self, gchar **values, GError **error)
 		return FALSE;
 	}
 
-	if (!fu_util_start_engine(self,
-				  FU_ENGINE_LOAD_FLAG_REMOTES | FU_ENGINE_LOAD_FLAG_HWINFO,
-				  self->progress,
-				  error))
-		return FALSE;
-
-	remote = fu_engine_get_remote_by_id(self->engine, values[0], error);
+	remote = fwupd_client_get_remote_by_id(self->client, values[0], self->cancellable, error);
 	if (remote == NULL)
 		return FALSE;
 	if (!fu_engine_clean_remote(self->engine, fwupd_remote_get_id(remote), error))
@@ -2413,15 +2416,16 @@ fu_util_remote_disable(FuUtil *self, gchar **values, GError **error)
 	if (!fu_util_start_engine(self, FU_ENGINE_LOAD_FLAG_REMOTES, self->progress, error))
 		return FALSE;
 
-	remote = fu_engine_get_remote_by_id(self->engine, values[0], error);
+	remote = fwupd_client_get_remote_by_id(self->client, values[0], self->cancellable, error);
 	if (remote == NULL)
 		return FALSE;
 
-	if (!fu_engine_modify_remote(self->engine,
-				     fwupd_remote_get_id(remote),
-				     "Enabled",
-				     "false",
-				     error))
+	if (!fwupd_client_modify_remote(self->client,
+					fwupd_remote_get_id(remote),
+					"Enabled",
+					"false",
+					self->cancellable,
+					error))
 		return FALSE;
 
 	if (self->as_json)
@@ -2654,15 +2658,8 @@ fu_util_search(FuUtil *self, gchar **values, GError **error)
 		return FALSE;
 	}
 
-	/* load engine */
-	if (!fu_engine_load(self->engine,
-			    FU_ENGINE_LOAD_FLAG_PATH_STORE_DEFAULTS | FU_ENGINE_LOAD_FLAG_REMOTES,
-			    self->progress,
-			    error))
-		return FALSE;
-
 	/* get search results */
-	rels = fu_engine_search(self->engine, values[0], error);
+	rels = fwupd_client_search(self->client, values[0], self->cancellable, error);
 	if (rels == NULL)
 		return FALSE;
 	if (rels->len == 0) {
@@ -2744,18 +2741,19 @@ fu_util_remote_enable(FuUtil *self, gchar **values, GError **error)
 	if (!fu_util_start_engine(self, FU_ENGINE_LOAD_FLAG_REMOTES, self->progress, error))
 		return FALSE;
 
-	remote = fu_engine_get_remote_by_id(self->engine, values[0], error);
+	remote = fwupd_client_get_remote_by_id(self->client, values[0], self->cancellable, error);
 	if (remote == NULL)
 		return FALSE;
 
 	if (!fu_util_modify_remote_warning(self->console, remote, FALSE, error))
 		return FALSE;
 
-	if (!fu_engine_modify_remote(self->engine,
-				     fwupd_remote_get_id(remote),
-				     "Enabled",
-				     "true",
-				     error))
+	if (!fwupd_client_modify_remote(self->client,
+					fwupd_remote_get_id(remote),
+					"Enabled",
+					"true",
+					self->cancellable,
+					error))
 		return FALSE;
 
 	if (self->as_json)
@@ -2768,19 +2766,17 @@ fu_util_remote_enable(FuUtil *self, gchar **values, GError **error)
 static gboolean
 fu_util_set_test_devices_enabled(FuUtil *self, gboolean enable, GError **error)
 {
-	return fu_engine_modify_config(self->engine,
-				       "fwupd",
-				       "TestDevices",
-				       enable ? "true" : "false",
-				       error);
+	return fwupd_client_modify_config(self->client,
+					  "fwupd",
+					  "TestDevices",
+					  enable ? "true" : "false",
+					  self->cancellable,
+					  error);
 }
 
 static gboolean
 fu_util_disable_test_devices(FuUtil *self, gchar **values, GError **error)
 {
-	if (!fu_util_start_engine(self, FU_ENGINE_LOAD_FLAG_HWINFO, self->progress, error))
-		return FALSE;
-
 	if (!fu_util_set_test_devices_enabled(self, FALSE, error))
 		return FALSE;
 
@@ -2799,17 +2795,11 @@ fu_util_enable_test_devices(FuUtil *self, gchar **values, GError **error)
 	gboolean found = FALSE;
 	g_autoptr(GPtrArray) remotes = NULL;
 
-	if (!fu_util_start_engine(self,
-				  FU_ENGINE_LOAD_FLAG_REMOTES | FU_ENGINE_LOAD_FLAG_HWINFO,
-				  self->progress,
-				  error))
-		return FALSE;
-
 	if (!fu_util_set_test_devices_enabled(self, TRUE, error))
 		return FALSE;
 
 	/* verify remote is present */
-	remotes = fu_engine_get_remotes(self->engine, error);
+	remotes = fwupd_client_get_remotes(self->client, self->cancellable, error);
 	if (remotes == NULL)
 		return FALSE;
 	for (guint i = 0; i < remotes->len; i++) {
@@ -2851,7 +2841,7 @@ fu_util_check_activation_needed(FuUtil *self, GError **error)
 
 	/* only start up the plugins needed */
 	for (guint i = 0; i < devices->len; i++) {
-		FuDevice *dev = g_ptr_array_index(devices, i);
+		FwupdDevice *dev = g_ptr_array_index(devices, i);
 		if (fu_device_has_flag(dev, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION)) {
 			fu_engine_add_plugin_filter(self->engine, fu_device_get_plugin(dev));
 			has_pending = TRUE;
@@ -2902,7 +2892,7 @@ fu_util_activate(FuUtil *self, gchar **values, GError **error)
 		if (devices == NULL)
 			return FALSE;
 	} else if (g_strv_length(values) == 1) {
-		FuDevice *device;
+		FwupdDevice *device;
 		device = fu_util_get_device(self, values[0], error);
 		if (device == NULL)
 			return FALSE;
@@ -2918,7 +2908,7 @@ fu_util_activate(FuUtil *self, gchar **values, GError **error)
 
 	/* activate anything with _NEEDS_ACTIVATION */
 	for (guint i = 0; i < devices->len; i++) {
-		FuDevice *device = g_ptr_array_index(devices, i);
+		FwupdDevice *device = g_ptr_array_index(devices, i);
 		if (!fu_device_has_flag(device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION))
 			continue;
 		has_pending = TRUE;
@@ -3926,7 +3916,7 @@ static gboolean
 fu_util_verify_update(FuUtil *self, gchar **values, GError **error)
 {
 	g_autofree gchar *str = NULL;
-	g_autoptr(FuDevice) dev = NULL;
+	g_autoptr(FwupdDevice) dev = NULL;
 
 	/* progress */
 	fu_progress_set_id(self->progress, G_STRLOC);
@@ -3964,7 +3954,7 @@ fu_util_verify_update(FuUtil *self, gchar **values, GError **error)
 	fu_progress_step_done(self->progress);
 
 	/* show checksums */
-	str = fu_device_to_string(dev);
+	str = fwupd_codec_to_string(FWUPD_CODEC(dev));
 	fu_console_print_literal(self->console, str);
 	return TRUE;
 }
@@ -3976,16 +3966,8 @@ fu_util_get_history(FuUtil *self, gchar **values, GError **error)
 	g_autoptr(GPtrArray) devices_filtered = NULL;
 	g_autoptr(FuUtilNode) root = g_node_new(NULL);
 
-	/* load engine */
-	if (!fu_util_start_engine(self,
-				  FU_ENGINE_LOAD_FLAG_COLDPLUG | FU_ENGINE_LOAD_FLAG_REMOTES |
-				      FU_ENGINE_LOAD_FLAG_HWINFO | FU_ENGINE_LOAD_FLAG_HISTORY,
-				  self->progress,
-				  error))
-		return FALSE;
-
 	/* get all devices from the history database */
-	devices = fu_engine_get_history(self->engine, error);
+	devices = fwupd_client_get_history(self->client, self->cancellable, error);
 	if (devices == NULL)
 		return FALSE;
 
@@ -4041,10 +4023,10 @@ fu_util_get_history(FuUtil *self, gchar **values, GError **error)
 		}
 
 		/* try to lookup releases from client, falling back to the history release */
-		rels = fu_engine_get_releases(self->engine,
-					      self->request,
-					      fwupd_device_get_id(dev),
-					      &error_local);
+		rels = fwupd_client_get_releases(self->client,
+						 fwupd_device_get_id(dev),
+						 self->cancellable,
+						 &error_local);
 		if (rels == NULL) {
 			if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND)) {
 				rels = g_ptr_array_new();
@@ -4148,16 +4130,8 @@ fu_util_download_metadata(FuUtil *self, GError **error)
 	guint refresh_cnt = 0;
 	g_autoptr(GPtrArray) remotes = NULL;
 
-	/* load engine */
-	if (!fu_util_start_engine(self,
-				  FU_ENGINE_LOAD_FLAG_COLDPLUG | FU_ENGINE_LOAD_FLAG_REMOTES |
-				      FU_ENGINE_LOAD_FLAG_HWINFO,
-				  self->progress,
-				  error))
-		return FALSE;
-
 	/* download new metadata */
-	remotes = fu_engine_get_remotes(self->engine, error);
+	remotes = fwupd_client_get_remotes(self->client, self->cancellable, error);
 	if (remotes == NULL)
 		return FALSE;
 	for (guint i = 0; i < remotes->len; i++) {
@@ -4257,12 +4231,8 @@ fu_util_get_remotes(FuUtil *self, gchar **values, GError **error)
 	g_autoptr(FuUtilNode) root = g_node_new(NULL);
 	g_autoptr(GPtrArray) remotes = NULL;
 
-	/* load engine */
-	if (!fu_util_start_engine(self, FU_ENGINE_LOAD_FLAG_REMOTES, self->progress, error))
-		return FALSE;
-
 	/* list remotes */
-	remotes = fu_engine_get_remotes(self->engine, error);
+	remotes = fwupd_client_get_remotes(self->client, self->cancellable, error);
 	if (remotes == NULL)
 		return FALSE;
 	if (remotes->len == 0) {
@@ -4360,7 +4330,7 @@ fu_util_security(FuUtil *self, gchar **values, GError **error)
 	}
 
 	/* print the "also" */
-	devices = fu_engine_get_devices(self->engine, error);
+	devices = fwupd_client_get_devices(self->client, self->cancellable, error);
 	if (devices == NULL)
 		return FALSE;
 	if (devices->len > 0) {
@@ -4493,7 +4463,7 @@ fu_util_esp_list(FuUtil *self, gchar **values, GError **error)
 static gboolean
 fu_util_modify_tag(FuUtil *self, gchar **values, gboolean enable, GError **error)
 {
-	g_autoptr(FuDevice) dev = NULL;
+	g_autoptr(FwupdDevice) dev = NULL;
 	const gchar *tag = enable ? "emulation-tag" : "~emulation-tag";
 
 	if (!fu_util_start_engine(self,
@@ -4642,7 +4612,7 @@ fu_util_switch_branch(FuUtil *self, gchar **values, GError **error)
 	g_autoptr(FwupdRelease) rel = NULL;
 	g_autoptr(GPtrArray) rels = NULL;
 	g_autoptr(GPtrArray) branches = g_ptr_array_new_with_free_func(g_free);
-	g_autoptr(FuDevice) dev = NULL;
+	g_autoptr(FwupdDevice) dev = NULL;
 
 	/* load engine */
 	if (!fu_util_start_engine(self,
@@ -4671,7 +4641,10 @@ fu_util_switch_branch(FuUtil *self, gchar **values, GError **error)
 	}
 
 	/* get all releases, including the alternate branch versions */
-	rels = fu_engine_get_releases(self->engine, self->request, fu_device_get_id(dev), error);
+	rels = fwupd_client_get_releases(self->client,
+					 fu_device_get_id(dev),
+					 self->cancellable,
+					 error);
 	if (rels == NULL)
 		return FALSE;
 
@@ -4984,7 +4957,7 @@ static gboolean
 fu_util_reboot_cleanup(FuUtil *self, gchar **values, GError **error)
 {
 	FuPlugin *plugin;
-	g_autoptr(FuDevice) device = NULL;
+	g_autoptr(FwupdDevice) device = NULL;
 
 	if (!fu_util_start_engine(self,
 				  FU_ENGINE_LOAD_FLAG_COLDPLUG |
@@ -5007,7 +4980,7 @@ fu_util_reboot_cleanup(FuUtil *self, gchar **values, GError **error)
 	plugin = fu_engine_get_plugin_by_name(self->engine, fu_device_get_plugin(device), error);
 	if (plugin == NULL)
 		return FALSE;
-	return fu_plugin_runner_reboot_cleanup(plugin, device, error);
+	return fu_plugin_runner_reboot_cleanup(plugin, FU_DEVICE(device), error);
 }
 
 static void
@@ -6271,6 +6244,165 @@ fu_util_print_error(FuUtil *self, const GError *error)
 	fu_console_print_full(self->console, FU_CONSOLE_PRINT_FLAG_STDERR, "%s\n", error->message);
 }
 
+static gboolean
+fu_util_sync_impl_connect(FwupdClient *client,
+			  gpointer user_data,
+			  GCancellable *cancellable,
+			  GError **error)
+{
+	FuUtil *self = (FuUtil *)user_data;
+	return fu_util_start_engine(
+	    self,
+	    FU_ENGINE_LOAD_FLAG_COLDPLUG | FU_ENGINE_LOAD_FLAG_EXTERNAL_PLUGINS |
+		FU_ENGINE_LOAD_FLAG_BUILTIN_PLUGINS | FU_ENGINE_LOAD_FLAG_PATH_STORE_DEFAULTS |
+		FU_ENGINE_LOAD_FLAG_HWINFO | FU_ENGINE_LOAD_FLAG_REMOTES |
+		FU_ENGINE_LOAD_FLAG_HISTORY,
+	    self->progress,
+	    error);
+}
+
+static GPtrArray *
+fu_util_sync_impl_get_devices(FwupdClient *client,
+			      gpointer user_data,
+			      GCancellable *cancellable,
+			      GError **error)
+{
+	FuUtil *self = (FuUtil *)user_data;
+	return fu_engine_get_devices(self->engine, error);
+}
+
+static FwupdDevice *
+fu_util_sync_impl_get_device_by_id(FwupdClient *client,
+				   const gchar *device_id,
+				   gpointer user_data,
+				   GCancellable *cancellable,
+				   GError **error)
+{
+	FuUtil *self = (FuUtil *)user_data;
+	return FWUPD_DEVICE(fu_engine_get_device(self->engine, device_id, error));
+}
+
+static GPtrArray *
+fu_util_sync_impl_get_devices_by_guid(FwupdClient *client,
+				      const gchar *guid,
+				      gpointer user_data,
+				      GCancellable *cancellable,
+				      GError **error)
+{
+	FuUtil *self = (FuUtil *)user_data;
+	return fu_engine_get_devices_by_guid(self->engine, guid, error);
+}
+
+static GPtrArray *
+fu_util_sync_impl_get_plugins(FwupdClient *client,
+			      gpointer user_data,
+			      GCancellable *cancellable,
+			      GError **error)
+{
+	FuUtil *self = (FuUtil *)user_data;
+	return g_ptr_array_ref(fu_engine_get_plugins(self->engine));
+}
+
+static GPtrArray *
+fu_util_sync_impl_get_history(FwupdClient *client,
+			      gpointer user_data,
+			      GCancellable *cancellable,
+			      GError **error)
+{
+	FuUtil *self = (FuUtil *)user_data;
+	return fu_engine_get_history(self->engine, error);
+}
+
+static GPtrArray *
+fu_util_sync_impl_get_releases(FwupdClient *client,
+			       const gchar *device_id,
+			       gpointer user_data,
+			       GCancellable *cancellable,
+			       GError **error)
+{
+	FuUtil *self = (FuUtil *)user_data;
+	return fu_engine_get_releases(self->engine, self->request, device_id, error);
+}
+
+static GPtrArray *
+fu_util_sync_impl_get_upgrades(FwupdClient *client,
+			       const gchar *device_id,
+			       gpointer user_data,
+			       GCancellable *cancellable,
+			       GError **error)
+{
+	FuUtil *self = (FuUtil *)user_data;
+	return fu_engine_get_upgrades(self->engine, self->request, device_id, error);
+}
+
+static GPtrArray *
+fu_util_sync_impl_get_remotes(FwupdClient *client,
+			      gpointer user_data,
+			      GCancellable *cancellable,
+			      GError **error)
+{
+	FuUtil *self = (FuUtil *)user_data;
+	return fu_engine_get_remotes(self->engine, error);
+}
+
+static FwupdRemote *
+fu_util_sync_impl_get_remote_by_id(FwupdClient *client,
+				   const gchar *remote_id,
+				   gpointer user_data,
+				   GCancellable *cancellable,
+				   GError **error)
+{
+	FuUtil *self = (FuUtil *)user_data;
+	return fu_engine_get_remote_by_id(self->engine, remote_id, error);
+}
+
+static GHashTable *
+fu_util_sync_impl_get_report_metadata(FwupdClient *client,
+				      gpointer user_data,
+				      GCancellable *cancellable,
+				      GError **error)
+{
+	FuUtil *self = (FuUtil *)user_data;
+	return fu_engine_get_report_metadata(self->engine, error);
+}
+
+static gboolean
+fu_util_sync_impl_modify_config(FwupdClient *client,
+				const gchar *section,
+				const gchar *key,
+				const gchar *value,
+				gpointer user_data,
+				GCancellable *cancellable,
+				GError **error)
+{
+	FuUtil *self = (FuUtil *)user_data;
+	return fu_engine_modify_config(self->engine, section, key, value, error);
+}
+
+static gboolean
+fu_util_sync_impl_modify_remote(FwupdClient *client,
+				const gchar *remote_id,
+				const gchar *key,
+				const gchar *value,
+				gpointer user_data,
+				GCancellable *cancellable,
+				GError **error)
+{
+	FuUtil *self = (FuUtil *)user_data;
+	return fu_engine_modify_remote(self->engine, remote_id, key, value, error);
+}
+
+static GPtrArray *
+fu_util_sync_impl_search(FwupdClient *client,
+			 const gchar *token,
+			 gpointer user_data,
+			 GCancellable *cancellable,
+			 GError **error)
+{
+	FuUtil *self = (FuUtil *)user_data;
+	return fu_engine_search(self->engine, token, error);
+}
+
 int
 main(int argc, char *argv[])
 { /* nocheck:lines */
@@ -6505,6 +6637,22 @@ main(int argc, char *argv[])
 	     _("Prefix for import and output files"),
 	     NULL},
 	    {NULL}};
+	static FwupdClientSyncImpl impl = {
+	    .connect = fu_util_sync_impl_connect,
+	    .get_devices = fu_util_sync_impl_get_devices,
+	    .get_devices_by_guid = fu_util_sync_impl_get_devices_by_guid,
+	    .get_device_by_id = fu_util_sync_impl_get_device_by_id,
+	    .get_history = fu_util_sync_impl_get_history,
+	    .get_releases = fu_util_sync_impl_get_releases,
+	    .get_upgrades = fu_util_sync_impl_get_upgrades,
+	    .get_plugins = fu_util_sync_impl_get_plugins,
+	    .get_remotes = fu_util_sync_impl_get_remotes,
+	    .get_remote_by_id = fu_util_sync_impl_get_remote_by_id,
+	    .get_report_metadata = fu_util_sync_impl_get_report_metadata,
+	    .modify_config = fu_util_sync_impl_modify_config,
+	    .modify_remote = fu_util_sync_impl_modify_remote,
+	    .search = fu_util_sync_impl_search,
+	};
 
 #ifdef _WIN32
 	/* workaround Windows setting the codepage to 1252 */
@@ -6531,6 +6679,7 @@ main(int argc, char *argv[])
 
 	/* used for monitoring and downloading */
 	self->client = fwupd_client_new();
+	fwupd_client_set_sync_impl(self->client, &impl, self, NULL);
 	fwupd_client_set_main_context(self->client, self->main_ctx);
 	fwupd_client_set_daemon_version(self->client, PACKAGE_VERSION);
 	fwupd_client_set_user_agent_for_package(self->client, "fwupdtool", PACKAGE_VERSION);

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -5252,6 +5252,95 @@ fu_util_cancelled_cb(GCancellable *cancellable, gpointer user_data)
 }
 
 static void
+fu_util_device_added_cb(FwupdClient *client, FwupdDevice *device, gpointer user_data)
+{
+	FuUtil *self = (FuUtil *)user_data;
+	g_autofree gchar *tmp = NULL;
+
+	if (self->as_json)
+		return;
+
+	tmp = fu_util_device_to_string(self->client, device, 0);
+
+	/* TRANSLATORS: this is when a device is hotplugged */
+	fu_console_print(self->console, "%s\n%s", _("Device added:"), tmp);
+}
+
+static void
+fu_util_device_removed_cb(FwupdClient *client, FwupdDevice *device, gpointer user_data)
+{
+	FuUtil *self = (FuUtil *)user_data;
+	g_autofree gchar *tmp = NULL;
+
+	if (self->as_json)
+		return;
+
+	tmp = fu_util_device_to_string(self->client, device, 0);
+
+	/* TRANSLATORS: this is when a device is hotplugged */
+	fu_console_print(self->console, "%s\n%s", _("Device removed:"), tmp);
+}
+
+static void
+fu_util_device_changed_cb(FwupdClient *client, FwupdDevice *device, gpointer user_data)
+{
+	FuUtil *self = (FuUtil *)user_data;
+	g_autofree gchar *tmp = NULL;
+
+	if (self->as_json)
+		return;
+
+	tmp = fu_util_device_to_string(self->client, device, 0);
+
+	/* TRANSLATORS: this is when a device has been updated */
+	fu_console_print(self->console, "%s\n%s", _("Device changed:"), tmp);
+}
+
+static void
+fu_util_changed_cb(FwupdClient *client, gpointer user_data)
+{
+	FuUtil *self = (FuUtil *)user_data;
+
+	if (self->as_json)
+		return;
+
+	/* TRANSLATORS: this is when the daemon state changes */
+	fu_console_print_literal(self->console, _("Changed"));
+}
+
+static gboolean
+fu_util_monitor(FuUtil *self, gchar **values, GError **error)
+{
+	/* get all the devices */
+	if (!fwupd_client_connect(self->client, self->cancellable, error))
+		return FALSE;
+
+	/* watch for any hotplugged device */
+	g_signal_connect(FWUPD_CLIENT(self->client),
+			 "changed",
+			 G_CALLBACK(fu_util_changed_cb),
+			 self);
+	g_signal_connect(FWUPD_CLIENT(self->client),
+			 "device-added",
+			 G_CALLBACK(fu_util_device_added_cb),
+			 self);
+	g_signal_connect(FWUPD_CLIENT(self->client),
+			 "device-removed",
+			 G_CALLBACK(fu_util_device_removed_cb),
+			 self);
+	g_signal_connect(FWUPD_CLIENT(self->client),
+			 "device-changed",
+			 G_CALLBACK(fu_util_device_changed_cb),
+			 self);
+	g_signal_connect(G_CANCELLABLE(self->cancellable),
+			 "cancelled",
+			 G_CALLBACK(fu_util_cancelled_cb),
+			 self);
+	g_main_loop_run(self->loop);
+	return TRUE;
+}
+
+static void
 fu_util_print_error(FuUtil *self, const GError *error)
 {
 	if (self->as_json) {
@@ -5893,6 +5982,12 @@ main(int argc, char *argv[])
 			      /* TRANSLATORS: command description */
 			      _("Return all the hardware IDs for the machine"),
 			      fu_util_hwids);
+	fu_util_cmd_array_add(cmd_array,
+			      "monitor",
+			      NULL,
+			      /* TRANSLATORS: command description */
+			      _("Monitor the daemon for events"),
+			      fu_util_monitor);
 
 	/* do stuff on ctrl+c */
 	self->cancellable = g_cancellable_new();

--- a/src/fwupdmgr.md
+++ b/src/fwupdmgr.md
@@ -215,6 +215,8 @@ See `man fwupd.conf` for the full list of variables.
 **hwids**: Return all the hardware IDs for the machine.
 These GUIDs are sometimes called CHIDs when using Microsoft Windows, and the values returned by fwupd should also match those from `ComputerHardwareIds.exe`.
 
+**monitor**: Monitor the daemon for events.
+
 ## EXIT STATUS
 
 Commands that successfully execute will return "0", with generic failure as "1".


### PR DESCRIPTION
In the short-term we can use this in fwupdtool to avoid the daemon round-trip, and in the medium term we can share an implementation for the CLI action.

Implement `->connect()` and `->get_plugins()` as a simple demo.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
