### PR TITLE
Detach the FuInputStream hierarchy from GInputStream

### DIFF
--- a/contrib/ci/check-source.py
+++ b/contrib/ci/check-source.py
@@ -859,6 +859,9 @@ class Checker:
                 "~g_file_input_stream_*": "Use fu_file_input_stream_*() instead",
                 "g_zlib_compressor_new": "Use fu_compressor_stream_new_compress() instead",
                 "g_zlib_decompressor_new": "Use fu_compressor_stream_new_decompress() instead",
+                "g_input_stream_read_all": "Use fu_input_stream_read_all() instead",
+                "g_input_stream_read_bytes": "Use fu_input_stream_read_bytes() instead",
+                "g_input_stream_read": "Use fu_input_stream_read() instead",
             }.items():
                 idx = node.tokens.find_fuzzy([token, "("])
                 if idx != -1:

--- a/libfwupdplugin/fu-composite-input-stream-test.c
+++ b/libfwupdplugin/fu-composite-input-stream-test.c
@@ -114,7 +114,7 @@ fu_composite_input_stream_func(void)
 	ret = g_seekable_seek(G_SEEKABLE(composite_stream), 0x1, G_SEEK_SET, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	rc = g_input_stream_read(G_INPUT_STREAM(composite_stream), buf, 2, NULL, &error);
+	rc = fu_input_stream_read(composite_stream, buf, 2, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 1);
 	g_assert_cmpint(buf[0], ==, 'b');
@@ -124,7 +124,7 @@ fu_composite_input_stream_func(void)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(composite_stream)), ==, 0x7);
-	rc = g_input_stream_read(G_INPUT_STREAM(composite_stream), buf, sizeof(buf), NULL, &error);
+	rc = fu_input_stream_read(composite_stream, buf, sizeof(buf), NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 
@@ -133,7 +133,7 @@ fu_composite_input_stream_func(void)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(composite_stream)), ==, 0x7);
-	rc = g_input_stream_read(G_INPUT_STREAM(composite_stream), buf, sizeof(buf), NULL, &error);
+	rc = fu_input_stream_read(composite_stream, buf, sizeof(buf), NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 
@@ -142,7 +142,7 @@ fu_composite_input_stream_func(void)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(composite_stream)), ==, 0x6);
-	rc = g_input_stream_read(G_INPUT_STREAM(composite_stream), buf, sizeof(buf), NULL, &error);
+	rc = fu_input_stream_read(composite_stream, buf, sizeof(buf), NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 1);
 	g_assert_cmpint(buf[0], ==, 'g');

--- a/libfwupdplugin/fu-composite-input-stream.c
+++ b/libfwupdplugin/fu-composite-input-stream.c
@@ -49,17 +49,13 @@ struct _FuCompositeInputStream {
 };
 
 static void
-fu_composite_input_stream_seekable_iface_init(GSeekableIface *iface);
-static void
 fu_composite_input_stream_codec_iface_init(FwupdCodecInterface *iface);
 
 G_DEFINE_TYPE_WITH_CODE(FuCompositeInputStream,
 			fu_composite_input_stream,
 			FU_TYPE_INPUT_STREAM,
-			G_IMPLEMENT_INTERFACE(G_TYPE_SEEKABLE,
-					      fu_composite_input_stream_seekable_iface_init)
-			    G_IMPLEMENT_INTERFACE(FWUPD_TYPE_CODEC,
-						  fu_composite_input_stream_codec_iface_init))
+			G_IMPLEMENT_INTERFACE(FWUPD_TYPE_CODEC,
+					      fu_composite_input_stream_codec_iface_init))
 
 static void
 fu_composite_input_stream_add_string(FwupdCodec *codec, guint idt, GString *str)
@@ -221,15 +217,15 @@ fu_composite_input_stream_add_stream(FuCompositeInputStream *self,
 }
 
 static goffset
-fu_composite_input_stream_tell(GSeekable *seekable)
+fu_composite_input_stream_tell(FuInputStream *stream)
 {
-	FuCompositeInputStream *self = FU_COMPOSITE_INPUT_STREAM(seekable);
+	FuCompositeInputStream *self = FU_COMPOSITE_INPUT_STREAM(stream);
 	g_return_val_if_fail(FU_IS_COMPOSITE_INPUT_STREAM(self), -1);
 	return self->pos;
 }
 
 static gboolean
-fu_composite_input_stream_can_seek(GSeekable *seekable)
+fu_composite_input_stream_can_seek(FuInputStream *stream)
 {
 	return TRUE;
 }
@@ -254,13 +250,13 @@ fu_composite_input_stream_get_item_for_offset(FuCompositeInputStream *self,
 }
 
 static gboolean
-fu_composite_input_stream_seek(GSeekable *seekable,
+fu_composite_input_stream_seek(FuInputStream *stream,
 			       goffset offset,
 			       GSeekType type,
 			       GCancellable *cancellable,
 			       GError **error)
 {
-	FuCompositeInputStream *self = FU_COMPOSITE_INPUT_STREAM(seekable);
+	FuCompositeInputStream *self = FU_COMPOSITE_INPUT_STREAM(stream);
 
 	g_return_val_if_fail(FU_IS_COMPOSITE_INPUT_STREAM(self), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
@@ -279,35 +275,6 @@ fu_composite_input_stream_seek(GSeekable *seekable,
 	return TRUE;
 }
 
-static gboolean
-fu_composite_input_stream_can_truncate(GSeekable *seekable)
-{
-	return FALSE;
-}
-
-static gboolean
-fu_composite_input_stream_truncate(GSeekable *seekable,
-				   goffset offset,
-				   GCancellable *cancellable,
-				   GError **error)
-{
-	g_set_error_literal(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_NOT_SUPPORTED,
-			    "cannot truncate FuCompositeInputStream");
-	return FALSE;
-}
-
-static void
-fu_composite_input_stream_seekable_iface_init(GSeekableIface *iface)
-{
-	iface->tell = fu_composite_input_stream_tell;
-	iface->can_seek = fu_composite_input_stream_can_seek;
-	iface->seek = fu_composite_input_stream_seek;
-	iface->can_truncate = fu_composite_input_stream_can_truncate;
-	iface->truncate_fn = fu_composite_input_stream_truncate;
-}
-
 /**
  * fu_composite_input_stream_new:
  *
@@ -324,11 +291,11 @@ fu_composite_input_stream_new(void)
 }
 
 static gssize
-fu_composite_input_stream_read(GInputStream *stream,
-			       void *buffer,
-			       gsize count,
-			       GCancellable *cancellable,
-			       GError **error)
+fu_composite_input_stream_read_fn(FuInputStream *stream,
+				  void *buffer,
+				  gsize count,
+				  GCancellable *cancellable,
+				  GError **error)
 {
 	FuCompositeInputStream *self = FU_COMPOSITE_INPUT_STREAM(stream);
 	FuCompositeInputStreamItem *item;
@@ -376,8 +343,11 @@ static void
 fu_composite_input_stream_class_init(FuCompositeInputStreamClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	GInputStreamClass *istream_class = G_INPUT_STREAM_CLASS(klass);
-	istream_class->read_fn = fu_composite_input_stream_read;
+	FuInputStreamClass *istream_class = FU_INPUT_STREAM_CLASS(klass);
+	istream_class->read_fn = fu_composite_input_stream_read_fn;
+	istream_class->tell = fu_composite_input_stream_tell;
+	istream_class->can_seek = fu_composite_input_stream_can_seek;
+	istream_class->seek = fu_composite_input_stream_seek;
 	object_class->finalize = fu_composite_input_stream_finalize;
 }
 

--- a/libfwupdplugin/fu-composite-input-stream.c
+++ b/libfwupdplugin/fu-composite-input-stream.c
@@ -350,11 +350,11 @@ fu_composite_input_stream_read(GInputStream *stream,
 			return -1;
 		self->last_item = item;
 	}
-	rc = g_input_stream_read(G_INPUT_STREAM(item->partial_stream),
-				 buffer,
-				 count,
-				 cancellable,
-				 error);
+	rc = fu_input_stream_read(FU_INPUT_STREAM(item->partial_stream),
+				  buffer,
+				  count,
+				  cancellable,
+				  error);
 	if (rc < 0)
 		return rc;
 

--- a/libfwupdplugin/fu-compressor-stream-test.c
+++ b/libfwupdplugin/fu-compressor-stream-test.c
@@ -63,7 +63,11 @@ fu_test_decompress_gconverter(GBytes *blob, FuCompressorFormat format, GError **
 	converter_stream = g_converter_input_stream_new(base, conv);
 
 	while (TRUE) {
-		rc = g_input_stream_read(converter_stream, tmp, sizeof(tmp), NULL, error);
+		rc = g_input_stream_read(converter_stream, /* nocheck:blocked */
+					 tmp,
+					 sizeof(tmp),
+					 NULL,
+					 error);
 		if (rc < 0)
 			return NULL;
 		if (rc == 0)

--- a/libfwupdplugin/fu-compressor-stream-test.c
+++ b/libfwupdplugin/fu-compressor-stream-test.c
@@ -186,7 +186,7 @@ fu_compressor_stream_type_func(void)
 
 	g_assert_no_error(error);
 	g_assert_nonnull(stream);
-	g_assert_true(G_IS_INPUT_STREAM(stream));
+	g_assert_false(G_IS_INPUT_STREAM(stream)); /* nocheck:blocked */
 	g_assert_true(G_IS_SEEKABLE(stream));
 	g_assert_true(FU_IS_INPUT_STREAM(stream));
 	g_assert_true(FU_IS_STREAM_INPUT_STREAM(stream));

--- a/libfwupdplugin/fu-compressor-stream-test.c
+++ b/libfwupdplugin/fu-compressor-stream-test.c
@@ -213,14 +213,14 @@ fu_compressor_stream_read_func(void)
 
 	orig_data = g_bytes_get_data(original, &orig_sz);
 	for (gsize i = 0; i < orig_sz; i++) {
-		rc = g_input_stream_read(G_INPUT_STREAM(dstream), buf, 1, NULL, &error);
+		rc = fu_input_stream_read(dstream, buf, 1, NULL, &error);
 		g_assert_no_error(error);
 		g_assert_cmpint(rc, ==, 1);
 		g_assert_cmpint(buf[0], ==, orig_data[i]);
 	}
 
 	/* EOF */
-	rc = g_input_stream_read(G_INPUT_STREAM(dstream), buf, 1, NULL, &error);
+	rc = fu_input_stream_read(dstream, buf, 1, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 }
@@ -240,7 +240,7 @@ fu_compressor_stream_decompress_invalid_func(void)
 	g_assert_no_error(error);
 	g_assert_nonnull(dstream);
 
-	rc = g_input_stream_read(G_INPUT_STREAM(dstream), buf, sizeof(buf), NULL, &error);
+	rc = fu_input_stream_read(dstream, buf, sizeof(buf), NULL, &error);
 	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA);
 	g_assert_cmpint(rc, ==, -1);
 }
@@ -317,7 +317,7 @@ fu_compressor_stream_empty_func(void)
 	g_assert_no_error(error);
 	g_assert_nonnull(dstream);
 
-	rc = g_input_stream_read(G_INPUT_STREAM(dstream), buf, sizeof(buf), NULL, &error);
+	rc = fu_input_stream_read(dstream, buf, sizeof(buf), NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 }
@@ -343,7 +343,7 @@ fu_compressor_stream_format_mismatch_func(void)
 	g_assert_no_error(error);
 	g_assert_nonnull(dstream);
 
-	rc = g_input_stream_read(G_INPUT_STREAM(dstream), buf, sizeof(buf), NULL, &error);
+	rc = fu_input_stream_read(dstream, buf, sizeof(buf), NULL, &error);
 	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA);
 	g_assert_cmpint(rc, ==, -1);
 }
@@ -390,7 +390,7 @@ fu_compressor_stream_no_close_source_func(void)
 
 	/* the source should still be readable after the compressor is finalized */
 	g_seekable_seek(G_SEEKABLE(source), 0, G_SEEK_SET, NULL, NULL);
-	rc = g_input_stream_read(G_INPUT_STREAM(source), buf, 4, NULL, &error);
+	rc = fu_input_stream_read(source, buf, 4, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 4);
 	g_assert_cmpint(buf[0], ==, 'A');

--- a/libfwupdplugin/fu-compressor-stream.c
+++ b/libfwupdplugin/fu-compressor-stream.c
@@ -9,6 +9,7 @@
 #include "config.h"
 
 #include "fu-compressor-stream.h"
