### PR TITLE
libfwupd: seal the memfd for fwupd_unix_input_stream_from_fn()

### DIFF
--- a/src/fu-dbus-daemon.c
+++ b/src/fu-dbus-daemon.c
@@ -1083,9 +1083,6 @@ fu_dbus_daemon_invocation_get_input_stream(GDBusMethodInvocation *invocation, GE
 	stream = fu_unix_seekable_input_stream_new(g_steal_fd(&fd), TRUE, error);
 	if (stream == NULL)
 		return NULL;
-	if (!fu_unix_seekable_input_stream_require_seal(FU_UNIX_SEEKABLE_INPUT_STREAM(stream),
-							error))
-		return NULL;
 	return g_steal_pointer(&stream);
 #else
 	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "unsupported feature");

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -5083,14 +5083,8 @@ fu_engine_update_metadata(FuEngine *self,
 	stream_fd = fu_unix_seekable_input_stream_new(fd, TRUE, error);
 	if (stream_fd == NULL)
 		return FALSE;
-	if (!fu_unix_seekable_input_stream_require_seal(FU_UNIX_SEEKABLE_INPUT_STREAM(stream_fd),
-							error))
-		return FALSE;
 	stream_sig = fu_unix_seekable_input_stream_new(fd_sig, TRUE, error);
 	if (stream_sig == NULL)
-		return FALSE;
-	if (!fu_unix_seekable_input_stream_require_seal(FU_UNIX_SEEKABLE_INPUT_STREAM(stream_sig),
-							error))
 		return FALSE;
 
 	/* read the entire file into memory */

--- a/src/fu-unix-seekable-input-stream-test.c
+++ b/src/fu-unix-seekable-input-stream-test.c
@@ -8,9 +8,6 @@
 
 #include <fcntl.h>
 #include <glib/gstdio.h>
-#ifdef HAVE_MEMFD_CREATE
-#include <sys/mman.h>
-#endif
 
 #include "fwupd-error.h"
 
@@ -81,64 +78,6 @@ fu_unix_seekable_input_stream_non_regular_func(void)
 #endif
 }
 
-static void
-fu_unix_seekable_input_stream_sealed_memfd_func(void)
-{
-#if defined(HAVE_GIO_UNIX) && defined(HAVE_MEMFD_CREATE)
-	gboolean ret;
-	g_autofd gint fd = -1;
-	g_autoptr(GError) error = NULL;
-	g_autoptr(FuInputStream) stream = NULL;
-	const gchar data[] = "hello";
-
-	fd = memfd_create("fwupd-test", MFD_CLOEXEC | MFD_ALLOW_SEALING);
-	g_assert_cmpint(fd, >=, 0);
-	g_assert_cmpint(write(fd, data, sizeof(data)), ==, sizeof(data));
-	g_assert_cmpint(lseek(fd, 0, SEEK_SET), ==, 0);
-	g_assert_cmpint(
-	    fcntl(fd, F_ADD_SEALS, F_SEAL_SEAL | F_SEAL_WRITE | F_SEAL_SHRINK | F_SEAL_GROW),
-	    ==,
-	    0);
-
-	stream = fu_unix_seekable_input_stream_new(g_steal_fd(&fd), TRUE, &error);
-	g_assert_no_error(error);
-	g_assert_nonnull(stream);
-	ret = fu_unix_seekable_input_stream_require_seal(FU_UNIX_SEEKABLE_INPUT_STREAM(stream),
-							 &error);
-	g_assert_no_error(error);
-	g_assert_true(ret);
-#else
-	g_test_skip("No gio-unix-2.0 or memfd_create support, skipping");
-#endif
-}
-
-static void
-fu_unix_seekable_input_stream_unsealed_memfd_func(void)
-{
-#if defined(HAVE_GIO_UNIX) && defined(HAVE_MEMFD_CREATE)
-	gboolean ret;
-	g_autofd gint fd = -1;
-	g_autoptr(GError) error = NULL;
-	g_autoptr(FuInputStream) stream = NULL;
-	const gchar data[] = "hello";
-
-	fd = memfd_create("fwupd-test", MFD_CLOEXEC | MFD_ALLOW_SEALING);
-	g_assert_cmpint(fd, >=, 0);
-	g_assert_cmpint(write(fd, data, sizeof(data)), ==, sizeof(data));
-	g_assert_cmpint(lseek(fd, 0, SEEK_SET), ==, 0);
-
-	stream = fu_unix_seekable_input_stream_new(g_steal_fd(&fd), TRUE, &error);
-	g_assert_no_error(error);
-	g_assert_nonnull(stream);
-	ret = fu_unix_seekable_input_stream_require_seal(FU_UNIX_SEEKABLE_INPUT_STREAM(stream),
-							 &error);
-	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
-	g_assert_false(ret);
-#else
-	g_test_skip("No gio-unix-2.0 or memfd_create support, skipping");
-#endif
-}
-
 int
 main(int argc, char **argv)
 {
@@ -147,9 +86,5 @@ main(int argc, char **argv)
 	g_test_add_func("/fwupd/unix-seekable-input-stream", fu_unix_seekable_input_stream_func);
 	g_test_add_func("/fwupd/unix-seekable-input-stream/non-regular",
 			fu_unix_seekable_input_stream_non_regular_func);
-	g_test_add_func("/fwupd/unix-seekable-input-stream/sealed-memfd",
-			fu_unix_seekable_input_stream_sealed_memfd_func);
-	g_test_add_func("/fwupd/unix-seekable-input-stream/unsealed-memfd",
-			fu_unix_seekable_input_stream_unsealed_memfd_func);
 	return g_test_run();
 }

