### PR TITLE
synaptics-rmi: Use safe reads for device responses

### DIFF
--- a/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
@@ -362,6 +362,10 @@ fu_synaptics_rmi_device_setup(FuDevice *device, GError **error)
 	FuSynapticsRmiDevicePrivate *priv = GET_PRIVATE(self);
 	guint16 addr;
 	guint16 prod_info_addr;
+	guint8 f01_query1 = 0;
+	guint8 f01_query43 = 0;
+	guint8 fw_version_major = 0;
+	guint8 fw_version_minor = 0;
 	guint8 product_sub_id = 0;
 	gboolean has_build_id_query = FALSE;
 	gboolean has_dds4_queries = FALSE;
@@ -402,9 +406,15 @@ fu_synaptics_rmi_device_setup(FuDevice *device, GError **error)
 		g_prefix_error_literal(error, "failed to read the basic query: ");
 		return FALSE;
 	}
-	has_lts = (f01_basic->data[1] & RMI_DEVICE_F01_QRY1_HAS_LTS) > 0;
-	has_sensor_id = (f01_basic->data[1] & RMI_DEVICE_F01_QRY1_HAS_SENSOR_ID) > 0;
-	has_query42 = (f01_basic->data[1] & RMI_DEVICE_F01_QRY1_HAS_PROPS_2) > 0;
+	if (!fu_memread_uint8_safe(f01_basic->data, f01_basic->len, 0x1, &f01_query1, error))
+		return FALSE;
+	if (!fu_memread_uint8_safe(f01_basic->data, f01_basic->len, 0x2, &fw_version_major, error))
+		return FALSE;
+	if (!fu_memread_uint8_safe(f01_basic->data, f01_basic->len, 0x3, &fw_version_minor, error))
+		return FALSE;
+	has_lts = (f01_query1 & RMI_DEVICE_F01_QRY1_HAS_LTS) > 0;
+	has_sensor_id = (f01_query1 & RMI_DEVICE_F01_QRY1_HAS_SENSOR_ID) > 0;
+	has_query42 = (f01_query1 & RMI_DEVICE_F01_QRY1_HAS_PROPS_2) > 0;
 
 	/* get the product ID */
 	addr += 11;
@@ -447,12 +457,15 @@ fu_synaptics_rmi_device_setup(FuDevice *device, GError **error)
 	/* read package ids */
 	if (has_query42) {
 		g_autoptr(GByteArray) f01_tmp = NULL;
+		guint8 f01_query42 = 0;
 		f01_tmp = fu_synaptics_rmi_device_read(self, addr++, 1, error);
 		if (f01_tmp == NULL) {
 			g_prefix_error_literal(error, "failed to read query 42: ");
 			return FALSE;
 		}
-		has_dds4_queries = (f01_tmp->data[0] & RMI_DEVICE_F01_QRY42_DS4_QUERIES) > 0;
+		if (!fu_memread_uint8_safe(f01_tmp->data, f01_tmp->len, 0x0, &f01_query42, error))
+			return FALSE;
+		has_dds4_queries = (f01_query42 & RMI_DEVICE_F01_QRY42_DS4_QUERIES) > 0;
 	}
 	if (has_dds4_queries) {
 		g_autoptr(GByteArray) f01_tmp = NULL;
@@ -467,8 +480,10 @@ fu_synaptics_rmi_device_setup(FuDevice *device, GError **error)
 		g_prefix_error_literal(error, "failed to read F01 Query43: ");
 		return FALSE;
 	}
-	has_package_id_query = (f01_ds4->data[0] & RMI_DEVICE_F01_QRY43_01_PACKAGE_ID) > 0;
-	has_build_id_query = (f01_ds4->data[0] & RMI_DEVICE_F01_QRY43_01_BUILD_ID) > 0;
+	if (!fu_memread_uint8_safe(f01_ds4->data, f01_ds4->len, 0x0, &f01_query43, error))
+		return FALSE;
+	has_package_id_query = (f01_query43 & RMI_DEVICE_F01_QRY43_01_PACKAGE_ID) > 0;
+	has_build_id_query = (f01_query43 & RMI_DEVICE_F01_QRY43_01_BUILD_ID) > 0;
 	if (has_package_id_query)
 		prod_info_addr++;
 	if (has_build_id_query) {
@@ -536,10 +551,8 @@ fu_synaptics_rmi_device_setup(FuDevice *device, GError **error)
 	}
 
 	/* set versions */
