### PR TITLE
trivial: Do not pass filenames to the run-tests pre-push hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,6 +103,7 @@ repos:
         name: run tests before pushing
         language: system
         entry: "test-fwupd"
+        pass_filenames: false
         stages: [pre-push]
       - id: clang-format
         name: clang-format


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

---

pre-commit appends the filenames changed in the pushed range to the hook command by default. Since commit fd9243b1f3 ("contrib: Use meson test in test-venv.sh and pass args to it"), test-venv.sh forwards its arguments to `meson test` as test names. Pushing an ordinary source-file change therefore fails before running a test:

```
ERROR: *:plugins/foo/fu-plugin.c test name does not match any test
```

Run the hook without filenames so the full test suite runs as intended.

Reproduce: `pre-commit run run-tests --hook-stage pre-push --files src/fu-main.c` — fails instantly as above without this change; with it, the full suite runs (143/143 OK locally).