+#include "fu-input-stream.h"
 #include "fu-stream-input-stream-private.h"
 
 /**
@@ -77,6 +78,7 @@ fu_compressor_stream_new_decompress(FuInputStream *source,
 				    GError **error)
 {
 	g_autoptr(FuCompressorStream) self = NULL;
+	g_autoptr(GInputStream) g_source = NULL; /* nocheck:blocked */
 
 	g_return_val_if_fail(FU_IS_INPUT_STREAM(source), NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
@@ -85,7 +87,9 @@ fu_compressor_stream_new_decompress(FuInputStream *source,
 
 	self->conv = G_CONVERTER(g_zlib_decompressor_new(
 	    fu_compressor_stream_format_to_glib(format))); /* nocheck:blocked */
-	self->converter_stream = g_converter_input_stream_new(G_INPUT_STREAM(source), self->conv);
+
+	g_source = fu_input_stream_as_g_input_stream(source);
+	self->converter_stream = g_converter_input_stream_new(g_source, self->conv);
 	g_filter_input_stream_set_close_base_stream(G_FILTER_INPUT_STREAM(self->converter_stream),
 						    FALSE);
 	fu_stream_input_stream_set_base_stream(FU_STREAM_INPUT_STREAM(self),
@@ -110,6 +114,7 @@ FuInputStream *
 fu_compressor_stream_new_compress(FuInputStream *source, FuCompressorFormat format, GError **error)
 {
 	g_autoptr(FuCompressorStream) self = NULL;
+	g_autoptr(GInputStream) g_source = NULL; /* nocheck:blocked */
 
 	g_return_val_if_fail(FU_IS_INPUT_STREAM(source), NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
@@ -118,7 +123,8 @@ fu_compressor_stream_new_compress(FuInputStream *source, FuCompressorFormat form
 
 	self->conv = G_CONVERTER(g_zlib_compressor_new(fu_compressor_stream_format_to_glib(format),
 						       -1)); /* nocheck:blocked */
-	self->converter_stream = g_converter_input_stream_new(G_INPUT_STREAM(source), self->conv);
+	g_source = fu_input_stream_as_g_input_stream(source);
+	self->converter_stream = g_converter_input_stream_new(g_source, self->conv);
 	g_filter_input_stream_set_close_base_stream(G_FILTER_INPUT_STREAM(self->converter_stream),
 						    FALSE);
 	fu_stream_input_stream_set_base_stream(FU_STREAM_INPUT_STREAM(self),

--- a/libfwupdplugin/fu-efi-lz77-decompressor.c
+++ b/libfwupdplugin/fu-efi-lz77-decompressor.c
@@ -96,11 +96,11 @@ fu_efi_lz77_decompressor_read_source_bits(FuEfiLz77DecompressHelper *helper,
 		helper->bit_buf |= (guint32)(((guint64)helper->sub_bit_buf) << number_of_bits);
 
 		/* get 1 byte into sub_bit_buf */
-		rc = g_input_stream_read(G_INPUT_STREAM(helper->stream),
-					 &sub_bit_buf,
-					 sizeof(sub_bit_buf),
-					 NULL,
-					 error);
+		rc = fu_input_stream_read(helper->stream,
+					  &sub_bit_buf,
+					  sizeof(sub_bit_buf),
+					  NULL,
+					  error);
 		if (rc < 0)
 			return FALSE;
 		if (rc == 0) {

--- a/libfwupdplugin/fu-file-input-stream.c
+++ b/libfwupdplugin/fu-file-input-stream.c
@@ -84,30 +84,38 @@ fu_file_input_stream_from_file(GFile *file, GCancellable *cancellable, GError **
 }
 
 /**
- * fu_file_input_stream_query_info:
+ * fu_file_input_stream_get_file_size:
  * @stream: a #FuFileInputStream
- * @attributes: a file attribute query string
  * @cancellable: (nullable): optional #GCancellable
  * @error: (nullable): optional return location for an error
  *
- * Queries a file input stream for the given @attributes.
+ * Return the size of the file, in bytes. Returns zero if an error
+ * occurs, a caller that needs to distinguish between zero-sized
+ * files and zero-means-error must provide a GError.
  *
- * Returns: (transfer full): a #GFileInfo, or %NULL on error
+ * Returns: The file size in bytes or zero on error
  *
  * Since: 2.1.7
  **/
-GFileInfo *
-fu_file_input_stream_query_info(FuFileInputStream *stream,
-				const gchar *attributes,
-				GCancellable *cancellable,
-				GError **error)
+guint64
+fu_file_input_stream_get_file_size(FuFileInputStream *stream,
+				   GCancellable *cancellable,
+				   GError **error)
 {
-	g_return_val_if_fail(FU_IS_FILE_INPUT_STREAM(stream), NULL);
-	g_return_val_if_fail(attributes != NULL, NULL);
-	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
-	return g_file_input_stream_query_info(/* nocheck:blocked */
+	g_autoptr(GFileInfo) info = NULL;
+
+	g_return_val_if_fail(FU_IS_FILE_INPUT_STREAM(stream), 0);
+	g_return_val_if_fail(error == NULL || *error == NULL, 0);
+
+	info = g_file_input_stream_query_info(/* nocheck:blocked */
 					      stream->file_stream,
-					      attributes,
+					      G_FILE_ATTRIBUTE_STANDARD_SIZE,
 					      cancellable,
 					      error);
+	if (info == NULL) {
+		fwupd_error_convert(error);
+		return 0;
+	}
+
+	return g_file_info_get_attribute_uint64(info, G_FILE_ATTRIBUTE_STANDARD_SIZE);
 }

--- a/libfwupdplugin/fu-file-input-stream.c
+++ b/libfwupdplugin/fu-file-input-stream.c
@@ -9,6 +9,43 @@
 #include "config.h"
 
 #include "fu-file-input-stream.h"
+#include "fu-stream-input-stream-private.h"
+
+/**
+ * FuFileInputStream:
+ *
+ * An input stream that replaces #GFileInputStream, providing file-specific
+ * operations within the #FuInputStream type hierarchy. This implementation
+ * is a drop-in replacement for #GFileInputStream for the needs
+ * within fwupd.
+ */
+
+struct _FuFileInputStream {
+	FuStreamInputStream parent_instance;
+	GFileInputStream *file_stream; /* nocheck:blocked */
+};
+
+G_DEFINE_TYPE(FuFileInputStream, fu_file_input_stream, FU_TYPE_STREAM_INPUT_STREAM)
+
+static void
+fu_file_input_stream_finalize(GObject *object)
+{
+	FuFileInputStream *self = FU_FILE_INPUT_STREAM(object);
+	g_clear_object(&self->file_stream);
+	G_OBJECT_CLASS(fu_file_input_stream_parent_class)->finalize(object);
+}
+
+static void
+fu_file_input_stream_class_init(FuFileInputStreamClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	object_class->finalize = fu_file_input_stream_finalize;
+}
+
+static void
+fu_file_input_stream_init(FuFileInputStream *self)
+{
+}
 
 /**
  * fu_file_input_stream_from_file:
@@ -26,9 +63,24 @@
 FuFileInputStream *
 fu_file_input_stream_from_file(GFile *file, GCancellable *cancellable, GError **error)
 {
+	g_autoptr(GFileInputStream) file_stream = NULL; /* nocheck:blocked */
+	g_autoptr(FuFileInputStream) self = NULL;
+
 	g_return_val_if_fail(G_IS_FILE(file), NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
-	return g_file_read(file, cancellable, error); /* nocheck:blocked */
+
+	file_stream = g_file_read(file, cancellable, error); /* nocheck:blocked */
+	if (file_stream == NULL) {
+		fwupd_error_convert(error);
+		return NULL;
+	}
+
+	self = g_object_new(FU_TYPE_FILE_INPUT_STREAM, NULL);
+	fu_stream_input_stream_set_base_stream(FU_STREAM_INPUT_STREAM(self),
+					       G_INPUT_STREAM(file_stream));
+	self->file_stream = g_object_ref(file_stream);
+
+	return g_steal_pointer(&self);
 }
 
 /**
@@ -53,7 +105,8 @@ fu_file_input_stream_query_info(FuFileInputStream *stream,
 	g_return_val_if_fail(FU_IS_FILE_INPUT_STREAM(stream), NULL);
 	g_return_val_if_fail(attributes != NULL, NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
-	return g_file_input_stream_query_info(G_FILE_INPUT_STREAM(stream), /* nocheck:blocked */
+	return g_file_input_stream_query_info(/* nocheck:blocked */
+					      stream->file_stream,
 					      attributes,
 					      cancellable,
 					      error);

--- a/libfwupdplugin/fu-file-input-stream.h
+++ b/libfwupdplugin/fu-file-input-stream.h
@@ -6,16 +6,14 @@
 
 #pragma once
 
-#include "fu-input-stream.h"
+#include "fu-stream-input-stream.h"
 
-typedef GFileInputStream FuFileInputStream;	      /* nocheck:blocked */
-typedef GFileInputStreamClass FuFileInputStreamClass; /* nocheck:blocked */
-
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuFileInputStream, g_object_unref)   /* nocheck:blocked */
-#define FU_FILE_INPUT_STREAM(o)	      G_FILE_INPUT_STREAM(o)	   /* nocheck:blocked */
-#define FU_TYPE_FILE_INPUT_STREAM     G_TYPE_FILE_INPUT_STREAM	   /* nocheck:blocked */
-#define FU_IS_FILE_INPUT_STREAM(o)    G_IS_FILE_INPUT_STREAM(o)	   /* nocheck:blocked */
-#define FU_FILE_INPUT_STREAM_CLASS(o) G_FILE_INPUT_STREAM_CLASS(o) /* nocheck:blocked */
+#define FU_TYPE_FILE_INPUT_STREAM (fu_file_input_stream_get_type())
+G_DECLARE_FINAL_TYPE(FuFileInputStream,
+		     fu_file_input_stream,
+		     FU,
+		     FILE_INPUT_STREAM,
+		     FuStreamInputStream)
 
 FuFileInputStream *
 fu_file_input_stream_from_file(GFile *file,

--- a/libfwupdplugin/fu-file-input-stream.h
+++ b/libfwupdplugin/fu-file-input-stream.h
@@ -19,8 +19,7 @@ FuFileInputStream *
 fu_file_input_stream_from_file(GFile *file,
 			       GCancellable *cancellable,
 			       GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1);
-GFileInfo *
-fu_file_input_stream_query_info(FuFileInputStream *stream,
-				const gchar *attributes,
-				GCancellable *cancellable,
-				GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
+guint64
+fu_file_input_stream_get_file_size(FuFileInputStream *stream,
+				   GCancellable *cancellable,
+				   GError **error) G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-ginput-stream-adapter.c
+++ b/libfwupdplugin/fu-ginput-stream-adapter.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#define G_LOG_DOMAIN "FuGInputStreamAdapter"
+
+#include "config.h"
+
+#include "fu-input-stream.h"
+
+/**
+ * FuGInputStreamAdapter:
+ *
+ * A #GInputStream subclass that wraps an #FuInputStream, bridging
+ * fwupd's stream abstraction back to the GLib #GInputStream type
+ * hierarchy for use with external APIs.
+ */
+
+typedef struct {
+	GInputStream parent_instance; /* nocheck:blocked */
+	FuInputStream *fu_stream;
+} FuGInputStreamAdapter;
+
+typedef struct {
+	GInputStreamClass parent_class; /* nocheck:blocked */
+} FuGInputStreamAdapterClass;
+
+GType
+fu_ginput_stream_adapter_get_type(void);
+
+static void
+fu_ginput_stream_adapter_seekable_iface_init(GSeekableIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE(FuGInputStreamAdapter,
+			fu_ginput_stream_adapter,
+			G_TYPE_INPUT_STREAM, /* nocheck:blocked */
+			G_IMPLEMENT_INTERFACE(G_TYPE_SEEKABLE,
+					      fu_ginput_stream_adapter_seekable_iface_init))
+
+static gssize
+fu_ginput_stream_adapter_read_fn(GInputStream *stream, /* nocheck:blocked */
+				 void *buffer,
+				 gsize count,
+				 GCancellable *cancellable,
+				 GError **error)
+{
+	FuGInputStreamAdapter *self = (FuGInputStreamAdapter *)stream;
+	return fu_input_stream_read(self->fu_stream, buffer, count, cancellable, error);
+}
+
+static goffset
+fu_ginput_stream_adapter_tell(GSeekable *seekable)
+{
+	FuGInputStreamAdapter *self = (FuGInputStreamAdapter *)seekable;
+	return g_seekable_tell(G_SEEKABLE(self->fu_stream));
+}
+
+static gboolean
+fu_ginput_stream_adapter_can_seek(GSeekable *seekable)
+{
+	FuGInputStreamAdapter *self = (FuGInputStreamAdapter *)seekable;
+	return g_seekable_can_seek(G_SEEKABLE(self->fu_stream));
+}
+
+static gboolean
+fu_ginput_stream_adapter_seek(GSeekable *seekable,
+			      goffset offset,
+			      GSeekType type,
+			      GCancellable *cancellable,
+			      GError **error)
+{
+	FuGInputStreamAdapter *self = (FuGInputStreamAdapter *)seekable;
+	return g_seekable_seek(G_SEEKABLE(self->fu_stream), offset, type, cancellable, error);
+}
+
+static gboolean
+fu_ginput_stream_adapter_can_truncate(GSeekable *seekable)
+{
+	return FALSE;
+}
+
+static gboolean
+fu_ginput_stream_adapter_truncate(GSeekable *seekable,
+				  goffset offset,
+				  GCancellable *cancellable,
+				  GError **error)
+{
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "cannot truncate");
+	return FALSE;
+}
+
+static void
+fu_ginput_stream_adapter_seekable_iface_init(GSeekableIface *iface)
+{
+	iface->tell = fu_ginput_stream_adapter_tell;
+	iface->can_seek = fu_ginput_stream_adapter_can_seek;
+	iface->seek = fu_ginput_stream_adapter_seek;
+	iface->can_truncate = fu_ginput_stream_adapter_can_truncate;
+	iface->truncate_fn = fu_ginput_stream_adapter_truncate;
+}
+
+static void
+fu_ginput_stream_adapter_finalize(GObject *object)
+{
+	FuGInputStreamAdapter *self = (FuGInputStreamAdapter *)object;
+	g_clear_object(&self->fu_stream);
+	G_OBJECT_CLASS(fu_ginput_stream_adapter_parent_class)->finalize(object);
+}
+
+static void
+fu_ginput_stream_adapter_class_init(FuGInputStreamAdapterClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	GInputStreamClass *istream_class = G_INPUT_STREAM_CLASS(klass); /* nocheck:blocked */
+	object_class->finalize = fu_ginput_stream_adapter_finalize;
+	istream_class->read_fn = fu_ginput_stream_adapter_read_fn;
+}
+
+static void
+fu_ginput_stream_adapter_init(FuGInputStreamAdapter *self)
+{
+}
+
+/**
+ * fu_input_stream_as_g_input_stream:
+ * @stream: a #FuInputStream
+ *
+ * Creates a #GInputStream adapter that delegates all reads and seeks to @stream.
+ * Use this when a GLib or external API requires a #GInputStream.
+ *
+ * Returns: (transfer full): a #GInputStream
+ *
+ * Since: 2.1.7
+ **/
+GInputStream *
+fu_input_stream_as_g_input_stream(FuInputStream *stream) /* nocheck:name */
+{
+	FuGInputStreamAdapter *self;
+
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), NULL);
+
+	self = g_object_new(fu_ginput_stream_adapter_get_type(), NULL);
+	self->fu_stream = g_object_ref(stream);
+
+	return G_INPUT_STREAM(self); /* nocheck:blocked */
+}

--- a/libfwupdplugin/fu-input-stream.c
+++ b/libfwupdplugin/fu-input-stream.c
@@ -28,6 +28,75 @@ fu_input_stream_init(FuInputStream *self)
 }
 
 /**
+ * fu_input_stream_read:
+ * @stream: a #FuInputStream
+ * @buffer: (not nullable): a buffer to read data into
+ * @count: the number of bytes that will be read from the stream
+ * @cancellable: (nullable): optional #GCancellable object
+ * @error: (nullable): optional return location for an error
+ *
+ * Tries to read @count bytes from the stream into the buffer starting at @buffer.
+ *
+ * Returns: number of bytes read, 0 for end of stream, or -1 on error
+ *
+ * Since: 2.1.7
+ **/
+gssize
+fu_input_stream_read(FuInputStream *stream,
+		     void *buffer,
+		     gsize count,
+		     GCancellable *cancellable,
+		     GError **error)
+{
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), -1);
+	g_return_val_if_fail(buffer != NULL, -1);
+	g_return_val_if_fail(error == NULL || *error == NULL, -1);
+	return g_input_stream_read(G_INPUT_STREAM(stream), /* nocheck:blocked */
+				   buffer,
+				   count,
+				   cancellable,
+				   error);
+}
+
+/**
+ * fu_input_stream_read_all:
+ * @stream: a #FuInputStream
+ * @buffer: (not nullable): a buffer to read data into
+ * @count: the number of bytes that will be read from the stream
+ * @bytes_read: (out) (nullable): location to store the number of bytes that was read
+ * @cancellable: (nullable): optional #GCancellable object
+ * @error: (nullable): optional return location for an error
+ *
+ * Tries to read @count bytes from the stream into the buffer starting at @buffer.
+ * Will block during this read.
+ *
+ * This function is similar to fu_input_stream_read(), except it tries to read as many bytes as
+ * requested, only stopping on an error or end of stream.
+ *
+ * Returns: %TRUE on success, %FALSE on error
+ *
+ * Since: 2.1.7
+ **/
+gboolean
+fu_input_stream_read_all(FuInputStream *stream,
+			 void *buffer,
+			 gsize count,
+			 gsize *bytes_read,
+			 GCancellable *cancellable,
+			 GError **error)
+{
+	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
+	g_return_val_if_fail(buffer != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+	return g_input_stream_read_all(G_INPUT_STREAM(stream), /* nocheck:blocked */
+				       buffer,
+				       count,
+				       bytes_read,
+				       cancellable,
+				       error);
+}
+
+/**
  * fu_input_stream_from_path:
  * @path: a filename
  * @error: (nullable): optional return location for an error

--- a/libfwupdplugin/fu-input-stream.c
+++ b/libfwupdplugin/fu-input-stream.c
@@ -15,6 +15,18 @@
 #include "fu-mem-private.h"
 #include "fu-sum.h"
 
+G_DEFINE_TYPE(FuInputStream, fu_input_stream, G_TYPE_INPUT_STREAM)
+
+static void
+fu_input_stream_class_init(FuInputStreamClass *klass)
+{
+}
+
+static void
+fu_input_stream_init(FuInputStream *self)
+{
+}
+
 /**
  * fu_input_stream_from_path:
  * @path: a filename

--- a/libfwupdplugin/fu-input-stream.c
+++ b/libfwupdplugin/fu-input-stream.c
@@ -162,11 +162,7 @@ fu_input_stream_read_safe(FuInputStream *stream,
 		g_prefix_error(error, "seek to 0x%x: ", (guint)seek_set);
 		return FALSE;
 	}
-	rc = g_input_stream_read(G_INPUT_STREAM(stream),
-				 buf + offset,
-				 count,
-				 NULL,
-				 error); /* nocheck:blocked */
+	rc = fu_input_stream_read(stream, buf + offset, count, NULL, error);
 	if (rc == -1) {
 		g_prefix_error(error, "failed read of 0x%x: ", (guint)count);
 		return FALSE;
@@ -382,11 +378,11 @@ fu_input_stream_read_byte_array(FuInputStream *stream,
 	/* read from stream in 32kB chunks */
 	while (TRUE) {
 		gssize sz;
-		sz = g_input_stream_read(G_INPUT_STREAM(stream), /* nocheck:blocked */
-					 tmp,
-					 MIN(count - buf->len, sizeof(tmp)),
-					 NULL,
-					 &error_local);
+		sz = fu_input_stream_read(stream,
+					  tmp,
+					  MIN(count - buf->len, sizeof(tmp)),
+					  NULL,
+					  &error_local);
 		if (sz == 0)
 			break;
 		if (sz < 0) {

--- a/libfwupdplugin/fu-input-stream.c
+++ b/libfwupdplugin/fu-input-stream.c
@@ -15,11 +15,116 @@
 #include "fu-mem-private.h"
 #include "fu-sum.h"
 
-G_DEFINE_TYPE(FuInputStream, fu_input_stream, G_TYPE_INPUT_STREAM)
+static void
+fu_input_stream_seekable_iface_init(GSeekableIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE(FuInputStream,
+			fu_input_stream,
+			G_TYPE_OBJECT,
+			G_IMPLEMENT_INTERFACE(G_TYPE_SEEKABLE, fu_input_stream_seekable_iface_init))
+
+static goffset
+fu_input_stream_default_tell(FuInputStream *stream)
+{
+	return 0;
+}
+
+static gboolean
+fu_input_stream_default_can_seek(FuInputStream *stream)
+{
+	return FALSE;
+}
+
+static gboolean
+fu_input_stream_default_seek(FuInputStream *stream,
+			     goffset offset,
+			     GSeekType type,
+			     GCancellable *cancellable,
+			     GError **error)
+{
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "stream is not seekable");
+	return FALSE;
+}
+
+static goffset
+fu_input_stream_seekable_tell(GSeekable *seekable)
+{
+	FuInputStream *self = FU_INPUT_STREAM(seekable);
+	FuInputStreamClass *klass = FU_INPUT_STREAM_GET_CLASS(self);
+	return klass->tell(self);
+}
+
+static gboolean
+fu_input_stream_seekable_can_seek(GSeekable *seekable)
+{
+	FuInputStream *self = FU_INPUT_STREAM(seekable);
+	FuInputStreamClass *klass = FU_INPUT_STREAM_GET_CLASS(self);
+	return klass->can_seek(self);
+}
+
+static gboolean
+fu_input_stream_seekable_seek(GSeekable *seekable,
+			      goffset offset,
+			      GSeekType type,
+			      GCancellable *cancellable,
+			      GError **error)
+{
+	FuInputStream *self = FU_INPUT_STREAM(seekable);
+	FuInputStreamClass *klass = FU_INPUT_STREAM_GET_CLASS(self);
+	return klass->seek(self, offset, type, cancellable, error);
+}
+
+static gboolean
+fu_input_stream_seekable_can_truncate(GSeekable *seekable)
+{
+	return FALSE;
+}
+
+static gboolean
+fu_input_stream_seekable_truncate(GSeekable *seekable,
+				  goffset offset,
+				  GCancellable *cancellable,
+				  GError **error)
+{
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "cannot truncate FuInputStream");
+	return FALSE;
+}
+
+static void
+fu_input_stream_seekable_iface_init(GSeekableIface *iface)
+{
+	iface->tell = fu_input_stream_seekable_tell;
+	iface->can_seek = fu_input_stream_seekable_can_seek;
+	iface->seek = fu_input_stream_seekable_seek;
+	iface->can_truncate = fu_input_stream_seekable_can_truncate;
+	iface->truncate_fn = fu_input_stream_seekable_truncate;
+}
+
+static void
+fu_input_stream_constructed(GObject *object)
+{
+	FuInputStreamClass *klass = FU_INPUT_STREAM_GET_CLASS(object);
+
+	G_OBJECT_CLASS(fu_input_stream_parent_class)->constructed(object);
+
+	/* every FuInputStream subclass must implement read_fn */
+	g_assert(klass->read_fn != NULL); /* nocheck:blocked */
+}
 
 static void
 fu_input_stream_class_init(FuInputStreamClass *klass)
 {
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	object_class->constructed = fu_input_stream_constructed;
+	klass->tell = fu_input_stream_default_tell;
+	klass->can_seek = fu_input_stream_default_can_seek;
+	klass->seek = fu_input_stream_default_seek;
 }
 
 static void
@@ -51,11 +156,11 @@ fu_input_stream_read(FuInputStream *stream,
 	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), -1);
 	g_return_val_if_fail(buffer != NULL, -1);
 	g_return_val_if_fail(error == NULL || *error == NULL, -1);
-	return g_input_stream_read(G_INPUT_STREAM(stream), /* nocheck:blocked */
-				   buffer,
-				   count,
-				   cancellable,
-				   error);
+	return FU_INPUT_STREAM_GET_CLASS(stream)->read_fn(stream,
+							  buffer,
+							  count,
+							  cancellable,
+							  error);
 }
 
 /**
@@ -85,15 +190,35 @@ fu_input_stream_read_all(FuInputStream *stream,
 			 GCancellable *cancellable,
 			 GError **error)
 {
+	gsize total = 0;
+	guint8 *buf = buffer;
+
 	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(buffer != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
-	return g_input_stream_read_all(G_INPUT_STREAM(stream), /* nocheck:blocked */
-				       buffer,
-				       count,
-				       bytes_read,
-				       cancellable,
-				       error);
+
+	while (total < count) {
+		gssize rc;
+
+		if (cancellable && g_cancellable_set_error_if_cancelled(cancellable, error)) {
+			if (bytes_read != NULL)
+				*bytes_read = total;
+			return FALSE;
+		}
+
+		rc = fu_input_stream_read(stream, buf + total, count - total, cancellable, error);
+		if (rc == -1) {
+			if (bytes_read != NULL)
+				*bytes_read = total;
+			return FALSE;
+		}
+		if (rc == 0)
+			break;
+		total += rc;
+	}
+	if (bytes_read != NULL)
+		*bytes_read = total;
+	return TRUE;
 }
 
 /**

--- a/libfwupdplugin/fu-input-stream.h
+++ b/libfwupdplugin/fu-input-stream.h
@@ -13,10 +13,22 @@
 #include "fu-progress.h"
 
 #define FU_TYPE_INPUT_STREAM (fu_input_stream_get_type())
-G_DECLARE_DERIVABLE_TYPE(FuInputStream, fu_input_stream, FU, INPUT_STREAM, GInputStream)
+G_DECLARE_DERIVABLE_TYPE(FuInputStream, fu_input_stream, FU, INPUT_STREAM, GObject)
 
 struct _FuInputStreamClass {
-	GInputStreamClass parent_class;
+	GObjectClass parent_class;
+	gssize (*read_fn)(FuInputStream *stream,
+			  void *buffer,
+			  gsize count,
+			  GCancellable *cancellable,
+			  GError **error);
+	goffset (*tell)(FuInputStream *stream);
+	gboolean (*can_seek)(FuInputStream *stream);
+	gboolean (*seek)(FuInputStream *stream,
+			 goffset offset,
+			 GSeekType type,
+			 GCancellable *cancellable,
+			 GError **error);
 };
 
 FuInputStream *

--- a/libfwupdplugin/fu-input-stream.h
+++ b/libfwupdplugin/fu-input-stream.h
@@ -12,14 +12,12 @@
 #include "fu-endian.h"
 #include "fu-progress.h"
 
-typedef GInputStream FuInputStream;	      /* nocheck:blocked */
-typedef GInputStreamClass FuInputStreamClass; /* nocheck:blocked */
+#define FU_TYPE_INPUT_STREAM (fu_input_stream_get_type())
+G_DECLARE_DERIVABLE_TYPE(FuInputStream, fu_input_stream, FU, INPUT_STREAM, GInputStream)
 
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuInputStream, g_object_unref) /* nocheck:blocked */
-#define FU_INPUT_STREAM	      G_INPUT_STREAM		     /* nocheck:blocked */
-#define FU_TYPE_INPUT_STREAM  G_TYPE_INPUT_STREAM	     /* nocheck:blocked */
-#define FU_IS_INPUT_STREAM    G_IS_INPUT_STREAM		     /* nocheck:blocked */
-#define FU_INPUT_STREAM_CLASS G_INPUT_STREAM_CLASS	     /* nocheck:blocked */
+struct _FuInputStreamClass {
+	GInputStreamClass parent_class;
+};
 
 FuInputStream *
 fu_input_stream_from_path(const gchar *path, GError **error) G_GNUC_WARN_UNUSED_RESULT

--- a/libfwupdplugin/fu-input-stream.h
+++ b/libfwupdplugin/fu-input-stream.h
@@ -107,6 +107,19 @@ gchar *
 fu_input_stream_compute_checksum(FuInputStream *stream,
 				 GChecksumType checksum_type,
 				 GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1);
+gssize
+fu_input_stream_read(FuInputStream *stream,
+		     void *buffer,
+		     gsize count,
+		     GCancellable *cancellable,
+		     GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
+gboolean
+fu_input_stream_read_all(FuInputStream *stream,
+			 void *buffer,
+			 gsize count,
+			 gsize *bytes_read,
+			 GCancellable *cancellable,
+			 GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
 gboolean
 fu_input_stream_find(FuInputStream *stream,
 		     const guint8 *buf,

--- a/libfwupdplugin/fu-input-stream.h
+++ b/libfwupdplugin/fu-input-stream.h
@@ -120,6 +120,9 @@ fu_input_stream_read_all(FuInputStream *stream,
 			 gsize *bytes_read,
 			 GCancellable *cancellable,
 			 GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
+GInputStream *
+fu_input_stream_as_g_input_stream(FuInputStream *stream) G_GNUC_WARN_UNUSED_RESULT
+    G_GNUC_NON_NULL(1);
 gboolean
 fu_input_stream_find(FuInputStream *stream,
 		     const guint8 *buf,

--- a/libfwupdplugin/fu-json-firmware.c
+++ b/libfwupdplugin/fu-json-firmware.c
@@ -34,6 +34,7 @@ fu_json_firmware_parse(FuFirmware *firmware,
 	FuJsonFirmware *self = FU_JSON_FIRMWARE(firmware);
 	FuJsonFirmwarePrivate *priv = GET_PRIVATE(self);
 	g_autoptr(FwupdJsonParser) json_parser = fwupd_json_parser_new();
+	g_autoptr(GInputStream) g_stream = NULL; /* nocheck:blocked */
 
 #ifdef HAVE_FUZZER
 	/* make the fuzzer spend time on complexity, not depth or length -> OOM */
@@ -47,8 +48,9 @@ fu_json_firmware_parse(FuFirmware *firmware,
 #endif
 
 	/* just load into memory, no extraction performed */
+	g_stream = fu_input_stream_as_g_input_stream(stream);
 	priv->json_node = fwupd_json_parser_load_from_stream(json_parser,
-							     G_INPUT_STREAM(stream),
+							     g_stream,
 							     FWUPD_JSON_LOAD_FLAG_NONE,
 							     error);
 	if (priv->json_node == NULL)

--- a/libfwupdplugin/fu-linux-efivars.c
+++ b/libfwupdplugin/fu-linux-efivars.c
@@ -255,7 +255,6 @@ fu_linux_efivars_get_data(FuEfivars *efivars,
 	FuEfiVariableAttrs attr_tmp;
 	guint64 sz;
 	g_autofree gchar *fn = NULL;
-	g_autoptr(GFileInfo) info = NULL;
 	g_autoptr(FuInputStream) istr = NULL;
 
 	/* open file as stream */
@@ -267,18 +266,13 @@ fu_linux_efivars_get_data(FuEfivars *efivars,
 		fwupd_error_convert(error);
 		return FALSE;
 	}
-	info = fu_file_input_stream_query_info(FU_FILE_INPUT_STREAM(istr),
-					       G_FILE_ATTRIBUTE_STANDARD_SIZE,
-					       NULL,
-					       error);
-	if (info == NULL) {
-		g_prefix_error_literal(error, "failed to get stream info: ");
+	sz = fu_file_input_stream_get_file_size(FU_FILE_INPUT_STREAM(istr), NULL, error);
+	if (sz == 0 && error != NULL && *error != NULL) {
+		g_prefix_error_literal(error, "failed to get file size: ");
 		fwupd_error_convert(error);
 		return FALSE;
 	}
 
-	/* get total stream size */
-	sz = g_file_info_get_attribute_uint64(info, G_FILE_ATTRIBUTE_STANDARD_SIZE);
 	if (sz < 4) {
 		g_set_error(error,
 			    FWUPD_ERROR,

--- a/libfwupdplugin/fu-linux-efivars.c
+++ b/libfwupdplugin/fu-linux-efivars.c
@@ -289,8 +289,7 @@ fu_linux_efivars_get_data(FuEfivars *efivars,
 	}
 
 	/* read out the attributes */
-	attr_sz =
-	    g_input_stream_read(G_INPUT_STREAM(istr), &attr_tmp, sizeof(attr_tmp), NULL, error);
+	attr_sz = fu_input_stream_read(istr, &attr_tmp, sizeof(attr_tmp), NULL, error);
 	if (attr_sz == -1) {
 		g_prefix_error_literal(error, "failed to read attr: ");
 		fwupd_error_convert(error);
@@ -312,12 +311,7 @@ fu_linux_efivars_get_data(FuEfivars *efivars,
 		*data_sz = data_sz_tmp;
 	if (data != NULL) {
 		g_autofree guint8 *data_tmp = g_malloc0(data_sz_tmp);
-		if (!g_input_stream_read_all(G_INPUT_STREAM(istr),
-					     data_tmp,
-					     data_sz_tmp,
-					     NULL,
-					     NULL,
-					     error)) {
+		if (!fu_input_stream_read_all(istr, data_tmp, data_sz_tmp, NULL, NULL, error)) {
 			g_prefix_error_literal(error, "failed to read data: ");
 			return FALSE;
 		}

--- a/libfwupdplugin/fu-memory-input-stream.c
+++ b/libfwupdplugin/fu-memory-input-stream.c
@@ -8,7 +8,165 @@
 
 #include "config.h"
 
+#include "fu-mem.h"
 #include "fu-memory-input-stream.h"
+
+/**
+ * FuMemoryInputStream:
+ *
+ * A memory-backed input stream that wraps a #GBytes, the
+ * fwupd equivalent to #GMemoryInputStream. This implementation
+ * is a drop-in replacement for #GMemoryInputStream for the needs
+ * within fwupd.
+ */
+struct _FuMemoryInputStream {
+	FuInputStream parent_instance;
+	GBytes *bytes;
+	gsize pos;
+};
+
+static void
+fu_memory_input_stream_seekable_iface_init(GSeekableIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE(FuMemoryInputStream,
+			fu_memory_input_stream,
+			FU_TYPE_INPUT_STREAM,
+			G_IMPLEMENT_INTERFACE(G_TYPE_SEEKABLE,
+					      fu_memory_input_stream_seekable_iface_init))
+
+static gssize
+fu_memory_input_stream_read(GInputStream *stream,
+			    void *buffer,
+			    gsize count,
+			    GCancellable *cancellable,
+			    GError **error)
+{
+	FuMemoryInputStream *self = FU_MEMORY_INPUT_STREAM(stream);
+	gsize data_sz = 0;
+	const guint8 *data = g_bytes_get_data(self->bytes, &data_sz);
+	gsize available;
+
+	if (self->pos >= data_sz)
+		return 0;
+
+	available = data_sz - self->pos;
+	count = MIN(count, available);
+	if (count > 0) {
+		if (!fu_memcpy_safe(buffer, count, 0x0, data, data_sz, self->pos, count, error))
+			return -1;
+	}
+	self->pos += count;
+	return (gssize)count;
+}
+
+static goffset
+fu_memory_input_stream_tell(GSeekable *seekable)
+{
+	FuMemoryInputStream *self = FU_MEMORY_INPUT_STREAM(seekable);
+	return (goffset)self->pos;
+}
+
+static gboolean
+fu_memory_input_stream_can_seek(GSeekable *seekable)
+{
+	return TRUE;
+}
+
+static gboolean
+fu_memory_input_stream_seek(GSeekable *seekable,
+			    goffset offset,
+			    GSeekType type,
+			    GCancellable *cancellable,
+			    GError **error)
+{
+	FuMemoryInputStream *self = FU_MEMORY_INPUT_STREAM(seekable);
+	gsize data_sz = g_bytes_get_size(self->bytes);
+	goffset new_pos;
+
+	switch (type) {
+	case G_SEEK_SET:
+		new_pos = offset;
+		break;
+	case G_SEEK_CUR:
+		new_pos = (goffset)self->pos + offset;
+		break;
+	case G_SEEK_END:
+		new_pos = (goffset)data_sz + offset;
+		break;
+	default:
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "unsupported seek type");
+		return FALSE;
+	}
+
+	if (new_pos < 0 || (gsize)new_pos > data_sz) {
+		g_set_error(error, /* nocheck:error */
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "seek to %" G_GINT64_MODIFIER
+			    "d is outside stream of size 0x%" G_GSIZE_MODIFIER "x",
+			    (gint64)new_pos,
+			    data_sz);
+		return FALSE;
+	}
+
+	self->pos = (gsize)new_pos;
+	return TRUE;
+}
+
+static gboolean
+fu_memory_input_stream_can_truncate(GSeekable *seekable)
+{
+	return FALSE;
+}
+
+static gboolean
+fu_memory_input_stream_truncate(GSeekable *seekable,
+				goffset offset,
+				GCancellable *cancellable,
+				GError **error)
+{
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "cannot truncate FuMemoryInputStream");
+	return FALSE;
+}
+
+static void
+fu_memory_input_stream_seekable_iface_init(GSeekableIface *iface)
+{
+	iface->tell = fu_memory_input_stream_tell;
+	iface->can_seek = fu_memory_input_stream_can_seek;
+	iface->seek = fu_memory_input_stream_seek;
+	iface->can_truncate = fu_memory_input_stream_can_truncate;
+	iface->truncate_fn = fu_memory_input_stream_truncate;
+}
+
+static void
+fu_memory_input_stream_finalize(GObject *object)
+{
+	FuMemoryInputStream *self = FU_MEMORY_INPUT_STREAM(object);
+	g_clear_pointer(&self->bytes, g_bytes_unref);
+	G_OBJECT_CLASS(fu_memory_input_stream_parent_class)->finalize(object);
+}
+
+static void
+fu_memory_input_stream_class_init(FuMemoryInputStreamClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	GInputStreamClass *istream_class = G_INPUT_STREAM_CLASS(klass); /* nocheck:blocked */
+	object_class->finalize = fu_memory_input_stream_finalize;
+	istream_class->read_fn = fu_memory_input_stream_read;
+}
+
+static void
+fu_memory_input_stream_init(FuMemoryInputStream *self)
+{
+	self->bytes = g_bytes_new(NULL, 0);
+}
 
 /**
  * fu_memory_input_stream_new:
@@ -22,7 +180,9 @@
 FuInputStream *
 fu_memory_input_stream_new(void)
 {
-	return g_memory_input_stream_new(); /* nocheck:blocked */
+	FuMemoryInputStream *self = g_object_new(FU_TYPE_MEMORY_INPUT_STREAM, NULL);
+
+	return FU_INPUT_STREAM(self);
 }
 
 /**
@@ -38,8 +198,15 @@ fu_memory_input_stream_new(void)
 FuInputStream *
 fu_memory_input_stream_new_from_bytes(GBytes *bytes)
 {
+	g_autoptr(FuMemoryInputStream) self = NULL;
+
 	g_return_val_if_fail(bytes != NULL, NULL);
-	return g_memory_input_stream_new_from_bytes(bytes); /* nocheck:blocked */
+
+	self = g_object_new(FU_TYPE_MEMORY_INPUT_STREAM, NULL);
+	g_clear_pointer(&self->bytes, g_bytes_unref);
+	self->bytes = g_bytes_ref(bytes);
+
+	return FU_INPUT_STREAM(g_steal_pointer(&self));
 }
 
 /**
@@ -57,6 +224,15 @@ fu_memory_input_stream_new_from_bytes(GBytes *bytes)
 FuInputStream *
 fu_memory_input_stream_new_from_data(const void *data, gssize len, GDestroyNotify destroy)
 {
+	g_autoptr(GBytes) bytes = NULL;
+
 	g_return_val_if_fail(data != NULL, NULL);
-	return g_memory_input_stream_new_from_data(data, len, destroy); /* nocheck:blocked */
+	g_return_val_if_fail(len >= -1, NULL);
+
+	if (len == -1)
+		len = strlen(data);
+
+	bytes = g_bytes_new_with_free_func(data, len, destroy, (gpointer)data);
+
+	return fu_memory_input_stream_new_from_bytes(bytes);
 }

--- a/libfwupdplugin/fu-memory-input-stream.c
+++ b/libfwupdplugin/fu-memory-input-stream.c
@@ -25,21 +25,14 @@ struct _FuMemoryInputStream {
 	gsize pos;
 };
 
-static void
-fu_memory_input_stream_seekable_iface_init(GSeekableIface *iface);
-
-G_DEFINE_TYPE_WITH_CODE(FuMemoryInputStream,
-			fu_memory_input_stream,
-			FU_TYPE_INPUT_STREAM,
-			G_IMPLEMENT_INTERFACE(G_TYPE_SEEKABLE,
-					      fu_memory_input_stream_seekable_iface_init))
+G_DEFINE_TYPE(FuMemoryInputStream, fu_memory_input_stream, FU_TYPE_INPUT_STREAM)
 
 static gssize
-fu_memory_input_stream_read(GInputStream *stream,
-			    void *buffer,
-			    gsize count,
-			    GCancellable *cancellable,
-			    GError **error)
+fu_memory_input_stream_read_fn(FuInputStream *stream,
+			       void *buffer,
+			       gsize count,
+			       GCancellable *cancellable,
+			       GError **error)
 {
 	FuMemoryInputStream *self = FU_MEMORY_INPUT_STREAM(stream);
 	gsize data_sz = 0;
@@ -60,26 +53,26 @@ fu_memory_input_stream_read(GInputStream *stream,
 }
 
 static goffset
-fu_memory_input_stream_tell(GSeekable *seekable)
+fu_memory_input_stream_tell(FuInputStream *stream)
 {
-	FuMemoryInputStream *self = FU_MEMORY_INPUT_STREAM(seekable);
+	FuMemoryInputStream *self = FU_MEMORY_INPUT_STREAM(stream);
 	return (goffset)self->pos;
 }
 
 static gboolean
-fu_memory_input_stream_can_seek(GSeekable *seekable)
+fu_memory_input_stream_can_seek(FuInputStream *stream)
 {
 	return TRUE;
 }
 
 static gboolean
-fu_memory_input_stream_seek(GSeekable *seekable,
+fu_memory_input_stream_seek(FuInputStream *stream,
 			    goffset offset,
 			    GSeekType type,
 			    GCancellable *cancellable,
 			    GError **error)
 {
-	FuMemoryInputStream *self = FU_MEMORY_INPUT_STREAM(seekable);
+	FuMemoryInputStream *self = FU_MEMORY_INPUT_STREAM(stream);
 	gsize data_sz = g_bytes_get_size(self->bytes);
 	goffset new_pos;
 
@@ -116,35 +109,6 @@ fu_memory_input_stream_seek(GSeekable *seekable,
 	return TRUE;
 }
 
-static gboolean
-fu_memory_input_stream_can_truncate(GSeekable *seekable)
-{
-	return FALSE;
-}
-
-static gboolean
-fu_memory_input_stream_truncate(GSeekable *seekable,
-				goffset offset,
-				GCancellable *cancellable,
-				GError **error)
-{
-	g_set_error_literal(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_NOT_SUPPORTED,
-			    "cannot truncate FuMemoryInputStream");
-	return FALSE;
-}
-
-static void
-fu_memory_input_stream_seekable_iface_init(GSeekableIface *iface)
-{
-	iface->tell = fu_memory_input_stream_tell;
-	iface->can_seek = fu_memory_input_stream_can_seek;
-	iface->seek = fu_memory_input_stream_seek;
-	iface->can_truncate = fu_memory_input_stream_can_truncate;
-	iface->truncate_fn = fu_memory_input_stream_truncate;
-}
-
 static void
 fu_memory_input_stream_finalize(GObject *object)
 {
@@ -157,9 +121,12 @@ static void
 fu_memory_input_stream_class_init(FuMemoryInputStreamClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	GInputStreamClass *istream_class = G_INPUT_STREAM_CLASS(klass); /* nocheck:blocked */
+	FuInputStreamClass *istream_class = FU_INPUT_STREAM_CLASS(klass);
 	object_class->finalize = fu_memory_input_stream_finalize;
-	istream_class->read_fn = fu_memory_input_stream_read;
+	istream_class->read_fn = fu_memory_input_stream_read_fn;
+	istream_class->tell = fu_memory_input_stream_tell;
+	istream_class->can_seek = fu_memory_input_stream_can_seek;
+	istream_class->seek = fu_memory_input_stream_seek;
 }
 
 static void

--- a/libfwupdplugin/fu-memory-input-stream.h
+++ b/libfwupdplugin/fu-memory-input-stream.h
@@ -8,14 +8,12 @@
 
 #include "fu-input-stream.h"
 
-typedef GMemoryInputStream FuMemoryInputStream;		  /* nocheck:blocked */
-typedef GMemoryInputStreamClass FuMemoryInputStreamClass; /* nocheck:blocked */
-
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuMemoryInputStream, g_object_unref)     /* nocheck:blocked */
-#define FU_MEMORY_INPUT_STREAM(o)	G_MEMORY_INPUT_STREAM(o)       /* nocheck:blocked */
-#define FU_TYPE_MEMORY_INPUT_STREAM	G_TYPE_MEMORY_INPUT_STREAM     /* nocheck:blocked */
-#define FU_IS_MEMORY_INPUT_STREAM(o)	G_IS_MEMORY_INPUT_STREAM(o)    /* nocheck:blocked */
-#define FU_MEMORY_INPUT_STREAM_CLASS(o) G_MEMORY_INPUT_STREAM_CLASS(o) /* nocheck:blocked */
+#define FU_TYPE_MEMORY_INPUT_STREAM (fu_memory_input_stream_get_type())
+G_DECLARE_FINAL_TYPE(FuMemoryInputStream,
+		     fu_memory_input_stream,
+		     FU,
+		     MEMORY_INPUT_STREAM,
+		     FuInputStream)
 
 FuInputStream *
 fu_memory_input_stream_new(void) G_GNUC_WARN_UNUSED_RESULT;

--- a/libfwupdplugin/fu-oprom-device.c
+++ b/libfwupdplugin/fu-oprom-device.c
@@ -108,7 +108,7 @@ fu_oprom_device_dump_firmware(FuDevice *device, FuProgress *progress, GError **e
 	while (TRUE) {
 		gssize sz;
 		guint8 tmp[32 * FU_KB] = {0x0};
-		sz = g_input_stream_read(G_INPUT_STREAM(stream), tmp, sizeof(tmp), NULL, error);
+		sz = fu_input_stream_read(stream, tmp, sizeof(tmp), NULL, error);
 		if (sz == 0)
 			break;
 		g_debug("ROM returned 0x%04x bytes", (guint)sz);

--- a/libfwupdplugin/fu-partial-input-stream-test.c
+++ b/libfwupdplugin/fu-partial-input-stream-test.c
@@ -201,7 +201,7 @@ fu_partial_input_stream_func(void)
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(base_stream)), ==, 8);
 	/* we CANNOT seek past the end... */
 	ret = g_seekable_seek(G_SEEKABLE(base_stream), pos + 10000, G_SEEK_SET, NULL, &error);
-	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
 	g_assert_false(ret);
 	g_clear_error(&error);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(base_stream)), ==, 8);
@@ -279,7 +279,7 @@ fu_partial_input_stream_func(void)
 
 	/* attempt to seek way past the base stream */
 	ret = g_seekable_seek(G_SEEKABLE(stream), 0x1000, G_SEEK_SET, NULL, &error);
-	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
 	g_assert_false(ret);
 	g_clear_error(&error);
 

--- a/libfwupdplugin/fu-partial-input-stream-test.c
+++ b/libfwupdplugin/fu-partial-input-stream-test.c
@@ -89,32 +89,6 @@ fu_partial_input_stream_simple_func(void)
 }
 
 static void
-fu_partial_input_stream_closed_base_func(void)
-{
-	gboolean ret;
-	gssize rc;
-	guint8 buf[2] = {0x0};
-	g_autoptr(GBytes) blob = g_bytes_new_static("12345678", 8);
-	g_autoptr(GError) error = NULL;
-	g_autoptr(FuInputStream) stream = NULL;
-	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-
-	stream = fu_partial_input_stream_new(base_stream, 2, 4, &error);
-	g_assert_no_error(error);
-	g_assert_nonnull(stream);
-	ret = g_input_stream_close(G_INPUT_STREAM(base_stream), NULL, &error);
-	g_assert_no_error(error);
-	g_assert_true(ret);
-
-	ret = g_seekable_seek(G_SEEKABLE(stream), 0x0, G_SEEK_SET, NULL, &error);
-	g_assert_no_error(error);
-	g_assert_true(ret);
-	rc = fu_input_stream_read(stream, buf, sizeof(buf), NULL, &error);
-	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_CLOSED);
-	g_assert_cmpint(rc, ==, -1);
-}
-
-static void
 fu_partial_input_stream_func(void)
 {
 	gboolean ret;
@@ -305,8 +279,6 @@ main(int argc, char **argv)
 {
 	g_test_init(&argc, &argv, NULL);
 	g_test_add_func("/fwupd/partial-input-stream", fu_partial_input_stream_func);
-	g_test_add_func("/fwupd/partial-input-stream/closed-base",
-			fu_partial_input_stream_closed_base_func);
 	g_test_add_func("/fwupd/partial-input-stream/simple", fu_partial_input_stream_simple_func);
 	g_test_add_func("/fwupd/partial-input-stream/composite",
 			fu_partial_input_stream_composite_func);

--- a/libfwupdplugin/fu-partial-input-stream-test.c
+++ b/libfwupdplugin/fu-partial-input-stream-test.c
@@ -38,7 +38,7 @@ fu_partial_input_stream_composite_func(void)
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(partial_stream)), ==, 0x0);
 
 	/* read the 34 */
-	rc = g_input_stream_read(G_INPUT_STREAM(partial_stream), buf, sizeof(buf), NULL, &error);
+	rc = fu_input_stream_read(partial_stream, buf, sizeof(buf), NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 2);
 	g_assert_cmpint(buf[0], ==, '3');
@@ -47,7 +47,7 @@ fu_partial_input_stream_composite_func(void)
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(partial_stream)), ==, 0x2);
 
 	/* there is no more data to read */
-	rc = g_input_stream_read(G_INPUT_STREAM(partial_stream), buf, sizeof(buf), NULL, &error);
+	rc = fu_input_stream_read(partial_stream, buf, sizeof(buf), NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(composite_stream)), ==, 0x4);
@@ -76,7 +76,7 @@ fu_partial_input_stream_simple_func(void)
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 0x2);
 
 	/* read from offset */
-	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 2, NULL, &error);
+	rc = fu_input_stream_read(stream, buf, 2, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 2);
 	g_assert_cmpint(buf[0], ==, '7');
@@ -109,7 +109,7 @@ fu_partial_input_stream_closed_base_func(void)
 	ret = g_seekable_seek(G_SEEKABLE(stream), 0x0, G_SEEK_SET, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, sizeof(buf), NULL, &error);
+	rc = fu_input_stream_read(stream, buf, sizeof(buf), NULL, &error);
 	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_CLOSED);
 	g_assert_cmpint(rc, ==, -1);
 }
@@ -146,7 +146,7 @@ fu_partial_input_stream_func(void)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream_file)), ==, 216);
-	rc = g_input_stream_read(G_INPUT_STREAM(stream_file), buf, 2, NULL, &error);
+	rc = fu_input_stream_read(stream_file, buf, 2, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 	pos = g_seekable_tell(G_SEEKABLE(stream_file));
@@ -154,7 +154,7 @@ fu_partial_input_stream_func(void)
 	ret = g_seekable_seek(G_SEEKABLE(stream_file), pos, G_SEEK_SET, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	rc = g_input_stream_read(G_INPUT_STREAM(stream_file), buf, 2, NULL, &error);
+	rc = fu_input_stream_read(stream_file, buf, 2, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream_file)), ==, 216);
@@ -164,14 +164,14 @@ fu_partial_input_stream_func(void)
 	g_assert_true(ret);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream_file)), ==, 10216);
 	/* reads all return zero */
-	rc = g_input_stream_read(G_INPUT_STREAM(stream_file), buf, 2, NULL, &error);
+	rc = fu_input_stream_read(stream_file, buf, 2, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 	/* END offset is negative */
 	ret = g_seekable_seek(G_SEEKABLE(stream_file), -0x1, G_SEEK_END, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	rc = g_input_stream_read(G_INPUT_STREAM(stream_file), buf, 1, NULL, &error);
+	rc = fu_input_stream_read(stream_file, buf, 1, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 1);
 	g_assert_cmpint(buf[0], ==, 10);
@@ -187,7 +187,7 @@ fu_partial_input_stream_func(void)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(base_stream)), ==, 8);
-	rc = g_input_stream_read(G_INPUT_STREAM(base_stream), buf, 2, NULL, &error);
+	rc = fu_input_stream_read(base_stream, buf, 2, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 	pos = g_seekable_tell(G_SEEKABLE(base_stream));
@@ -195,7 +195,7 @@ fu_partial_input_stream_func(void)
 	ret = g_seekable_seek(G_SEEKABLE(base_stream), pos, G_SEEK_SET, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	rc = g_input_stream_read(G_INPUT_STREAM(base_stream), buf, 2, NULL, &error);
+	rc = fu_input_stream_read(base_stream, buf, 2, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(base_stream)), ==, 8);
@@ -209,7 +209,7 @@ fu_partial_input_stream_func(void)
 	ret = g_seekable_seek(G_SEEKABLE(base_stream), -1, G_SEEK_END, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	rc = g_input_stream_read(G_INPUT_STREAM(base_stream), buf, 1, NULL, &error);
+	rc = fu_input_stream_read(base_stream, buf, 1, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 1);
 	g_assert_cmpint(buf[0], ==, '8');
@@ -224,13 +224,13 @@ fu_partial_input_stream_func(void)
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 0x2);
 
 	/* read from start */
-	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 2, NULL, &error);
+	rc = fu_input_stream_read(stream, buf, 2, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 2);
 	g_assert_cmpint(buf[0], ==, '5');
 	g_assert_cmpint(buf[1], ==, '6');
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 0x4);
-	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 2, NULL, &error);
+	rc = fu_input_stream_read(stream, buf, 2, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 
@@ -245,7 +245,7 @@ fu_partial_input_stream_func(void)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(base_stream)), ==, 0x8);
-	rc = g_input_stream_read(G_INPUT_STREAM(base_stream), buf, 1, NULL, &error);
+	rc = fu_input_stream_read(base_stream, buf, 1, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(base_stream)), ==, 0x8);
@@ -255,7 +255,7 @@ fu_partial_input_stream_func(void)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 0x4);
-	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, sizeof(buf), NULL, &error);
+	rc = fu_input_stream_read(stream, buf, sizeof(buf), NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 
@@ -264,7 +264,7 @@ fu_partial_input_stream_func(void)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 0x3);
-	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, sizeof(buf), NULL, &error);
+	rc = fu_input_stream_read(stream, buf, sizeof(buf), NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 1);
 	g_assert_cmpint(buf[0], ==, '6');
