### PR TITLE
trivial: fix freebsd CI build

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -217,7 +217,7 @@ jobs:
           sync: rsync
           envs: "CI CC"
           prepare: |
-            pkg install -y bash python3 git cmake gcc
+            pkg install -y bash python3 git ninja cmake gcc
           run: |
             ./contrib/ci/fwupd_setup_helpers.py install-dependencies -o freebsd --yes
             ./contrib/setup


### PR DESCRIPTION
Seems that ninja is no longer pulled in by meson or w/e other package required it.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
