### PR TITLE
logitech-hidpp: Fix segfault parsing bootloader firmware records

### DIFF
--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.c
@@ -52,6 +52,14 @@ fu_logitech_hidpp_bootloader_parse_pkts(FuLogitechHidppBootloader *self,
 
 		if (rcd->record_type == FU_IHEX_FIRMWARE_RECORD_TYPE_EOF)
 			break;
+		if (rcd->byte_cnt > FU_STRUCT_LOGITECH_HIDPP_BOOTLOADER_PKT_N_ELEMENTS_DATA) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "firmware data invalid: too large %u bytes",
+				    rcd->byte_cnt);
+			return NULL;
+		}
 
 		if (rcd->record_type == FU_IHEX_FIRMWARE_RECORD_TYPE_SIGNATURE) {
 			fu_struct_logitech_hidpp_bootloader_pkt_set_cmd(


### PR DESCRIPTION
When parsing ihex firmware files for the Logitech Unifying Receiver, records with byte_cnt > 28 would overflow the internal packet buffer, causing a crash during firmware recovery.

The explicit bounds check that existed in fwupd 1.9.34 was removed in commit 7803cfd58 (Use FuIhexFirmware to parse firmware) which relied on fu_memcpy_safe for bounds checking. However, that check fails when the buffer size is incorrectly computed after set_len modifies the packed struct layout.

Restore the explicit bounds check to reject oversized records before any buffer access occurs, fixing crashes like the one reported in https://github.com/fwupd/fwupd/issues/10682.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