@@ -273,7 +273,7 @@ fu_partial_input_stream_func(void)
 	ret = g_seekable_seek(G_SEEKABLE(stream), 0x2, G_SEEK_SET, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, sizeof(buf), NULL, &error);
+	rc = fu_input_stream_read(stream, buf, sizeof(buf), NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 2);
 
@@ -290,7 +290,7 @@ fu_partial_input_stream_func(void)
 	ret = g_seekable_seek(G_SEEKABLE(stream_complete), 0x8, G_SEEK_SET, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	rc = g_input_stream_read(G_INPUT_STREAM(stream_complete), buf, sizeof(buf), NULL, &error);
+	rc = fu_input_stream_read(stream_complete, buf, sizeof(buf), NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 

--- a/libfwupdplugin/fu-partial-input-stream.c
+++ b/libfwupdplugin/fu-partial-input-stream.c
@@ -255,11 +255,7 @@ fu_partial_input_stream_read(GInputStream *stream,
 		return -1;
 	}
 	count = MIN(count, self->size - g_seekable_tell(G_SEEKABLE(stream)));
-	return g_input_stream_read(G_INPUT_STREAM(self->base_stream),
-				   buffer,
-				   count,
-				   cancellable,
-				   error);
+	return fu_input_stream_read(self->base_stream, buffer, count, cancellable, error);
 }
 
 static void

--- a/libfwupdplugin/fu-partial-input-stream.c
+++ b/libfwupdplugin/fu-partial-input-stream.c
@@ -39,17 +39,13 @@ struct _FuPartialInputStream {
 };
 
 static void
-fu_partial_input_stream_seekable_iface_init(GSeekableIface *iface);
-static void
 fu_partial_input_stream_codec_iface_init(FwupdCodecInterface *iface);
 
 G_DEFINE_TYPE_WITH_CODE(FuPartialInputStream,
 			fu_partial_input_stream,
 			FU_TYPE_INPUT_STREAM,
-			G_IMPLEMENT_INTERFACE(G_TYPE_SEEKABLE,
-					      fu_partial_input_stream_seekable_iface_init)
-			    G_IMPLEMENT_INTERFACE(FWUPD_TYPE_CODEC,
-						  fu_partial_input_stream_codec_iface_init))
+			G_IMPLEMENT_INTERFACE(FWUPD_TYPE_CODEC,
+					      fu_partial_input_stream_codec_iface_init))
 
 static void
 fu_partial_input_stream_add_string(FwupdCodec *codec, guint idt, GString *str)
