### PR TITLE
trivial: debian: Use dh_python3 to properly install Python scripts

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -343,6 +343,16 @@
       <package variant="aarch64" />
     </distro>
   </dependency>
+  <dependency id="dh-python">
+    <distro id="debian">
+      <control />
+    </distro>
+    <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+      <package variant="aarch64" />
+    </distro>
+  </dependency>
   <dependency id="dh-strip-nondeterminism">
     <distro id="debian">
       <control />
@@ -1179,6 +1189,15 @@
       <package variant="x86_64" />
       <package variant="aarch64" />
       <package variant="mingw64" />
+    </distro>
+    <distro id="debian">
+      <control />
+      <native />
+    </distro>
+    <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+      <package variant="aarch64" />
     </distro>
   </dependency>
   <dependency id="python3-gi">

--- a/contrib/debian/control.in
+++ b/contrib/debian/control.in
@@ -33,10 +33,10 @@ Architecture: linux-any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
          libfwupd3 (= ${binary:Version}),
+         ${python3:Depends},
          shared-mime-info,
          systemd-sysusers
-Recommends: python3,
-	    bolt,
+Recommends: bolt,
 	    default-dbus-system-bus | dbus-system-bus,
 	    ${recommends:secureboot-db},
 	    udisks2,
@@ -74,13 +74,13 @@ Package: fwupd-tests
 Architecture: linux-any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
+         ${python3:Depends},
          ca-certificates,
          default-dbus-system-bus | dbus-system-bus,
          fwupd,
          gnome-desktop-testing,
          ieee-data,
          polkitd | policykit-1,
-         python3,
          python3-flask,
          python3-gi
 Breaks: fwupd (<< 0.9.4-1)

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -33,7 +33,7 @@ endif
 CONFARGS += -Dplugin_modem_manager=enabled
 
 %:
-	dh $@ --with gir
+	dh $@ --with gir --with python3
 
 override_dh_auto_clean:
 	rm -fr obj-*
@@ -82,6 +82,11 @@ override_dh_install:
 
 	# the below step is automatic with debhelper >= 14
 	dh_installsysusers
+
+override_dh_python3:
+	dh_python3 -pfwupd
+	dh_python3 -pfwupd-tests /usr/share/installed-tests/fwupd
+	dh_python3 -pfwupd-tests /usr/libexec/installed-tests/fwupd
 
 override_dh_strip_nondeterminism:
 	dh_strip_nondeterminism -Xfirmware-example.xml.gz


### PR DESCRIPTION
Usually it is a good thing to use `/usr/bin/env python3` as shebang in Python scripts to avoid portability issues.  The rationale of [Debian's Python Policy](https://www.debian.org/doc/packaging-manuals/python-policy/#interpreter-directive-shebang) is that any Python script installed with a package should use the system's Python interpreter from `/usr/bin/python3`.  Among other things, `dh_python3` modifies the shebang in scripts so that `/usr/bin/python3` is always called regardless of which `python3` is first found in `$PATH`.
Next to the usual modifications in `debian/control` and `/debian/rules`, it is also necessary to override the dh_python3 target in `debian/rules` because the scripts in the package `fwupd-tests` are installed to `/usr/share/installed-tests/fwupd/` instead of `/usr/share/fwupd/` which is why `dh_python3` needs to be called twice, once for the package `fwupd` and once for `fwupd-tests` with the corresponding path.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
