### PR TITLE
ccgx: reject out-of-range device mode before indexing versions

### DIFF
--- a/plugins/ccgx/fu-ccgx-hpi-device.c
+++ b/plugins/ccgx/fu-ccgx-hpi-device.c
@@ -1484,6 +1484,14 @@ fu_ccgx_hpi_device_setup(FuDevice *device, GError **error)
 	self->hpi_addrsz = mode & 0x80 ? 2 : 1;
 	self->num_ports = (mode >> 2) & 0x03 ? 2 : 1;
 	self->fw_mode = (FuCcgxFwMode)(mode & 0x03);
+	if (self->fw_mode >= FU_CCGX_FW_MODE_LAST) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "invalid device mode 0x%x",
+			    (guint)self->fw_mode);
+		return FALSE;
+	}
 	fu_device_set_logical_id(device, fu_ccgx_fw_mode_to_string(self->fw_mode));
 	fu_device_add_instance_str(device, "MODE", fu_device_get_logical_id(device));
 


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

**Out-of-range device mode indexes the version array**

The HPI device-mode byte is masked to `fw_mode = mode & 0x03`, so it spans 0-3, yet only three modes are defined and `versions[FU_CCGX_FW_MODE_LAST]` holds three entries; the reserved value 3 slips past the lone `!= FU_CCGX_FW_MODE_BOOT` check and `versions[fw_mode]` then reads one element past the array, with the stray value feeding the `APP` GUID and the device version. Rejecting a mode outside the enum right after the read keeps both later reads in bounds, mirroring how `fu_ccgx_hpi_device_get_metadata_offset()` already treats an unknown mode.