@@ -66,27 +62,27 @@ fu_partial_input_stream_codec_iface_init(FwupdCodecInterface *iface)
 }
 
 static goffset
-fu_partial_input_stream_tell(GSeekable *seekable)
+fu_partial_input_stream_tell(FuInputStream *stream)
 {
-	FuPartialInputStream *self = FU_PARTIAL_INPUT_STREAM(seekable);
+	FuPartialInputStream *self = FU_PARTIAL_INPUT_STREAM(stream);
 	return g_seekable_tell(G_SEEKABLE(self->base_stream)) - self->offset;
 }
 
 static gboolean
-fu_partial_input_stream_can_seek(GSeekable *seekable)
+fu_partial_input_stream_can_seek(FuInputStream *stream)
 {
-	FuPartialInputStream *self = FU_PARTIAL_INPUT_STREAM(seekable);
+	FuPartialInputStream *self = FU_PARTIAL_INPUT_STREAM(stream);
 	return g_seekable_can_seek(G_SEEKABLE(self->base_stream));
 }
 
 static gboolean
-fu_partial_input_stream_seek(GSeekable *seekable,
+fu_partial_input_stream_seek(FuInputStream *stream,
 			     goffset offset,
 			     GSeekType type,
 			     GCancellable *cancellable,
 			     GError **error)
 {
-	FuPartialInputStream *self = FU_PARTIAL_INPUT_STREAM(seekable);
+	FuPartialInputStream *self = FU_PARTIAL_INPUT_STREAM(stream);
 
 	g_return_val_if_fail(FU_IS_PARTIAL_INPUT_STREAM(self), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
@@ -111,35 +107,6 @@ fu_partial_input_stream_seek(GSeekable *seekable,
 			       G_SEEK_SET,
 			       cancellable,
 			       error);
-}
-
-static gboolean
-fu_partial_input_stream_can_truncate(GSeekable *seekable)
-{
-	return FALSE;
-}
-
-static gboolean
-fu_partial_input_stream_truncate(GSeekable *seekable,
-				 goffset offset,
-				 GCancellable *cancellable,
-				 GError **error)
-{
-	g_set_error_literal(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_NOT_SUPPORTED,
-			    "cannot truncate FuPartialInputStream");
-	return FALSE;
-}
-
-static void
-fu_partial_input_stream_seekable_iface_init(GSeekableIface *iface)
-{
-	iface->tell = fu_partial_input_stream_tell;
-	iface->can_seek = fu_partial_input_stream_can_seek;
-	iface->seek = fu_partial_input_stream_seek;
-	iface->can_truncate = fu_partial_input_stream_can_truncate;
-	iface->truncate_fn = fu_partial_input_stream_truncate;
 }
 
 /**
@@ -238,11 +205,11 @@ fu_partial_input_stream_get_size(FuPartialInputStream *self)
 }
 
 static gssize
-fu_partial_input_stream_read(GInputStream *stream,
-			     void *buffer,
-			     gsize count,
-			     GCancellable *cancellable,
-			     GError **error)
+fu_partial_input_stream_read_fn(FuInputStream *stream,
+				void *buffer,
+				gsize count,
+				GCancellable *cancellable,
+				GError **error)
 {
 	FuPartialInputStream *self = FU_PARTIAL_INPUT_STREAM(stream);
 	g_return_val_if_fail(FU_IS_PARTIAL_INPUT_STREAM(self), -1);
@@ -271,8 +238,11 @@ static void
 fu_partial_input_stream_class_init(FuPartialInputStreamClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	GInputStreamClass *istream_class = G_INPUT_STREAM_CLASS(klass);
-	istream_class->read_fn = fu_partial_input_stream_read;
+	FuInputStreamClass *istream_class = FU_INPUT_STREAM_CLASS(klass);
+	istream_class->read_fn = fu_partial_input_stream_read_fn;
+	istream_class->tell = fu_partial_input_stream_tell;
+	istream_class->can_seek = fu_partial_input_stream_can_seek;
+	istream_class->seek = fu_partial_input_stream_seek;
 	object_class->finalize = fu_partial_input_stream_finalize;
 }
 

--- a/libfwupdplugin/fu-quirks.c
+++ b/libfwupdplugin/fu-quirks.c
@@ -271,6 +271,7 @@ fu_quirks_convert_quirk_to_xml_cb(XbBuilderSource *source,
 	FuQuirks *self = FU_QUIRKS(user_data);
 	g_autoptr(GBytes) bytes = NULL;
 	g_autoptr(GBytes) bytes_xml = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
 
 	bytes = xb_builder_source_ctx_get_bytes(ctx, cancellable, error);
 	if (bytes == NULL)
@@ -278,7 +279,8 @@ fu_quirks_convert_quirk_to_xml_cb(XbBuilderSource *source,
 	bytes_xml = fu_quirks_convert_keyfile_to_xml(self, bytes, error);
 	if (bytes_xml == NULL)
 		return NULL;
-	return G_INPUT_STREAM(fu_memory_input_stream_new_from_bytes(bytes_xml));
+	stream = fu_memory_input_stream_new_from_bytes(bytes_xml);
+	return fu_input_stream_as_g_input_stream(stream);
 }
 
 static gint

--- a/libfwupdplugin/fu-stream-input-stream-test.c
+++ b/libfwupdplugin/fu-stream-input-stream-test.c
@@ -17,9 +17,9 @@ fu_stream_input_stream_read_func(void)
 	guint8 buf[8] = {0};
 	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream =
-	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
+	g_autoptr(GInputStream) base_stream =		/* nocheck:blocked */
+	    g_memory_input_stream_new_from_bytes(blob); /* nocheck:blocked */
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
 
 	/* read first 4 bytes */
 	rc = fu_input_stream_read(stream, buf, 4, NULL, &error);
@@ -51,9 +51,9 @@ fu_stream_input_stream_read_short_func(void)
 	gssize rc;
 	guint8 buf[16] = {0};
 	g_autoptr(GBytes) blob = g_bytes_new_static("ABC", 3);
-	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream =
-	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
+	g_autoptr(GInputStream) base_stream =		/* nocheck:blocked */
+	    g_memory_input_stream_new_from_bytes(blob); /* nocheck:blocked */
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
 	g_autoptr(GError) error = NULL;
 
 	rc = fu_input_stream_read(stream, buf, sizeof(buf), NULL, &error);
@@ -72,9 +72,9 @@ fu_stream_input_stream_seek_func(void)
 	guint8 buf[2] = {0};
 	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream =
-	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
+	g_autoptr(GInputStream) base_stream =		/* nocheck:blocked */
+	    g_memory_input_stream_new_from_bytes(blob); /* nocheck:blocked */
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
 
 	/* can_seek should return TRUE for a seekable base stream */
 	g_assert_true(g_seekable_can_seek(G_SEEKABLE(stream)));
@@ -129,9 +129,9 @@ fu_stream_input_stream_tell_func(void)
 	guint8 buf[3] = {0};
 	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEF", 6);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream =
-	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
+	g_autoptr(GInputStream) base_stream =		/* nocheck:blocked */
+	    g_memory_input_stream_new_from_bytes(blob); /* nocheck:blocked */
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
 
 	/* initial position is 0 */
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 0);
@@ -159,9 +159,9 @@ fu_stream_input_stream_truncate_func(void)
 	gboolean ret;
 	g_autoptr(GBytes) blob = g_bytes_new_static("ABCD", 4);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream =
-	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
+	g_autoptr(GInputStream) base_stream =		/* nocheck:blocked */
+	    g_memory_input_stream_new_from_bytes(blob); /* nocheck:blocked */
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
 
 	g_assert_false(g_seekable_can_truncate(G_SEEKABLE(stream)));
 
@@ -177,9 +177,9 @@ fu_stream_input_stream_read_bytes_func(void)
 	gsize sz = 0;
 	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream =
-	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
+	g_autoptr(GInputStream) base_stream =		/* nocheck:blocked */
+	    g_memory_input_stream_new_from_bytes(blob); /* nocheck:blocked */
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
 	g_autoptr(GBytes) result = NULL;
 
 	result = fu_input_stream_read_bytes(stream, 2, 4, NULL, &error);
@@ -201,9 +201,9 @@ fu_stream_input_stream_size_func(void)
 	gsize sz = 0;
 	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream =
-	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
+	g_autoptr(GInputStream) base_stream =		/* nocheck:blocked */
+	    g_memory_input_stream_new_from_bytes(blob); /* nocheck:blocked */
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
 
 	ret = fu_input_stream_size(stream, &sz, &error);
 	g_assert_no_error(error);
@@ -218,9 +218,9 @@ fu_stream_input_stream_read_safe_func(void)
 	guint8 buf[8] = {0};
 	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream =
-	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
+	g_autoptr(GInputStream) base_stream =		/* nocheck:blocked */
+	    g_memory_input_stream_new_from_bytes(blob); /* nocheck:blocked */
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
 
 	/* read 3 bytes from offset 2 in the stream, store at offset 0 in buf */
 	ret = fu_input_stream_read_safe(stream, buf, sizeof(buf), 0x0, 0x2, 3, &error);
@@ -236,9 +236,9 @@ fu_stream_input_stream_checksum_func(void)
 {
 	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream =
-	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
+	g_autoptr(GInputStream) base_stream =		/* nocheck:blocked */
+	    g_memory_input_stream_new_from_bytes(blob); /* nocheck:blocked */
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
 	g_autofree gchar *csum_wrapper = NULL;
 	g_autofree gchar *csum_expected = NULL;
 
@@ -259,9 +259,9 @@ fu_stream_input_stream_empty_func(void)
 	guint8 buf[4] = {0};
 	g_autoptr(GBytes) blob = g_bytes_new_static("", 0);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream =
-	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
+	g_autoptr(GInputStream) base_stream =		/* nocheck:blocked */
+	    g_memory_input_stream_new_from_bytes(blob); /* nocheck:blocked */
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
 
 	/* size should be 0 */
 	ret = fu_input_stream_size(stream, &sz, &error);
@@ -286,9 +286,9 @@ fu_stream_input_stream_closed_base_func(void)
 	guint8 buf[4] = {0};
 	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream =
-	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
+	g_autoptr(GInputStream) base_stream =		/* nocheck:blocked */
+	    g_memory_input_stream_new_from_bytes(blob); /* nocheck:blocked */
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
 
 	/* close the base stream */
 	ret = g_input_stream_close(G_INPUT_STREAM(base_stream), NULL, &error);
@@ -305,11 +305,11 @@ static void
 fu_stream_input_stream_type_func(void)
 {
 	g_autoptr(GBytes) blob = g_bytes_new_static("ABCD", 4);
-	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream =
-	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
+	g_autoptr(GInputStream) base_stream =		/* nocheck:blocked */
+	    g_memory_input_stream_new_from_bytes(blob); /* nocheck:blocked */
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
 
-	g_assert_true(G_IS_INPUT_STREAM(stream));
+	g_assert_false(G_IS_INPUT_STREAM(stream)); /* nocheck:blocked */
 	g_assert_true(G_IS_SEEKABLE(stream));
 	g_assert_true(FU_IS_INPUT_STREAM(stream));
 	g_assert_true(FU_IS_STREAM_INPUT_STREAM(stream));
@@ -323,9 +323,9 @@ fu_stream_input_stream_seek_read_cycle_func(void)
 	guint8 buf[1] = {0};
 	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
 	g_autoptr(GError) error = NULL;
-	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream =
-	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
+	g_autoptr(GInputStream) base_stream =		/* nocheck:blocked */
+	    g_memory_input_stream_new_from_bytes(blob); /* nocheck:blocked */
+	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
 
 	/* read each byte individually by seeking */
 	for (gsize i = 0; i < 8; i++) {

--- a/libfwupdplugin/fu-stream-input-stream-test.c
+++ b/libfwupdplugin/fu-stream-input-stream-test.c
@@ -18,7 +18,8 @@ fu_stream_input_stream_read_func(void)
 	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+	g_autoptr(FuInputStream) stream =
+	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
 
 	/* read first 4 bytes */
 	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 4, NULL, &error);
@@ -51,7 +52,8 @@ fu_stream_input_stream_read_short_func(void)
 	guint8 buf[16] = {0};
 	g_autoptr(GBytes) blob = g_bytes_new_static("ABC", 3);
 	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+	g_autoptr(FuInputStream) stream =
+	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
 	g_autoptr(GError) error = NULL;
 
 	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, sizeof(buf), NULL, &error);
@@ -71,7 +73,8 @@ fu_stream_input_stream_seek_func(void)
 	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+	g_autoptr(FuInputStream) stream =
+	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
 
 	/* can_seek should return TRUE for a seekable base stream */
 	g_assert_true(g_seekable_can_seek(G_SEEKABLE(stream)));
@@ -127,7 +130,8 @@ fu_stream_input_stream_tell_func(void)
 	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEF", 6);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+	g_autoptr(FuInputStream) stream =
+	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
 
 	/* initial position is 0 */
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 0);
@@ -156,7 +160,8 @@ fu_stream_input_stream_truncate_func(void)
 	g_autoptr(GBytes) blob = g_bytes_new_static("ABCD", 4);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+	g_autoptr(FuInputStream) stream =
+	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
 
 	g_assert_false(g_seekable_can_truncate(G_SEEKABLE(stream)));
 
@@ -173,7 +178,8 @@ fu_stream_input_stream_read_bytes_func(void)
 	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+	g_autoptr(FuInputStream) stream =
+	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
 	g_autoptr(GBytes) result = NULL;
 
 	result = fu_input_stream_read_bytes(stream, 2, 4, NULL, &error);
@@ -196,7 +202,8 @@ fu_stream_input_stream_size_func(void)
 	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+	g_autoptr(FuInputStream) stream =
+	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
 
 	ret = fu_input_stream_size(stream, &sz, &error);
 	g_assert_no_error(error);
@@ -212,7 +219,8 @@ fu_stream_input_stream_read_safe_func(void)
 	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+	g_autoptr(FuInputStream) stream =
+	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
 
 	/* read 3 bytes from offset 2 in the stream, store at offset 0 in buf */
 	ret = fu_input_stream_read_safe(stream, buf, sizeof(buf), 0x0, 0x2, 3, &error);
@@ -229,7 +237,8 @@ fu_stream_input_stream_checksum_func(void)
 	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+	g_autoptr(FuInputStream) stream =
+	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
 	g_autofree gchar *csum_wrapper = NULL;
 	g_autofree gchar *csum_expected = NULL;
 
@@ -251,7 +260,8 @@ fu_stream_input_stream_empty_func(void)
 	g_autoptr(GBytes) blob = g_bytes_new_static("", 0);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+	g_autoptr(FuInputStream) stream =
+	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
 
 	/* size should be 0 */
 	ret = fu_input_stream_size(stream, &sz, &error);
@@ -277,7 +287,8 @@ fu_stream_input_stream_closed_base_func(void)
 	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+	g_autoptr(FuInputStream) stream =
+	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
 
 	/* close the base stream */
 	ret = g_input_stream_close(G_INPUT_STREAM(base_stream), NULL, &error);
@@ -295,7 +306,8 @@ fu_stream_input_stream_type_func(void)
 {
 	g_autoptr(GBytes) blob = g_bytes_new_static("ABCD", 4);
 	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+	g_autoptr(FuInputStream) stream =
+	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
 
 	g_assert_true(G_IS_INPUT_STREAM(stream));
 	g_assert_true(G_IS_SEEKABLE(stream));
@@ -312,7 +324,8 @@ fu_stream_input_stream_seek_read_cycle_func(void)
 	g_autoptr(GBytes) blob = g_bytes_new_static("ABCDEFGH", 8);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(FuInputStream) base_stream = fu_memory_input_stream_new_from_bytes(blob);
-	g_autoptr(FuInputStream) stream = fu_stream_input_stream_from_stream(base_stream);
+	g_autoptr(FuInputStream) stream =
+	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
 
 	/* read each byte individually by seeking */
 	for (gsize i = 0; i < 8; i++) {

--- a/libfwupdplugin/fu-stream-input-stream-test.c
+++ b/libfwupdplugin/fu-stream-input-stream-test.c
@@ -22,7 +22,7 @@ fu_stream_input_stream_read_func(void)
 	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
 
 	/* read first 4 bytes */
-	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 4, NULL, &error);
+	rc = fu_input_stream_read(stream, buf, 4, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 4);
 	g_assert_cmpint(buf[0], ==, 'A');
@@ -31,7 +31,7 @@ fu_stream_input_stream_read_func(void)
 	g_assert_cmpint(buf[3], ==, 'D');
 
 	/* read next 4 bytes */
-	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 4, NULL, &error);
+	rc = fu_input_stream_read(stream, buf, 4, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 4);
 	g_assert_cmpint(buf[0], ==, 'E');
@@ -40,7 +40,7 @@ fu_stream_input_stream_read_func(void)
 	g_assert_cmpint(buf[3], ==, 'H');
 
 	/* reading past end returns 0 */
-	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 4, NULL, &error);
+	rc = fu_input_stream_read(stream, buf, 4, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 }
@@ -56,7 +56,7 @@ fu_stream_input_stream_read_short_func(void)
 	    fu_stream_input_stream_from_stream(G_INPUT_STREAM(base_stream));
 	g_autoptr(GError) error = NULL;
 