-	fw_ver = g_strdup_printf("%u.%u.%u",
-				 f01_basic->data[2],
-				 f01_basic->data[3],
-				 priv->flash.build_id);
+	fw_ver =
+	    g_strdup_printf("%u.%u.%u", fw_version_major, fw_version_minor, priv->flash.build_id);
 	fu_device_set_version(device, fw_ver);
 	if (priv->f34->function_version == 0x0 || priv->f34->function_version == 0x1) {
 		bl_ver = g_strdup_printf("%c.0.0", priv->flash.bootloader_id[1]);
@@ -608,6 +621,7 @@ static gboolean
 fu_synaptics_rmi_device_poll(FuSynapticsRmiDevice *self, GError **error)
 {
 	FuSynapticsRmiDevicePrivate *priv = GET_PRIVATE(self);
+	guint8 f34_data = 0;
 	g_autoptr(GByteArray) f34_db = NULL;
 
 	/* get if the last flash read completed successfully */
@@ -616,12 +630,14 @@ fu_synaptics_rmi_device_poll(FuSynapticsRmiDevice *self, GError **error)
 		g_prefix_error_literal(error, "failed to read f34_db: ");
 		return FALSE;
 	}
-	if ((f34_db->data[0] & 0x1f) != 0x0) {
+	if (!fu_memread_uint8_safe(f34_db->data, f34_db->len, 0x0, &f34_data, error))
+		return FALSE;
+	if ((f34_data & 0x1f) != 0x0) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_WRITE,
 			    "flash status invalid: 0x%x",
-			    (guint)(f34_db->data[0] & 0x1f));
+			    (guint)(f34_data & 0x1f));
 		return FALSE;
 	}
 
