### PR TITLE
docs: Add mention of new mgmt config interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ Additionally, the list of approved firmware can be supplemented using
 
 fwupdmgr is a command line client, but various additional graphical frontends are enumerated in the [fwupdmgr man page](https://fwupd.github.io/libfwupdplugin/fwupdmgr.html#description).
 
+For configuration management and reactive automation,
+[mgmt](https://mgmtconfig.com/) provides declarative resources and functions for
+fwupd.
+
 ## SAST Tools
 
 - [Coverity](https://scan.coverity.com/) - static analyzer for Java, C/C++, C#, JavaScript, Ruby, and Python code.

--- a/src/fwupdmgr.md
+++ b/src/fwupdmgr.md
@@ -31,6 +31,14 @@ These applications may be more useful to many users compared to using the comman
 
 * **System76 Firmware Manager**: <https://github.com/pop-os/firmware-manager>
 
+For automated configuration management and reactive automation,
+<https://mgmtconfig.com/> provides
+[resources](https://mgmtconfig.com/docs/resources/) for managing fwupd remotes,
+individual devices, and system-wide updates, as well as a
+[function](https://mgmtconfig.com/docs/functions/) that reports when a reboot is
+needed. It communicates with fwupd over D-Bus; firmware verification and
+installation remain handled by fwupd.
+
 On most systems fwupd is configured to download metadata from the Linux Vendor Firmware Service
 <https://fwupd.org/> and more information about the LVFS is available here: <https://lvfs.readthedocs.io/>
 


### PR DESCRIPTION
The https://mgmtconfig.com/ project at https://github.com/purpleidea/mgmt/ provides some functions and resources to manage firmware updates and the associated lifecycle. It doesn't directly do any of the magic, it relies on the available API's that are provided by this project over D-Bus.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [x] Documentation

Richard said to send a patch https://mastodon.social/@hughsie/116933780531265560

I'm obviously happy to edit this as the project sees fit. I've wrapped the changes to 80 chars, but if this is not preferred, I'm happy to edit.

Many thanks!

PS: The new work is already upstream, but since a new release hasn't been cut yet, the website doesn't yet mention the new resources and function yet.