### PR TITLE
efi-section: Validate GUID-defined section offset against size

### DIFF
--- a/libfwupdplugin/fu-efi-section.c
+++ b/libfwupdplugin/fu-efi-section.c
@@ -322,6 +322,15 @@ fu_efi_section_parse(FuFirmware *firmware,
 				    (guint)fu_struct_efi_section_guid_defined_get_offset(st_def));
 			return FALSE;
 		}
+		if (fu_struct_efi_section_guid_defined_get_offset(st_def) > size) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "invalid section offset 0x%x, greater than size 0x%x",
+				    (guint)fu_struct_efi_section_guid_defined_get_offset(st_def),
+				    (guint)size);
+			return FALSE;
+		}
 		offset_delta = fu_struct_efi_section_guid_defined_get_offset(st_def) - stlen;
 		if (!fu_size_checked_inc(&offset, offset_delta, error)) {
 			g_prefix_error_literal(error, "section offset overflow: ");

--- a/libfwupdplugin/fu-firmware-test.c
+++ b/libfwupdplugin/fu-firmware-test.c
@@ -643,6 +643,29 @@ fu_firmware_efi_section_extended_size_func(void)
 }
 
 static void
+fu_firmware_efi_section_guid_offset_func(void)
+{
+	gboolean ret;
+	g_autoptr(FuFirmware) firmware = fu_efi_section_new();
+	g_autoptr(FuStructEfiSection) st = fu_struct_efi_section_new();
+	g_autoptr(FuStructEfiSectionGuidDefined) st_def = fu_struct_efi_section_guid_defined_new();
+	g_autoptr(GBytes) blob = NULL;
+	g_autoptr(GError) error = NULL;
+
+	/* the data offset cannot be larger than the declared section size */
+	fu_struct_efi_section_set_size(st, 0x18);
+	fu_struct_efi_section_set_type(st, FU_EFI_SECTION_TYPE_GUID_DEFINED);
+	fu_struct_efi_section_guid_defined_set_offset(st_def, 0x19);
+	fu_byte_array_append_array(st->buf, st_def->buf);
+
+	blob = g_bytes_new(st->buf->data, st->buf->len);
+	ret = fu_firmware_parse_bytes(firmware, blob, 0x0, FU_FIRMWARE_PARSE_FLAG_NONE, &error);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL);
+	g_assert_cmpstr(error->message, ==, "invalid section offset 0x19, greater than size 0x18");
+	g_assert_false(ret);
+}
+
+static void
 fu_firmware_ifwi_fpt_func(void)
 {
 	g_autofree gchar *filename = NULL;
@@ -1225,6 +1248,8 @@ main(int argc, char **argv)
 			fu_firmware_ifwi_cpd_manifest_overflow_func);
 	g_test_add_func("/fwupd/firmware/efi-section-extended-size",
 			fu_firmware_efi_section_extended_size_func);
+	g_test_add_func("/fwupd/firmware/efi-section-guid-offset",
+			fu_firmware_efi_section_guid_offset_func);
 	g_test_add_func("/fwupd/firmware/ifwi-fpt", fu_firmware_ifwi_fpt_func);
 	g_test_add_func("/fwupd/firmware/oprom", fu_firmware_oprom_func);
 	g_test_add_func("/fwupd/firmware/dfu", fu_firmware_dfu_func);


### PR DESCRIPTION
Type of pull request:
- [x] Code fix

Follow-up to 40a21cc04. The `GUID_DEFINED` branch bounds the section offset only from below (`< st_def->buf->len`); an offset greater than `size` makes `size - offset` underflow at `fu_partial_input_stream_new`. Add the upper-bound check mirroring the parent fix. Includes a regression test.

Built and tested clean (full meson suite + `-Db_sanitize=address`).