### PR TITLE
fix: update error message to reference --ignore-requirements instead of --force

### DIFF
--- a/src/fu-engine-requirements.c
+++ b/src/fu-engine-requirements.c
@@ -1091,14 +1091,15 @@ fu_engine_requirements_check(FuEngine *self,
 		return FALSE;
 #else
 		if ((flags & FWUPD_INSTALL_FLAG_IGNORE_REQUIREMENTS) == 0) {
-			g_set_error_literal(error,
-					    FWUPD_ERROR,
-					    FWUPD_ERROR_NOT_SUPPORTED,
-					    "generic GUID requires --force, a CHID, child, parent "
-					    "or sibling requirement");
+			g_set_error_literal(
+			    error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "generic GUID requires --ignore-requirements, a CHID, child, parent "
+			    "or sibling requirement");
 			return FALSE;
 		}
-		g_info("ignoring enforce-requires requirement due to --force");
+		g_info("ignoring enforce-requires requirement due to --ignore-requirements");
 #endif
 	}
 

--- a/src/fwupdtool.md
+++ b/src/fwupdtool.md
@@ -26,7 +26,7 @@ For example, you can convert DFU or Intel HEX firmware into the vendor-specific 
 
 The fwupdtool command takes various options depending on the action.
 Run **fwupdtool \-\-help** for the full list.
-Note that some runtimes failures can be ignored using **\-\-force**.
+Note that some runtimes failures can be ignored using **--force** or **--ignore-requirements**.
 
 ## EXIT STATUS
 


### PR DESCRIPTION
## Problem

The check in `fu_engine_requirements_check()` tests `FWUPD_INSTALL_FLAG_IGNORE_REQUIREMENTS`, but the error message and `g_info()` still referred to `--force`. This is misleading because `--force` does **not** bypass this check — only `--ignore-requirements` does.

Users running `fwupdtool` with `--force` would see an error suggesting they use `--force`, but that flag doesn't actually get past this check. They need `--ignore-requirements` instead.

## Changes

- **`src/fu-engine-requirements.c`**: Updated the error message from `--force` to `--ignore-requirements`, and updated the `g_info()` log message accordingly.
- **`src/fwupdtool.md`**: Updated the man page to mention both `--force` and `--ignore-requirements` as options for ignoring runtime failures.