@@ -689,6 +705,8 @@ fu_synaptics_rmi_device_wait_for_idle(FuSynapticsRmiDevice *self,
 	FuSynapticsRmiDevicePrivate *priv = GET_PRIVATE(self);
 	guint8 f34_command;
 	guint8 f34_enabled;
+	guint8 f34_raw0 = 0;
+	guint8 f34_raw1 = 0;
 	guint8 f34_status;
 	g_autoptr(GByteArray) res = NULL;
 	g_autoptr(GError) error_local = NULL;
@@ -725,16 +743,22 @@ fu_synaptics_rmi_device_wait_for_idle(FuSynapticsRmiDevice *self,
 		res = fu_synaptics_rmi_device_read(self, priv->flash.status_addr, 0x2, error);
 		if (res == NULL)
 			return FALSE;
-		f34_command = res->data[0] & RMI_F34_COMMAND_V1_MASK;
-		f34_status = res->data[1] & RMI_F34_STATUS_V1_MASK;
-		f34_enabled = !!(res->data[1] & RMI_F34_ENABLED_MASK);
+		if (!fu_memread_uint8_safe(res->data, res->len, 0x0, &f34_raw0, error))
+			return FALSE;
+		if (!fu_memread_uint8_safe(res->data, res->len, 0x1, &f34_raw1, error))
+			return FALSE;
+		f34_command = f34_raw0 & RMI_F34_COMMAND_V1_MASK;
+		f34_status = f34_raw1 & RMI_F34_STATUS_V1_MASK;
+		f34_enabled = !!(f34_raw1 & RMI_F34_ENABLED_MASK);
 	} else {
 		res = fu_synaptics_rmi_device_read(self, priv->flash.status_addr, 0x1, error);
 		if (res == NULL)
 			return FALSE;
-		f34_command = res->data[0] & RMI_F34_COMMAND_MASK;
-		f34_status = (res->data[0] >> RMI_F34_STATUS_SHIFT) & RMI_F34_STATUS_MASK;
-		f34_enabled = !!(res->data[0] & RMI_F34_ENABLED_MASK);
+		if (!fu_memread_uint8_safe(res->data, res->len, 0x0, &f34_raw0, error))
+			return FALSE;
+		f34_command = f34_raw0 & RMI_F34_COMMAND_MASK;
+		f34_status = (f34_raw0 >> RMI_F34_STATUS_SHIFT) & RMI_F34_STATUS_MASK;
+		f34_enabled = !!(f34_raw0 & RMI_F34_ENABLED_MASK);
 	}
 
 	/* PS/2 */

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-hid-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-hid-device.c
@@ -476,6 +476,7 @@ static gboolean
 fu_synaptics_rmi_hid_device_disable_sleep(FuSynapticsRmiDevice *rmi_device, GError **error)
 {
 	FuSynapticsRmiFunction *f01;
+	guint8 f01_control = 0;
 	g_autoptr(GByteArray) f01_control0 = NULL;
 
 	f01 = fu_synaptics_rmi_device_get_function(rmi_device, 0x34, error);
@@ -486,9 +487,11 @@ fu_synaptics_rmi_hid_device_disable_sleep(FuSynapticsRmiDevice *rmi_device, GErr
 		g_prefix_error_literal(error, "failed to write get f01_control0: ");
 		return FALSE;
 	}
-	f01_control0->data[0] |= RMI_F01_CRTL0_NOSLEEP_BIT;
-	f01_control0->data[0] =
-	    (f01_control0->data[0] & ~RMI_F01_CTRL0_SLEEP_MODE_MASK) | RMI_SLEEP_MODE_NORMAL;
+	if (!fu_memread_uint8_safe(f01_control0->data, f01_control0->len, 0x0, &f01_control, error))
+		return FALSE;
+	f01_control |= RMI_F01_CRTL0_NOSLEEP_BIT;
+	f01_control = (f01_control & ~RMI_F01_CTRL0_SLEEP_MODE_MASK) | RMI_SLEEP_MODE_NORMAL;
+	f01_control0->data[0] = f01_control;
 	if (!fu_synaptics_rmi_device_write(rmi_device,
 					   f01->control_base,
 					   f01_control0,

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-v5-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-v5-device.c
@@ -475,6 +475,7 @@ fu_synaptics_rmi_v5_device_setup(FuSynapticsRmiDevice *self, GError **error)
 {
 	FuSynapticsRmiFunction *f34;
 	FuSynapticsRmiFlash *flash = fu_synaptics_rmi_device_get_flash(self);
+	guint8 flash_properties1 = 0;
 	guint8 flash_properties2 = 0;
 	g_autoptr(GByteArray) f34_data0 = NULL;
 	g_autoptr(GByteArray) f34_data2 = NULL;
@@ -491,15 +492,27 @@ fu_synaptics_rmi_v5_device_setup(FuSynapticsRmiDevice *self, GError **error)
 		g_prefix_error_literal(error, "failed to read bootloader ID: ");
 		return FALSE;
 	}
-	flash->bootloader_id[0] = f34_data0->data[0];
-	flash->bootloader_id[1] = f34_data0->data[1];
+	if (!fu_memread_uint8_safe(f34_data0->data,
+				   f34_data0->len,
+				   0x0,
+				   &flash->bootloader_id[0],
+				   error))
+		return FALSE;
+	if (!fu_memread_uint8_safe(f34_data0->data,
+				   f34_data0->len,
+				   0x1,
+				   &flash->bootloader_id[1],
+				   error))
+		return FALSE;
 
 	/* get flash properties1 */
 	f34_data2 = fu_synaptics_rmi_device_read(self, f34->query_base + 0x2, 0x7, error);
 	if (f34_data2 == NULL)
 		return FALSE;
 
-	if (f34_data2->data[0] & 0x80) {
+	if (!fu_memread_uint8_safe(f34_data2->data, f34_data2->len, 0x0, &flash_properties1, error))
+		return FALSE;
+	if (flash_properties1 & 0x80) {
 		/* get flash properties2 */
 		buf_flash_properties2 =
 		    fu_synaptics_rmi_device_read(self, f34->query_base + 0x9, 1, error);
@@ -571,6 +584,7 @@ gboolean
 fu_synaptics_rmi_v5_device_query_status(FuSynapticsRmiDevice *self, GError **error)
 {
 	FuSynapticsRmiFunction *f01;
+	guint8 f01_data = 0;
 	g_autoptr(GByteArray) f01_db = NULL;
 
 	/* f01 */
@@ -582,7 +596,9 @@ fu_synaptics_rmi_v5_device_query_status(FuSynapticsRmiDevice *self, GError **err
 		g_prefix_error_literal(error, "failed to read the f01 data base: ");
 		return FALSE;
 	}
-	if (f01_db->data[0] & 0x40) {
+	if (!fu_memread_uint8_safe(f01_db->data, f01_db->len, 0x0, &f01_data, error))
+		return FALSE;
+	if (f01_data & 0x40) {
 		fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 	} else {
 		fu_device_remove_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-v7-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-v7-device.c
@@ -32,6 +32,7 @@ fu_synaptics_rmi_v7_device_detach(FuSynapticsRmiDevice *self, FuProgress *progre
 	/* enter SBL */
 	if (flash->has_sbl) {
 		FuSynapticsRmiFunction *f01;
+		guint16 sbl_version = 0;
 		g_autoptr(GByteArray) f01_basic = NULL;
 
 		if (!fu_synaptics_rmi_v7_device_enter_sbl(self, error)) {
@@ -49,9 +50,14 @@ fu_synaptics_rmi_v7_device_detach(FuSynapticsRmiDevice *self, FuProgress *progre
 			g_prefix_error_literal(error, "failed to read the basic query: ");
 			return FALSE;
 		}
-		fu_synaptics_rmi_device_set_previous_sbl_version(self,
-								 f01_basic->data[2] << 8 |
-								     f01_basic->data[3]);
+		if (!fu_memread_uint16_safe(f01_basic->data,
+					    f01_basic->len,
+					    0x2,
+					    &sbl_version,
+					    G_BIG_ENDIAN,
+					    error))
+			return FALSE;
+		fu_synaptics_rmi_device_set_previous_sbl_version(self, sbl_version);
 		g_debug("SBL version: %d.%d",
 			fu_synaptics_rmi_device_get_previous_sbl_version(self) >> 8,
 			fu_synaptics_rmi_device_get_previous_sbl_version(self) & 0xff);
@@ -906,6 +912,7 @@ fu_synaptics_rmi_v7_device_read_flash_config(FuSynapticsRmiDevice *self, GError 
 	g_autoptr(GByteArray) req_transfer_length = g_byte_array_new();
 	g_autoptr(GByteArray) res = NULL;
 	gsize partition_size = FU_STRUCT_RMI_PARTITION_TBL_SIZE;
+	guint8 flash_cfg0 = 0;
 
 	/* f34 */
 	f34 = fu_synaptics_rmi_device_get_function(self, 0x34, error);
@@ -968,11 +975,13 @@ fu_synaptics_rmi_v7_device_read_flash_config(FuSynapticsRmiDevice *self, GError 
 		g_prefix_error_literal(error, "failed to read: ");
 		return FALSE;
 	}
+	if (!fu_memread_uint8_safe(res->data, res->len, 0x0, &flash_cfg0, error))
+		return FALSE;
 
 	/* debugging */
 	fu_dump_full(G_LOG_DOMAIN, "FlashConfig", res->data, res->len, 80, FU_DUMP_FLAG_NONE);
 
-	if ((res->data[0] & 0x0f) == 1)
+	if ((flash_cfg0 & 0x0f) == 1)
 		partition_size += 0x2;
 
 	/* parse the config length */
@@ -1013,6 +1022,7 @@ fu_synaptics_rmi_v7_device_setup(FuSynapticsRmiDevice *self, GError **error)
 {
 	FuSynapticsRmiFlash *flash = fu_synaptics_rmi_device_get_flash(self);
 	FuSynapticsRmiFunction *f34;
+	guint8 f34_query0 = 0;
 	guint8 offset;
 	g_autoptr(FuStructSynapticsRmiV7F34x) st_f34x = NULL;
 	g_autoptr(GByteArray) f34_data0 = NULL;
@@ -1028,8 +1038,10 @@ fu_synaptics_rmi_v7_device_setup(FuSynapticsRmiDevice *self, GError **error)
 		g_prefix_error_literal(error, "failed to read bootloader ID: ");
 		return FALSE;
 	}
-	flash->has_security = (f34_data0->data[0] & 0x40) ? TRUE : FALSE;
-	offset = (f34_data0->data[0] & 0b00000111) + 1;
+	if (!fu_memread_uint8_safe(f34_data0->data, f34_data0->len, 0x0, &f34_query0, error))
+		return FALSE;
+	flash->has_security = (f34_query0 & 0x40) ? TRUE : FALSE;
+	offset = (f34_query0 & 0b00000111) + 1;
 	f34_data = fu_synaptics_rmi_device_read(self, f34->query_base + offset, 21, error);
 	if (f34_data == NULL)
 		return FALSE;
@@ -1095,7 +1107,8 @@ fu_synaptics_rmi_v7_device_query_status(FuSynapticsRmiDevice *self, GError **err
 		g_prefix_error_literal(error, "failed to read the f01 data base: ");
 		return FALSE;
 	}
-	status = f34_data->data[0];
+	if (!fu_memread_uint8_safe(f34_data->data, f34_data->len, 0x0, &status, error))
+		return FALSE;
 	if (status & 0x80) {
 		fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 	} else {


### PR DESCRIPTION
Type of pull request:
- [x] Code fix

`config_length` is a device-supplied F34 query field. Its siblings `block_size` and `payload_length` are checked non-zero, but `config_length` is only product-bounded, so a device reporting `config_length == 0` yields a zero-length readback and then dereferences `res->data[0]`. Guard the readback length before use.

Built and tested clean (full meson suite + `-Db_sanitize=address`, synaptics-rmi self-test).