### PR TITLE
trivial: ci: Merge duplicated dependencies

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -1195,6 +1195,9 @@
       <package variant="x86_64" />
       <package variant="aarch64" />
     </distro>
+    <distro id="freebsd">
+      <package>py312-pygobject</package>
+    </distro>
   </dependency>
   <dependency id="python3-gi-cairo">
     <distro id="arch">
@@ -1242,12 +1245,19 @@
     </distro>
   </dependency>
   <dependency id="python3-jinja2">
+    <distro id="arch">
+      <package variant="x86_64">python-jinja</package>
+    </distro>
     <distro id="centos">
       <package variant="x86_64" />
     </distro>
     <distro id="fedora">
       <package variant="x86_64" />
+      <package variant="aarch64" />
       <package variant="mingw64" />
+    </distro>
+    <distro id="debian">
+      <control />
     </distro>
     <distro id="ubuntu">
       <package variant="x86_64" />
@@ -1310,37 +1320,6 @@
     <distro id="ubuntu">
       <package variant="x86_64" />
       <package variant="aarch64" />
-    </distro>
-  </dependency>
-  <dependency id="python3-jinja2">
-    <distro id="debian">
-      <control />
-    </distro>
-    <distro id="centos">
-      <package variant="x86_64" />
-    </distro>
-    <distro id="fedora">
-      <package variant="x86_64" />
-      <package variant="aarch64" />
-    </distro>
-    <distro id="ubuntu">
-      <package variant="x86_64" />
-      <package variant="aarch64" />
-    </distro>
-  </dependency>
-  <dependency id="python3-gobject">
-    <distro id="arch">
-      <package variant="x86_64">python-gobject</package>
-    </distro>
-    <distro id="centos">
-      <package variant="x86_64" />
-    </distro>
-    <distro id="fedora">
-      <package variant="x86_64" />
-      <package variant="aarch64" />
-    </distro>
-    <distro id="freebsd">
-      <package>py312-pygobject</package>
     </distro>
   </dependency>
   <dependency id="python3-flask">


### PR DESCRIPTION
In `contrib/ci/dependencies.xml`, there are two entries for `python3-jinja2` as well as the two competing entries `python3-gi` and `python3-gobject` since commit b87fa41ff2d2d42b11d3493a877777f31fd4c681.
It is better to merge these entries to improve maintainability.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