-	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, sizeof(buf), NULL, &error);
+	rc = fu_input_stream_read(stream, buf, sizeof(buf), NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 3);
 	g_assert_cmpint(buf[0], ==, 'A');
@@ -85,7 +85,7 @@ fu_stream_input_stream_seek_func(void)
 	g_assert_true(ret);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 4);
 
-	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 2, NULL, &error);
+	rc = fu_input_stream_read(stream, buf, 2, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 2);
 	g_assert_cmpint(buf[0], ==, 'E');
@@ -97,7 +97,7 @@ fu_stream_input_stream_seek_func(void)
 	g_assert_true(ret);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 7);
 
-	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 1, NULL, &error);
+	rc = fu_input_stream_read(stream, buf, 1, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 1);
 	g_assert_cmpint(buf[0], ==, 'H');
@@ -108,7 +108,7 @@ fu_stream_input_stream_seek_func(void)
 	g_assert_true(ret);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 6);
 
-	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 2, NULL, &error);
+	rc = fu_input_stream_read(stream, buf, 2, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 2);
 	g_assert_cmpint(buf[0], ==, 'G');
@@ -137,7 +137,7 @@ fu_stream_input_stream_tell_func(void)
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 0);
 
 	/* read advances position */
-	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 3, NULL, &error);
+	rc = fu_input_stream_read(stream, buf, 3, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 3);
 	g_assert_cmpint(g_seekable_tell(G_SEEKABLE(stream)), ==, 3);
