### PR TITLE
Fix dropped status updates during updates

### DIFF
--- a/src/fu-daemon.c
+++ b/src/fu-daemon.c
@@ -100,14 +100,13 @@ fu_daemon_set_status(FuDaemon *self, FwupdStatus status)
 	if (priv->status == status)
 		return;
 
-	/* starting or stopping */
-	if ((priv->status == FWUPD_STATUS_IDLE && status != FWUPD_STATUS_WAITING_FOR_AUTH) ||
-	    status == FWUPD_STATUS_IDLE) {
+	/* only defer auth prompts to avoid a short-lived spinner */
+	if (status != FWUPD_STATUS_WAITING_FOR_AUTH) {
 		fu_daemon_set_status_internal(self, status);
 		return;
 	}
 
-	/* defer all updates to avoid flickering the UI */
+	/* defer waiting-for-auth updates to avoid flickering the UI */
 	helper = g_new0(FuDaemonSetStatusHelper, 1);
 	helper->self = self;
 	helper->status = status;


### PR DESCRIPTION
Commit 36c586429 added deferred status emission to reduce short-lived PolicyKit “Authenticating…” flicker. That defer/cancel behavior can also drop transient update statuses (for example device-write) before they are emitted, which hides useful phase information during firmware updates.

This change updates fu_daemon_set_status() to defer only FWUPD_STATUS_WAITING_FOR_AUTH and emit all other statuses immediately.




Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
