### PR TITLE
Fix failures starting daemon due to is-external flag

### DIFF
--- a/libfwupdplugin/fu-efi-x509-device.c
+++ b/libfwupdplugin/fu-efi-x509-device.c
@@ -11,6 +11,7 @@
 #include "fu-efi-variable-authentication2.h"
 #include "fu-efi-x509-device.h"
 #include "fu-input-stream.h"
+#include "fu-uefi-device.h"
 #include "fu-version-common.h"
 #include "fu-zip-firmware.h"
 
@@ -200,6 +201,7 @@ fu_efi_x509_device_class_init(FuEfiX509DeviceClass *klass)
 	device_class->prepare_firmware = fu_efi_x509_device_prepare_firmware;
 	device_class->write_firmware = fu_efi_x509_device_write_firmware;
 	device_class->set_progress = fu_efi_x509_device_set_progress;
+	fu_device_register_private_flag(device_class, FU_UEFI_DEVICE_PRIVATE_FLAG_IS_EXTERNAL);
 }
 
 /**

--- a/plugins/uefi-db/fu-uefi-db-device.c
+++ b/plugins/uefi-db/fu-uefi-db-device.c
@@ -197,4 +197,5 @@ fu_uefi_db_device_class_init(FuUefiDbDeviceClass *klass)
 	device_class->write_firmware = fu_uefi_db_device_write_firmware;
 	device_class->add_security_attrs = fu_uefi_db_device_add_security_attrs;
 	device_class->set_progress = fu_uefi_db_device_set_progress;
+	fu_device_register_private_flag(device_class, FU_UEFI_DEVICE_PRIVATE_FLAG_IS_EXTERNAL);
 }


### PR DESCRIPTION
The daemon aborts like this:
```
FuEfiX509Device flag is-external is unknown -- use fu_device_register_private_flag()
```

Pass the flag down from the parent

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