@@ -270,7 +270,7 @@ fu_stream_input_stream_empty_func(void)
 	g_assert_cmpint(sz, ==, 0);
 
 	/* read should return 0 immediately */
-	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, sizeof(buf), NULL, &error);
+	rc = fu_input_stream_read(stream, buf, sizeof(buf), NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 0);
 
@@ -296,7 +296,7 @@ fu_stream_input_stream_closed_base_func(void)
 	g_assert_true(ret);
 
 	/* reading through the wrapper should fail */
-	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, sizeof(buf), NULL, &error);
+	rc = fu_input_stream_read(stream, buf, sizeof(buf), NULL, &error);
 	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_CLOSED);
 	g_assert_cmpint(rc, ==, -1);
 }
@@ -333,7 +333,7 @@ fu_stream_input_stream_seek_read_cycle_func(void)
 		g_assert_no_error(error);
 		g_assert_true(ret);
 
-		rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 1, NULL, &error);
+		rc = fu_input_stream_read(stream, buf, 1, NULL, &error);
 		g_assert_no_error(error);
 		g_assert_cmpint(rc, ==, 1);
 		g_assert_cmpint(buf[0], ==, 'A' + (guint8)i);
@@ -344,7 +344,7 @@ fu_stream_input_stream_seek_read_cycle_func(void)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
-	rc = g_input_stream_read(G_INPUT_STREAM(stream), buf, 1, NULL, &error);
+	rc = fu_input_stream_read(stream, buf, 1, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(rc, ==, 1);
 	g_assert_cmpint(buf[0], ==, 'A');

--- a/libfwupdplugin/fu-stream-input-stream.c
+++ b/libfwupdplugin/fu-stream-input-stream.c
@@ -44,7 +44,11 @@ fu_stream_input_stream_read(GInputStream *stream,
 
 	g_return_val_if_fail(priv->base_stream != NULL, -1);
 
-	return g_input_stream_read(priv->base_stream, buffer, count, cancellable, error);
+	return g_input_stream_read(priv->base_stream, /* nocheck:blocked */
+				   buffer,
+				   count,
+				   cancellable,
+				   error);
 }
 
 static goffset

--- a/libfwupdplugin/fu-stream-input-stream.c
+++ b/libfwupdplugin/fu-stream-input-stream.c
@@ -22,22 +22,14 @@ typedef struct {
 	GInputStream *base_stream; /* nocheck:blocked */
 } FuStreamInputStreamPrivate;
 
-static void
-fu_stream_input_stream_seekable_iface_init(GSeekableIface *iface);
-
-G_DEFINE_TYPE_WITH_CODE(FuStreamInputStream,
-			fu_stream_input_stream,
-			FU_TYPE_INPUT_STREAM,
-			G_ADD_PRIVATE(FuStreamInputStream)
-			    G_IMPLEMENT_INTERFACE(G_TYPE_SEEKABLE,
-						  fu_stream_input_stream_seekable_iface_init))
+G_DEFINE_TYPE_WITH_PRIVATE(FuStreamInputStream, fu_stream_input_stream, FU_TYPE_INPUT_STREAM)
 
 static gssize
-fu_stream_input_stream_read(GInputStream *stream,
-			    void *buffer,
-			    gsize count,
-			    GCancellable *cancellable,
-			    GError **error)
+fu_stream_input_stream_read_fn(FuInputStream *stream,
+			       void *buffer,
+			       gsize count,
+			       GCancellable *cancellable,
+			       GError **error)
 {
 	FuStreamInputStream *self = FU_STREAM_INPUT_STREAM(stream);
 	FuStreamInputStreamPrivate *priv = fu_stream_input_stream_get_instance_private(self);
@@ -52,9 +44,9 @@ fu_stream_input_stream_read(GInputStream *stream,
 }
 
 static goffset
-fu_stream_input_stream_tell(GSeekable *seekable)
+fu_stream_input_stream_tell(FuInputStream *stream)
 {
-	FuStreamInputStream *self = FU_STREAM_INPUT_STREAM(seekable);
+	FuStreamInputStream *self = FU_STREAM_INPUT_STREAM(stream);
 	FuStreamInputStreamPrivate *priv = fu_stream_input_stream_get_instance_private(self);
 
 	if (!G_IS_SEEKABLE(priv->base_stream))
@@ -64,9 +56,9 @@ fu_stream_input_stream_tell(GSeekable *seekable)
 }
 
 static gboolean
-fu_stream_input_stream_can_seek(GSeekable *seekable)
+fu_stream_input_stream_can_seek(FuInputStream *stream)
 {
-	FuStreamInputStream *self = FU_STREAM_INPUT_STREAM(seekable);
+	FuStreamInputStream *self = FU_STREAM_INPUT_STREAM(stream);
 	FuStreamInputStreamPrivate *priv = fu_stream_input_stream_get_instance_private(self);
 
 	if (!G_IS_SEEKABLE(priv->base_stream))
@@ -76,13 +68,13 @@ fu_stream_input_stream_can_seek(GSeekable *seekable)
 }
 
 static gboolean
-fu_stream_input_stream_seek(GSeekable *seekable,
+fu_stream_input_stream_seek(FuInputStream *stream,
 			    goffset offset,
 			    GSeekType type,
 			    GCancellable *cancellable,
 			    GError **error)
 {
-	FuStreamInputStream *self = FU_STREAM_INPUT_STREAM(seekable);
+	FuStreamInputStream *self = FU_STREAM_INPUT_STREAM(stream);
 	FuStreamInputStreamPrivate *priv = fu_stream_input_stream_get_instance_private(self);
 
 	if (!G_IS_SEEKABLE(priv->base_stream)) {
@@ -94,35 +86,6 @@ fu_stream_input_stream_seek(GSeekable *seekable,
 	}
 
 	return g_seekable_seek(G_SEEKABLE(priv->base_stream), offset, type, cancellable, error);
-}
-
-static gboolean
-fu_stream_input_stream_can_truncate(GSeekable *seekable)
-{
-	return FALSE;
-}
-
-static gboolean
-fu_stream_input_stream_truncate(GSeekable *seekable,
-				goffset offset,
-				GCancellable *cancellable,
-				GError **error)
-{
-	g_set_error_literal(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_NOT_SUPPORTED,
-			    "cannot truncate FuStreamInputStream");
-	return FALSE;
-}
-
-static void
-fu_stream_input_stream_seekable_iface_init(GSeekableIface *iface)
-{
-	iface->tell = fu_stream_input_stream_tell;
-	iface->can_seek = fu_stream_input_stream_can_seek;
-	iface->seek = fu_stream_input_stream_seek;
-	iface->can_truncate = fu_stream_input_stream_can_truncate;
-	iface->truncate_fn = fu_stream_input_stream_truncate;
 }
 
 static void
@@ -138,9 +101,12 @@ static void
 fu_stream_input_stream_class_init(FuStreamInputStreamClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	GInputStreamClass *istream_class = G_INPUT_STREAM_CLASS(klass); /* nocheck:blocked */
+	FuInputStreamClass *istream_class = FU_INPUT_STREAM_CLASS(klass);
 	object_class->finalize = fu_stream_input_stream_finalize;
-	istream_class->read_fn = fu_stream_input_stream_read;
+	istream_class->read_fn = fu_stream_input_stream_read_fn;
+	istream_class->tell = fu_stream_input_stream_tell;
+	istream_class->can_seek = fu_stream_input_stream_can_seek;
+	istream_class->seek = fu_stream_input_stream_seek;
 }
 
 static void

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -145,6 +145,7 @@ fwupdplugin_src = [
   'fu-fit-firmware.c', # fuzzing
   'fu-fmap-firmware.c', # fuzzing
   'fu-fuzzer.c', # fuzzing
+  'fu-ginput-stream-adapter.c', # fuzzing
   'fu-hid-descriptor.c', # fuzzing
   'fu-hid-device.c',
   'fu-hid-report-item.c', # fuzzing

--- a/plugins/logitech-hidpp/fu-logitech-rdfu-firmware.c
+++ b/plugins/logitech-hidpp/fu-logitech-rdfu-firmware.c
@@ -31,6 +31,7 @@ fu_logitech_rdfu_firmware_parse(FuFirmware *firmware,
 	g_autoptr(FwupdJsonObject) json_obj = NULL;
 	g_autoptr(FwupdJsonObject) json_obj_payloads = NULL;
 	g_autoptr(FwupdJsonParser) json_parser = fwupd_json_parser_new();
+	g_autoptr(GInputStream) g_stream = NULL; /* nocheck:blocked */
 	g_autoptr(GPtrArray) keys = NULL;
 
 	/* set appropriate limits */
@@ -45,8 +46,9 @@ fu_logitech_rdfu_firmware_parse(FuFirmware *firmware,
 		return FALSE;
 	}
 
+	g_stream = fu_input_stream_as_g_input_stream(stream);
 	json_node = fwupd_json_parser_load_from_stream(json_parser,
-						       G_INPUT_STREAM(stream),
+						       g_stream,
 						       FWUPD_JSON_LOAD_FLAG_NONE,
 						       error);
 	if (json_node == NULL)

--- a/plugins/thunderbolt/fu-self-test.c
+++ b/plugins/thunderbolt/fu-self-test.c
@@ -228,7 +228,7 @@ mock_tree_firmware_verify(const FuThunderboltMockTree *node, GBytes *data)
 	g_autoptr(GError) error = NULL;
 	g_autofree gchar *sum_data = NULL;
 	const gchar *sum_disk = NULL;
-	gsize s;
+	gssize s;
 
 	sum_data = g_compute_checksum_for_bytes(G_CHECKSUM_SHA1, data);
 	chk = g_checksum_new(G_CHECKSUM_SHA1);
@@ -244,16 +244,14 @@ mock_tree_firmware_verify(const FuThunderboltMockTree *node, GBytes *data)
 	g_assert_nonnull(is);
 
 	do {
-		g_autoptr(GBytes) b = NULL;
-		const guchar *d;
+		guint8 tmpbuf[4096] = {0};
 
-		b = g_input_stream_read_bytes(G_INPUT_STREAM(is), 4096, NULL, &error);
+		s = fu_input_stream_read(is, tmpbuf, sizeof(tmpbuf), NULL, &error);
 		g_assert_no_error(error);
-		g_assert_nonnull(is);
+		g_assert_cmpint(s, >=, 0);
 
-		d = g_bytes_get_data(b, &s);
 		if (s > 0)
-			g_checksum_update(chk, d, (gssize)s);
+			g_checksum_update(chk, tmpbuf, s);
 
 	} while (s > 0);
 

--- a/src/fu-cabinet.c
+++ b/src/fu-cabinet.c
@@ -615,15 +615,15 @@ fu_cabinet_build_jcat_folder(FuCabinet *self, FuFirmware *img, GError **error)
 	}
 	if (g_str_has_suffix(fn, ".jcat")) {
 		g_autoptr(FuInputStream) istream = NULL;
+		g_autoptr(GInputStream) g_istream = NULL; /* nocheck:blocked */
 		istream = fu_firmware_get_stream(img, error);
 		if (istream == NULL)
 			return FALSE;
 		/* TODO: move this to libjcat? */
 		if (!g_seekable_seek(G_SEEKABLE(istream), 0x0, G_SEEK_SET, NULL, error))
 			return FALSE;
-		if (!fwupd_jcat_file_import_stream(self->jcat_file,
-						   G_INPUT_STREAM(istream),
-						   error)) {
+		g_istream = fu_input_stream_as_g_input_stream(istream);
+		if (!fwupd_jcat_file_import_stream(self->jcat_file, g_istream, error)) {
 			g_prefix_error_literal(error, "failed to import JCat stream: ");
 			return FALSE;
 		}
@@ -931,12 +931,15 @@ fu_cabinet_sign(FuCabinet *self,
 	/* load existing .jcat file if it exists */
 	img = fu_firmware_get_image_by_id(FU_FIRMWARE(self), "firmware.jcat", NULL);
 	if (img != NULL) {
-		g_autoptr(FuInputStream) stream = fu_firmware_get_stream(img, error);
+		g_autoptr(FuInputStream) stream = NULL;
+		g_autoptr(GInputStream) g_stream = NULL; /* nocheck:blocked */
+		stream = fu_firmware_get_stream(img, error);
 		if (stream == NULL)
 			return FALSE;
 		if (!g_seekable_seek(G_SEEKABLE(stream), 0x0, G_SEEK_SET, NULL, error))
 			return FALSE;
-		if (!fwupd_jcat_file_import_stream(jcat_file, G_INPUT_STREAM(stream), error))
+		g_stream = fu_input_stream_as_g_input_stream(stream);
+		if (!fwupd_jcat_file_import_stream(jcat_file, g_stream, error))
 			return FALSE;
 	}
 

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2494,6 +2494,7 @@ fu_engine_publish_release(FuEngine *self, FuRelease *release, GError **error)
 		g_autofree gchar *basename = g_path_get_basename(fu_release_get_filename(release));
 		g_autofree gchar *checksum = NULL;
 		g_autoptr(GError) error_passim = NULL;
+		g_autoptr(GInputStream) g_stream = NULL; /* nocheck:blocked */
 		g_autoptr(PassimItem) passim_item = passim_item_new();
 		if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_NEEDS_REBOOT) ||
 		    fu_device_has_flag(device, FWUPD_DEVICE_FLAG_NEEDS_SHUTDOWN))
@@ -2507,7 +2508,8 @@ fu_engine_publish_release(FuEngine *self, FuRelease *release, GError **error)
 		if (!fu_input_stream_size(stream, &streamsz, error))
 			return FALSE;
 		passim_item_set_size(passim_item, streamsz);
-		passim_item_set_stream(passim_item, G_INPUT_STREAM(stream));
+		g_stream = fu_input_stream_as_g_input_stream(stream);
+		passim_item_set_stream(passim_item, g_stream);
 		passim_item_set_hash(passim_item, checksum);
 		if (!passim_client_publish(self->passim_client, passim_item, &error_passim)) {
 			if (!g_error_matches(error_passim, G_IO_ERROR, G_IO_ERROR_EXISTS)) {
@@ -4353,6 +4355,7 @@ fu_engine_builder_cabinet_adapter_cb(XbBuilderSource *source,
 	g_autoptr(FuCabinet) cabinet = NULL;
 	g_autoptr(XbSilo) silo = NULL;
 	g_autofree gchar *xml = NULL;
+	g_autoptr(FuInputStream) memstream = NULL;
 
 	/* convert the CAB into metadata XML */
 	cabinet = fu_engine_build_cabinet_from_stream(self, fustream, error);
@@ -4364,8 +4367,8 @@ fu_engine_builder_cabinet_adapter_cb(XbBuilderSource *source,
 	xml = xb_silo_export(silo, XB_NODE_EXPORT_FLAG_NONE, error);
 	if (xml == NULL)
 		return NULL;
-	return G_INPUT_STREAM(
-	    fu_memory_input_stream_new_from_data(g_steal_pointer(&xml), -1, g_free));
+	memstream = fu_memory_input_stream_new_from_data(g_steal_pointer(&xml), -1, g_free);
+	return fu_input_stream_as_g_input_stream(memstream);
 }
 
 static XbBuilderSource *
@@ -4825,6 +4828,7 @@ fu_engine_get_system_jcat_result(FuEngine *self, FwupdRemote *remote, GError **e
 {
 	g_autoptr(GBytes) blob = NULL;
 	g_autoptr(FuInputStream) istream = NULL;
+	g_autoptr(GInputStream) g_istream = NULL; /* nocheck:blocked */
 	g_autoptr(GPtrArray) results = NULL;
 	g_autoptr(FwupdJcatItem) jcat_item = NULL;
 	g_autoptr(FwupdJcatFile) jcat_file = fwupd_jcat_file_new();
@@ -4838,7 +4842,8 @@ fu_engine_get_system_jcat_result(FuEngine *self, FwupdRemote *remote, GError **e
 	istream = fu_input_stream_from_path(fwupd_remote_get_filename_cache_sig(remote), error);
 	if (istream == NULL)
 		return NULL;
-	if (!fwupd_jcat_file_import_stream(jcat_file, G_INPUT_STREAM(istream), error))
+	g_istream = fu_input_stream_as_g_input_stream(istream);
+	if (!fwupd_jcat_file_import_stream(jcat_file, g_istream, error))
 		return NULL;
 	jcat_item = fwupd_jcat_file_get_item_default(jcat_file, error);
 	if (jcat_item == NULL)
@@ -4928,6 +4933,7 @@ fu_engine_update_metadata_bytes(FuEngine *self,
 	g_autoptr(FwupdRemote) remote = NULL;
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(FuInputStream) istream = NULL;
+	g_autoptr(GInputStream) g_istream = NULL; /* nocheck:blocked */
 	g_autoptr(GPtrArray) results = NULL;
 	g_autoptr(FwupdJcatFile) jcat_file = fwupd_jcat_file_new();
 	g_autoptr(FwupdJcatItem) jcat_item = NULL;
@@ -4957,7 +4963,8 @@ fu_engine_update_metadata_bytes(FuEngine *self,
 
 	/* verify JCatFile, or create a dummy one from legacy data */
 	istream = fu_memory_input_stream_new_from_bytes(bytes_sig);
-	if (!fwupd_jcat_file_import_stream(jcat_file, G_INPUT_STREAM(istream), error))
+	g_istream = fu_input_stream_as_g_input_stream(istream);
+	if (!fwupd_jcat_file_import_stream(jcat_file, g_istream, error))
 		return FALSE;
 
 	/* distrusting RSA? */
@@ -7686,6 +7693,7 @@ fu_engine_load_host_emulation(FuEngine *self, const gchar *fn, GError **error)
 	g_autoptr(FwupdJsonNode) json_node = NULL;
 	g_autoptr(FwupdJsonObject) json_obj = NULL;
 	g_autoptr(FwupdJsonParser) json_parser = fwupd_json_parser_new();
+	g_autoptr(GInputStream) g_istream_json = NULL; /* nocheck:blocked */
 	g_autoptr(FuInputStream) istream_json = NULL;
 	g_autoptr(FuInputStream) istream_raw = NULL;
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
@@ -7716,8 +7724,9 @@ fu_engine_load_host_emulation(FuEngine *self, const gchar *fn, GError **error)
 	} else {
 		istream_json = g_object_ref(istream_raw);
 	}
+	g_istream_json = fu_input_stream_as_g_input_stream(istream_json);
 	json_node = fwupd_json_parser_load_from_stream(json_parser,
-						       G_INPUT_STREAM(istream_json),
+						       g_istream_json,
 						       FWUPD_JSON_LOAD_FLAG_NONE,
 						       error);
 	if (json_node == NULL)

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -5490,10 +5490,12 @@ fu_util_jcat_load_filename(FuUtil *self, const gchar *filename, GError **error)
 
 	if (g_file_query_exists(gfile, self->cancellable)) {
 		g_autoptr(FuFileInputStream) istream = NULL;
+		g_autoptr(GInputStream) g_istream = NULL; /* nocheck:blocked */
 		istream = fu_file_input_stream_from_file(gfile, self->cancellable, error);
 		if (istream == NULL)
 			return NULL;
-		if (!fwupd_jcat_file_import_stream(file, G_INPUT_STREAM(istream), error))
+		g_istream = fu_input_stream_as_g_input_stream(FU_INPUT_STREAM(istream));
+		if (!fwupd_jcat_file_import_stream(file, g_istream, error))
 			return NULL;
 	}
 

--- a/src/fu-unix-seekable-input-stream-test.c
+++ b/src/fu-unix-seekable-input-stream-test.c
@@ -38,13 +38,13 @@ fu_unix_seekable_input_stream_func(void)
 	g_assert_nonnull(stream);
 
 	/* first chuck */
-	ret = g_input_stream_read(G_INPUT_STREAM(stream), buf, sizeof(buf) - 1, NULL, &error);
+	ret = fu_input_stream_read(stream, buf, sizeof(buf) - 1, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(ret, ==, 5);
 	g_assert_cmpstr((const gchar *)buf, ==, "<?xml");
 
 	/* second chuck */
-	ret = g_input_stream_read(G_INPUT_STREAM(stream), buf, sizeof(buf) - 1, NULL, &error);
+	ret = fu_input_stream_read(stream, buf, sizeof(buf) - 1, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(ret, ==, 5);
 	g_assert_cmpstr((const gchar *)buf, ==, " vers");
@@ -53,7 +53,7 @@ fu_unix_seekable_input_stream_func(void)
 	ret = g_seekable_seek(G_SEEKABLE(stream), 0, G_SEEK_SET, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(ret, ==, 1);
-	ret = g_input_stream_read(G_INPUT_STREAM(stream), buf, sizeof(buf) - 1, NULL, &error);
+	ret = fu_input_stream_read(stream, buf, sizeof(buf) - 1, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_cmpint(ret, ==, 5);
 	g_assert_cmpstr((const gchar *)buf, ==, "<?xml");

--- a/src/fu-unix-seekable-input-stream.c
+++ b/src/fu-unix-seekable-input-stream.c
@@ -9,15 +9,17 @@
 #include "config.h"
 
 #include <fcntl.h>
+#include <gio/gunixinputstream.h>
 #include <glib/gstdio.h>
 
 #include "fwupd-error.h"
 
-#include "fu-input-stream.h"
+#include "fu-stream-input-stream-private.h"
 #include "fu-unix-seekable-input-stream.h"
 
 struct _FuUnixSeekableInputStream {
-	GUnixInputStream parent_instance;
+	FuStreamInputStream parent_instance;
+	gint fd;
 };
 
 static void
@@ -26,14 +28,15 @@ fu_unix_seekable_input_stream_seekable_iface_init(GSeekableIface *iface);
 /* see https://gitlab.gnome.org/GNOME/glib/-/issues/3200 for why this is needed */
 G_DEFINE_TYPE_WITH_CODE(FuUnixSeekableInputStream,
 			fu_unix_seekable_input_stream,
-			G_TYPE_UNIX_INPUT_STREAM,
+			FU_TYPE_STREAM_INPUT_STREAM,
 			G_IMPLEMENT_INTERFACE(G_TYPE_SEEKABLE,
 					      fu_unix_seekable_input_stream_seekable_iface_init))
 
 static goffset
 fu_unix_seekable_input_stream_tell(GSeekable *seekable)
 {
-	goffset rc = lseek(g_unix_input_stream_get_fd(G_UNIX_INPUT_STREAM(seekable)), 0, SEEK_CUR);
+	FuUnixSeekableInputStream *self = FU_UNIX_SEEKABLE_INPUT_STREAM(seekable);
+	goffset rc = lseek(self->fd, 0, SEEK_CUR);
 	if (rc < 0)
 		g_critical("cannot tell FuUnixSeekableInputStream: %s", fwupd_strerror(errno));
 	return rc;
@@ -42,7 +45,8 @@ fu_unix_seekable_input_stream_tell(GSeekable *seekable)
 static gboolean
 fu_unix_seekable_input_stream_can_seek(GSeekable *seekable)
 {
-	return lseek(g_unix_input_stream_get_fd(G_UNIX_INPUT_STREAM(seekable)), 0, SEEK_CUR) >= 0;
+	FuUnixSeekableInputStream *self = FU_UNIX_SEEKABLE_INPUT_STREAM(seekable);
+	return lseek(self->fd, 0, SEEK_CUR) >= 0;
 }
 
 /* from glocalfileinputstream.c */
@@ -73,9 +77,7 @@ fu_unix_seekable_input_stream_seek(GSeekable *seekable,
 	g_return_val_if_fail(FU_IS_UNIX_SEEKABLE_INPUT_STREAM(self), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	rc = lseek(g_unix_input_stream_get_fd(G_UNIX_INPUT_STREAM(self)),
-		   offset,
-		   fu_unix_seekable_input_stream_seek_type_to_lseek(type));
+	rc = lseek(self->fd, offset, fu_unix_seekable_input_stream_seek_type_to_lseek(type));
 	if (rc < 0) {
 		g_set_error(error,
 			    G_IO_ERROR, /* nocheck:error */
@@ -135,11 +137,12 @@ FuInputStream *
 fu_unix_seekable_input_stream_new(gint fd, gboolean close_fd, GError **error)
 {
 	GStatBuf st = {0};
-	g_autoptr(FuInputStream) stream = NULL;
+	g_autoptr(FuUnixSeekableInputStream) self = NULL;
+	g_autoptr(GUnixInputStream) stream = NULL;
 
-	/* create wrapper */
-	stream =
-	    g_object_new(FU_TYPE_UNIX_SEEKABLE_INPUT_STREAM, "fd", fd, "close-fd", close_fd, NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
+	stream = G_UNIX_INPUT_STREAM(g_unix_input_stream_new(fd, close_fd)); /* nocheck:blocked */
 
 	/* check for a regular file */
 	if (fstat(fd, &st) != 0) {
@@ -159,8 +162,14 @@ fu_unix_seekable_input_stream_new(gint fd, gboolean close_fd, GError **error)
 		return NULL;
 	}
 
+	/* create wrapper */
+	self = g_object_new(FU_TYPE_UNIX_SEEKABLE_INPUT_STREAM, NULL);
+	self->fd = fd;
+	fu_stream_input_stream_set_base_stream(FU_STREAM_INPUT_STREAM(self),
+					       G_INPUT_STREAM(stream)); /* nocheck:blocked */
+
 	/* success */
-	return g_steal_pointer(&stream);
+	return FU_INPUT_STREAM(g_steal_pointer(&self));
 }
 
 /**
@@ -184,7 +193,7 @@ fu_unix_seekable_input_stream_require_seal(FuUnixSeekableInputStream *stream, GE
 	g_return_val_if_fail(FU_IS_UNIX_SEEKABLE_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	fd = g_unix_input_stream_get_fd(G_UNIX_INPUT_STREAM(stream));
+	fd = stream->fd;
 	seals = fcntl(fd, F_GET_SEALS);
 	if (seals < 0) {
 		g_set_error(error,

--- a/src/fu-unix-seekable-input-stream.h
+++ b/src/fu-unix-seekable-input-stream.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#include <gio/gunixinputstream.h>
-
-#include "fu-input-stream.h"
+#include "fu-stream-input-stream.h"
 
 #define FU_TYPE_UNIX_SEEKABLE_INPUT_STREAM (fu_unix_seekable_input_stream_get_type())
 
@@ -16,7 +14,7 @@ G_DECLARE_FINAL_TYPE(FuUnixSeekableInputStream,
 		     fu_unix_seekable_input_stream,
 		     FU,
 		     UNIX_SEEKABLE_INPUT_STREAM,
-		     GUnixInputStream)
+		     FuStreamInputStream)
 
 FuInputStream *
 fu_unix_seekable_input_stream_new(gint fd, gboolean close_fd, GError **error);

--- a/src/fu-usb-backend-test.c
+++ b/src/fu-usb-backend-test.c
@@ -25,6 +25,7 @@ fu_usb_backend_load_file(FuBackend *backend, const gchar *fn)
 	gboolean ret;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(FwupdJsonParser) json_parser = fwupd_json_parser_new();
+	g_autoptr(GInputStream) g_stream = NULL; /* nocheck:blocked */
 	g_autoptr(FwupdJsonNode) json_node = NULL;
 	g_autoptr(FwupdJsonObject) json_obj = NULL;
 	g_autoptr(FuInputStream) stream = NULL;
@@ -38,8 +39,9 @@ fu_usb_backend_load_file(FuBackend *backend, const gchar *fn)
 	stream = fu_input_stream_from_path(fn, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(stream);
+	g_stream = fu_input_stream_as_g_input_stream(stream);
 	json_node = fwupd_json_parser_load_from_stream(json_parser,
-						       G_INPUT_STREAM(stream),
+						       g_stream,
 						       FWUPD_JSON_LOAD_FLAG_NONE,
 						       &error);
 	g_assert_no_error(error);


### PR DESCRIPTION
This PR implements custom versions of the various `Fu*InputStream` implementations, eventually detaching it from the `GInputStream` hierarchy. The functional differences should be nil, everything is done the same way as before and/or just passed through to the underlying stream.

With this in place we can reimplement those streams in Rust without having to change any of the callers.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
