### PR TITLE
trivial: ci: Update pkg-config dependency

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -959,18 +959,24 @@
     </distro>
   </dependency>
   <dependency id="pkg-config">
+    <distro id="arch">
+      <package variant="x86_64">pkgconf</package>
+    </distro>
     <distro id="debian">
       <control />
+      <package>pkgconf</package>
     </distro>
     <distro id="ubuntu">
       <control />
-      <package variant="x86_64" />
-      <package variant="aarch64" />
+      <package variant="x86_64">pkgconf</package>
+      <package variant="aarch64">pkgconf</package>
     </distro>
     <distro id="centos">
-      <package variant="x86_64" />
+      <package variant="x86_64">pkgconf-pkg-config</package>
     </distro>
     <distro id="fedora">
+      <package variant="x86_64">pkgconf-pkg-config</package>
+      <package variant="aarch64">pkgconf-pkg-config</package>
       <package variant="mingw64">mingw64-pkg-config</package>
     </distro>
     <distro id="freebsd">


### PR DESCRIPTION
All distributions have migrated to use `pkgconf` in favor of `pkg-config` years ago.  It also features pkg-config compatibility.  It might be good to update the package names now before such a transitional package `pkg-config` is going to be removed from a distribution.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