--- a/src/fu-unix-seekable-input-stream.c
+++ b/src/fu-unix-seekable-input-stream.c
@@ -163,53 +163,6 @@ fu_unix_seekable_input_stream_new(gint fd, gboolean close_fd, GError **error)
 	return g_steal_pointer(&stream);
 }
 
-/**
- * fu_unix_seekable_input_stream_require_seal:
- * @stream: a #FuUnixSeekableInputStream
- * @error: (nullable): optional return location for an error
- *
- * Enforces that the file descriptor backing this stream is a memfd with the required seals set.
- *
- * Returns: %TRUE if sealed
- *
- * Since: 2.1.7
- **/
-gboolean
-fu_unix_seekable_input_stream_require_seal(FuUnixSeekableInputStream *stream, GError **error)
-{
-#ifdef HAVE_MEMFD_CREATE
-	gint fd;
-	gint seals;
-
-	g_return_val_if_fail(FU_IS_UNIX_SEEKABLE_INPUT_STREAM(stream), FALSE);
-	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
-
-	fd = g_unix_input_stream_get_fd(G_UNIX_INPUT_STREAM(stream));
-	seals = fcntl(fd, F_GET_SEALS);
-	if (seals < 0) {
-		/* not supported on this fd */
-		return TRUE;
-	}
-	if ((seals & F_SEAL_SEAL) == 0) {
-		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE, "fd not sealed");
-		return FALSE;
-	}
-	if ((seals & F_SEAL_WRITE) == 0) {
-		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE, "no WRITE seal");
-		return FALSE;
-	}
-	if ((seals & F_SEAL_SHRINK) == 0) {
-		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE, "no SHRINK seal");
-		return FALSE;
-	}
-	if ((seals & F_SEAL_GROW) == 0) {
-		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE, "no GROW seal");
-		return FALSE;
-	}
-#endif
-	return TRUE;
-}
-
 static void
 fu_unix_seekable_input_stream_class_init(FuUnixSeekableInputStreamClass *klass)
 {

--- a/src/fu-unix-seekable-input-stream.h
+++ b/src/fu-unix-seekable-input-stream.h
@@ -20,5 +20,3 @@ G_DECLARE_FINAL_TYPE(FuUnixSeekableInputStream,
 
 FuInputStream *
 fu_unix_seekable_input_stream_new(gint fd, gboolean close_fd, GError **error);
-gboolean
-fu_unix_seekable_input_stream_require_seal(FuUnixSeekableInputStream *stream, GError **error);


### PR DESCRIPTION
## Problem

`fwupdmgr get-details`, `install` and `update-metadata` fail whenever the file being passed lives on a **tmpfs**, with the daemon returning:

```
no WRITE seal
 ● Exit code was 1 and expected 0
 FAIL: fwupd/fwupdmgr.test (Child process exited with code 1)
```

Seen in the Debian autopkgtest: https://ci.debian.net/packages/f/fwupd/testing/amd64/72831274/

This supersedes #10610, which tried to fix it on the daemon side and was correctly rejected for re-introducing the TOCTOU window.

## Root cause

`fu_unix_seekable_input_stream_require_seal()` rejects mutable descriptors to prevent TOCTOU, and allows plain files only because `F_GET_SEALS` returns `-1` on filesystems that do not support sealing.

That assumption does not hold on a tmpfs. A regular file there was **not** created with `MFD_ALLOW_SEALING`, so the kernel reports `F_SEAL_SEAL` (and nothing else) rather than `-1`:

| fd source            | `F_GET_SEALS`       |
|----------------------|---------------------|
| regular file (ext4)  | `-1`                |
| regular file (tmpfs) | `F_SEAL_SEAL` (0x1) |
| sealed memfd         | `0xf`               |

So the daemon sees `F_SEAL_SEAL` set but `F_SEAL_WRITE` missing and rejects the fd. (Note this contradicts both assumptions in the #10610 thread — it is neither `0` nor `-1`.) The real culprit is that `fwupd_unix_input_stream_from_fn()` hands the daemon the raw `open()` fd, which is mutable and only ever passed the check by accident on non-tmpfs filesystems.

## Fix

Copy the file contents into a sealed memfd on the **client** so the daemon always receives an immutable snapshot. The daemon check stays strict (no TOCTOU regression), and this also closes the pre-existing gap where a mutable regular-file fd was accepted on other filesystems.

The copy uses `copy_file_range()` (in-kernel, no userspace bounce buffer) where available, falling back to a read/write loop otherwise. A regression test asserts the resulting fd is fully sealed.