### PR TITLE
dfu: avoid out-of-bounds read in fu_dfu_target_parse_sector

### DIFF
--- a/plugins/dfu/fu-dfu-self-test.c
+++ b/plugins/dfu/fu-dfu-self-test.c
@@ -123,6 +123,12 @@ fu_dfu_target_dfuse_func(void)
 	g_assert_false(ret);
 	ret = fu_dfu_target_parse_sectors(target, "@Internal Flash /0x08000000/12*001a", NULL);
 	g_assert_false(ret);
+
+	/* absent-sector-size device reporting a sector with a size but no type must be
+	 * rejected without reading past the end of the tokenised string */
+	fu_device_add_private_flag(FU_DEVICE(device), FU_DFU_DEVICE_FLAG_ABSENT_SECTOR_SIZE);
+	ret = fu_dfu_target_parse_sectors(target, "@Internal Flash /0x08000000/2*016", NULL);
+	g_assert_false(ret);
 }
 
 int

--- a/plugins/dfu/fu-dfu-target.c
+++ b/plugins/dfu/fu-dfu-target.c
@@ -143,7 +143,8 @@ fu_dfu_target_parse_sector(FuDfuTarget *self,
 	if (proxy == NULL)
 		return FALSE;
 	if (fu_device_has_private_flag(proxy, FU_DFU_DEVICE_FLAG_ABSENT_SECTOR_SIZE)) {
-		if (tmp[1] == '\0') {
+		/* handle trailing NUL */
+		if (tmp[0] != '\0' && tmp[1] == '\0') {
 			tmp[1] = tmp[0];
 			tmp[0] = 'B';
 		}


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

fu_dfu_target_parse_sector walks the dfuse sector descriptor with g_ascii_strtoull, and for devices with the absent-sector-size quirk (e.g. the STM32 dfuse bootloader, VID_0483&PID_DF11) it checks tmp[1] to decide whether a lone trailing type character needs the implied byte multiplier. if the size is the final token, e.g. a device reporting `2*016` with no type letter, tmp already sits on the terminating nul and tmp[1] reads one byte past the g_strsplit-allocated token; the following tmp[1] = tmp[0] can also write past it. the layout string comes from the usb interface descriptor through fu_dfu_target_setup, so a malformed or hostile dfuse device reaches this during enumeration. guarding tmp[0] against the nul before the lookahead leaves valid absent-size layouts unchanged and lets a truncated spec fall through to the existing invalid-multiplier rejection. the added self-test sets the quirk and asserts such a spec is now refused.
