### PR TITLE
Fix incorrect LVFS version parsing

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -1424,26 +1424,6 @@
       <package variant="aarch64" />
     </distro>
   </dependency>
-  <dependency id="python3-packaging">
-    <distro id="centos">
-      <package variant="x86_64" />
-    </distro>
-    <distro id="fedora">
-      <package variant="x86_64" />
-      <package variant="aarch64" />
-    </distro>
-    <distro id="arch">
-      <package variant="x86_64">python-packaging</package>
-    </distro>
-    <distro id="debian">
-      <control />
-    </distro>
-    <distro id="ubuntu">
-      <control />
-      <package variant="x86_64" />
-      <package variant="aarch64" />
-    </distro>
-  </dependency>
   <dependency id="rpm-build">
     <distro id="centos">
       <package variant="x86_64" />

--- a/contrib/ci/oss-fuzz.py
+++ b/contrib/ci/oss-fuzz.py
@@ -583,7 +583,6 @@ if __name__ == "__main__":
                 "libtool",
                 "python3",
                 "python3-jinja2",
-                "python3-packaging",
             ],
             stdout=open(os.devnull, "wb"),
         )

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -64,7 +64,6 @@ BuildRequires: libcurl-devel >= %{libcurl_version}
 BuildRequires: libjcat-devel
 %endif
 BuildRequires: polkit-devel >= 0.103
-BuildRequires: python3-packaging
 BuildRequires: python3-jinja2
 BuildRequires: sqlite-devel
 BuildRequires: systemd >= %{systemd_version}
@@ -200,7 +199,6 @@ or server machines.
 Summary: fwupd wrapper for Qubes OS - dom0 scripts
 Requires:   fwupd >= 2.0.0
 Requires:   libjcat >= 0.1.6
-Requires:   python3-packaging
 Requires:   sequoia-sqv
 
 %description qubes-dom0
@@ -210,7 +208,6 @@ fwupd wrapper for Qubes OS
 Summary: fwupd wrapper for Qubes OS - VM scripts
 Requires:   fwupd >= 2.0.0
 Requires:   libjcat >= 0.1.6
-Requires:   python3-packaging
 
 %description qubes-vm
 fwupd wrapper for Qubes OS

--- a/contrib/qubes/meson.build
+++ b/contrib/qubes/meson.build
@@ -53,16 +53,14 @@ install_symlink(
 )
 
 if get_option('tests')
-  # The tests that need dom0 skip themselves, so the rest can run anywhere.
-  # They import the modules under src/ by bare name, the way they do once
-  # installed alongside each other in /usr/share/qubes-fwupd/src, and read
-  # their fixtures relative to the source directory.
   test(
     'qubes-fwupdmgr-test',
     python3,
     args: ['-m', 'pytest', '-v', 'test/'],
     workdir: meson.current_source_dir(),
-    env: {'PYTHONPATH': meson.current_source_dir() / 'src'},
+    env: {
+      'PYTHONPATH': meson.current_source_dir() / 'src',
+    },
     timeout: 180,
   )
 endif

--- a/contrib/qubes/meson.build
+++ b/contrib/qubes/meson.build
@@ -51,3 +51,18 @@ install_symlink(
   pointing_to: '/usr/share/qubes-fwupd/src/qubes_fwupdmgr.py',
   install_dir: '/usr/sbin',
 )
+
+if get_option('tests')
+  # The tests that need dom0 skip themselves, so the rest can run anywhere.
+  # They import the modules under src/ by bare name, the way they do once
+  # installed alongside each other in /usr/share/qubes-fwupd/src, and read
+  # their fixtures relative to the source directory.
+  test(
+    'qubes-fwupdmgr-test',
+    python3,
+    args: ['-m', 'pytest', '-v', 'test/'],
+    workdir: meson.current_source_dir(),
+    env: {'PYTHONPATH': meson.current_source_dir() / 'src'},
+    timeout: 180,
+  )
+endif

--- a/contrib/qubes/src/qubes_fwupdmgr.py
+++ b/contrib/qubes/src/qubes_fwupdmgr.py
@@ -14,6 +14,7 @@ import subprocess
 import tempfile
 import sys
 import xml.etree.ElementTree as ET
+import re
 
 from pathlib import Path
 
@@ -327,15 +328,17 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         # and defines a total ordering over them that's a strict superset of the semver ordering (because the numerical components are the first element of the tuple)
         if version_specifier == "":
             raise ValueError("empty version specifier")
-        numerical_components = []
-        for component in version_specifier.split("."):
-            try:
-                if component == "":
-                    raise ValueError()
-                numerical_components.append(int(component.lstrip("0") or "0", 0))
-            except ValueError:
-                return ((), version_specifier)
-        return (tuple(numerical_components), "")
+        if not re.fullmatch(r"0[xX][0-9a-fA-F]+|\d+(?:\.\d+)*", version_specifier):
+            return ((), version_specifier)  # "plain" format
+        numerical_components = tuple(
+            (
+                int(component, 16)
+                if component.lower().startswith("0x")
+                else int(component, 10)
+            )
+            for component in version_specifier.split(".")
+        )
+        return (numerical_components, "")
 
     def _parse_parameters(self, updates_list, choice):
         """Parses device name, url, version and SHA256 checksum of the file list.
@@ -347,7 +350,9 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         self.name = updates_list[choice]["Name"]
         self.version = updates_list[choice]["Releases"][0]["Version"]
         for ver_check in updates_list[choice]["Releases"]:
-            if self._parse_lvfs_version(ver_check["Version"]) >= self._parse_lvfs_version(self.version):
+            if self._parse_lvfs_version(
+                ver_check["Version"]
+            ) >= self._parse_lvfs_version(self.version):
                 self.version = ver_check["Version"]
                 self.url = ver_check["Url"]
                 self.sha = ver_check["Checksum"]
@@ -388,9 +393,9 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
             raise ValueError("No vendor information in firmware metainfo.")
         if vendor not in dmi_info:
             raise ValueError("Wrong firmware provider.")
-        if not downgrade and self._parse_lvfs_version(version) <= self._parse_lvfs_version(
-            self.dmi_version
-        ):
+        if not downgrade and self._parse_lvfs_version(
+            version
+        ) <= self._parse_lvfs_version(self.dmi_version):
             raise ValueError(f"{version} < {self.dmi_version} Downgrade not allowed")
 
     def _get_dom0_devices(self):

--- a/contrib/qubes/src/qubes_fwupdmgr.py
+++ b/contrib/qubes/src/qubes_fwupdmgr.py
@@ -14,9 +14,9 @@ import subprocess
 import tempfile
 import sys
 import xml.etree.ElementTree as ET
+import re
 
 from pathlib import Path
-from packaging import version as pversion
 
 FWUPD_QUBES_DIR = "/usr/share/qubes-fwupd"
 
@@ -44,6 +44,7 @@ METADATA_URL = "https://fwupd.org/downloads/firmware.xml.xz"
 METADATA_URL_JCAT = "https://fwupd.org/downloads/firmware.xml.xz.jcat"
 
 FWUPDMGR = "/bin/fwupdmgr"
+FWUPDTOOL = "/bin/fwupdtool"
 
 BIOS_UPDATE_FLAG = os.path.join(FWUPD_DOM0_DIR, "bios_update")
 LVFS_TESTING_DOM0_FLAG = os.path.join(FWUPD_DOM0_DIR, "lvfs_testing")
@@ -225,6 +226,7 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
             {
                 "Name": device["Name"],
                 "Version": device["Version"],
+                "VersionFormat": device.get("VersionFormat"),
                 "Releases": [
                     {
                         "Version": update["Version"],
@@ -315,6 +317,47 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
                 except ValueError:
                     print("Invalid choice.")
 
+    def _compare_versions(self, version_a, version_b, version_format=None):
+        """Compares two firmware versions using `fwupdtool vercmp`. This supports all of the version number formats in https://fwupd.org/lvfs/docs/metainfo/version
+
+        Keywords arguments:
+        version_a -- first version specifier, e.g. "1.2.3"
+        version_b -- second version specifier, e.g. "1.2.4"
+        version_format -- device version format, e.g. "triplet" or "hex", none to auto-detect
+
+        Returns -1 if version_a is before version_b, 1 if after,
+        and 0 if equal.
+        """
+        for version in (version_a, version_b):
+            if not isinstance(version, str) or version.strip() == "":
+                raise ValueError(f"empty version specifier: {version!r}")
+            if version.startswith("-") or "\n" in version or "\r" in version:
+                # fwupdtool would read these as options, or as extra output
+                raise ValueError(f"unsupported version specifier: {version!r}")
+
+        # a None or "unknown" version format means auto-detect, so just leave off the third parameter if so
+        p = subprocess.run(
+            [FWUPDTOOL, "vercmp", version_a, version_b]
+            + ([] if version_format in (None, "unknown") else [version_format]),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if p.returncode != 0:
+            raise Exception(
+                f"fwupd-qubes: Comparing {version_a!r} with {version_b!r} failed: {p.stderr.decode(errors='replace').strip()}"
+            )
+        # fwupdtool outputs "VERSION1 <op> VERSION2"
+        output = p.stdout.decode(errors="replace")
+        for line in output.splitlines():
+            match = re.fullmatch(
+                f"{re.escape(version_a)} (<|==|>) {re.escape(version_b)}", line
+            )
+            if match:
+                return {"<": -1, "==": 0, ">": 1}[match.group(1)]
+        raise Exception(
+            f"fwupd-qubes: invalid `fwupdtool vercmp` output: {output.strip()!r}"
+        )
+
     def _parse_parameters(self, updates_list, choice):
         """Parses device name, url, version and SHA256 checksum of the file list.
 
@@ -323,9 +366,15 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         choice -- number of device to be updated
         """
         self.name = updates_list[choice]["Name"]
+        self.version_format = updates_list[choice].get("VersionFormat")
         self.version = updates_list[choice]["Releases"][0]["Version"]
         for ver_check in updates_list[choice]["Releases"]:
-            if pversion.parse(ver_check["Version"]) >= pversion.parse(self.version):
+            if (
+                self._compare_versions(
+                    ver_check["Version"], self.version, self.version_format
+                )
+                >= 0
+            ):
                 self.version = ver_check["Version"]
                 self.url = ver_check["Url"]
                 self.sha = ver_check["Checksum"]
@@ -343,13 +392,14 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
             raise Exception("dmidecode: Reading DMI failed")
         return p.communicate()[0].decode()
 
-    def _verify_dmi(self, arch_path, version, downgrade=False):
+    def _verify_dmi(self, arch_path, version, downgrade=False, version_format=None):
         """Verifies DMI tables for BIOS updates.
 
         Keywords arguments:
         arch_path -- absolute path of the update archive
         version -- version of the update
         downgrade -- downgrade flag
+        version_format -- version format of the device being updated
         """
         dmi_info = self._read_dmi()
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -366,8 +416,9 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
             raise ValueError("No vendor information in firmware metainfo.")
         if vendor not in dmi_info:
             raise ValueError("Wrong firmware provider.")
-        if not downgrade and pversion.parse(version) <= pversion.parse(
-            self.dmi_version
+        if (
+            not downgrade
+            and self._compare_versions(version, self.dmi_version, version_format) <= 0
         ):
             raise ValueError(f"{version} < {self.dmi_version} Downgrade not allowed")
 
@@ -404,7 +455,9 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         self._download_firmware_updates(self.url, self.sha, whonix=whonix)
         if self.name == "System Firmware":
             Path(BIOS_UPDATE_FLAG).touch(mode=0o644, exist_ok=True)
-            self._verify_dmi(self.arch_path, self.version)
+            self._verify_dmi(
+                self.arch_path, self.version, version_format=self.version_format
+            )
         self._install_dom0_firmware(
             self.arch_path,
             allow_older=allow_older,
@@ -428,10 +481,12 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
                     version = device["Version"]
                 except KeyError:
                     continue
+                version_format = device.get("VersionFormat")
                 downgrades.append(
                     {
                         "Name": device["Name"],
                         "Version": device["Version"],
+                        "VersionFormat": version_format,
                         "Releases": [
                             {
                                 "Version": downgrade["Version"],
@@ -440,8 +495,10 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
                                 "Checksum": downgrade["Checksum"][-1],
                             }
                             for downgrade in device["Releases"]
-                            if pversion.parse(downgrade["Version"])
-                            < pversion.parse(version)
+                            if self._compare_versions(
+                                downgrade["Version"], version, version_format
+                            )
+                            < 0
                         ],
                     }
                 )
@@ -536,16 +593,25 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
             return uri, match["Checksum"][-1]
 
         current = target_device.get("Version", "0")
+        version_format = target_device.get("VersionFormat")
         candidates = [
             r
             for r in releases
             if self._release_eligible(
-                r.get("Version"), current, allow_older, allow_reinstall
+                r.get("Version"), current, allow_older, allow_reinstall, version_format
             )
         ]
         if not candidates:
             raise Exception(f"No eligible release found for device '{device_id}'")
-        best = max(candidates, key=lambda r: pversion.Version(r["Version"]))
+        best = candidates[0]
+        for candidate in candidates[1:]:
+            if (
+                self._compare_versions(
+                    candidate["Version"], best["Version"], version_format
+                )
+                > 0
+            ):
+                best = candidate
         uri = self._release_uri(best)
         if not uri:
             raise Exception(
@@ -616,6 +682,7 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
                 self.arch_path,
                 downgrade["Version"],
                 downgrade=True,
+                version_format=downgrade.get("VersionFormat"),
             )
         self._install_dom0_firmware_downgrade(self.arch_path)
 
@@ -853,13 +920,18 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
             if not dev_id:
                 continue
             dev_ver = device.get("Version", "0")
+            version_format = device.get("VersionFormat")
 
             releases, _ = self._fwupd_get_releases(dev_id, allow_older, allow_reinstall)
             candidates = [
                 r
                 for r in releases
                 if self._release_eligible(
-                    r.get("Version"), dev_ver, allow_older, allow_reinstall
+                    r.get("Version"),
+                    dev_ver,
+                    allow_older,
+                    allow_reinstall,
+                    version_format,
                 )
             ]
             if not candidates:
@@ -869,6 +941,7 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
                 {
                     "Name": device.get("Name", "Unknown"),
                     "Version": dev_ver,
+                    "VersionFormat": version_format,
                     "Releases": [
                         {
                             "Version": r["Version"],
@@ -883,22 +956,28 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
             )
         return updates_list
 
-    def _release_eligible(self, rel_ver_str, cur_ver_str, allow_older, allow_reinstall):
-        """Return True if a release is eligible to install over current using
-        packaging.version human-readable Version strings.
+    def _release_eligible(
+        self,
+        rel_ver_str,
+        cur_ver_str,
+        allow_older,
+        allow_reinstall,
+        version_format=None,
+    ):
+        """Return True if a release is eligible to install over current, using
+        fwupd's own version comparison.
         """
         if not rel_ver_str:
             return False
         try:
-            rv = pversion.parse(rel_ver_str)
-            cv = pversion.parse(cur_ver_str or "0")
+            rc = self._compare_versions(rel_ver_str, cur_ver_str or "0", version_format)
         except Exception:
             return False
-        if rv > cv:
+        if rc > 0:
             return True
-        if rv == cv and allow_reinstall:
+        if rc == 0 and allow_reinstall:
             return True
-        if rv < cv and allow_older:
+        if rc < 0 and allow_older:
             return True
         return False
 

--- a/contrib/qubes/src/qubes_fwupdmgr.py
+++ b/contrib/qubes/src/qubes_fwupdmgr.py
@@ -326,6 +326,7 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         # 2) the first element is an empty tuple and the second is the raw version specifier passed into this function
         # this format of 2-tuple can represent any valid LVFS version specifier, including the "plain" format (arbitrary ASCII string),
         # and defines a total ordering over them that's a strict superset of the semver ordering (because the numerical components are the first element of the tuple)
+        version_specifier = version_specifier.strip()
         if version_specifier == "":
             raise ValueError("empty version specifier")
         if not re.fullmatch(r"0[xX][0-9a-fA-F]+|\d+(?:\.\d+)*", version_specifier):

--- a/contrib/qubes/src/qubes_fwupdmgr.py
+++ b/contrib/qubes/src/qubes_fwupdmgr.py
@@ -16,7 +16,6 @@ import sys
 import xml.etree.ElementTree as ET
 
 from pathlib import Path
-from packaging import version as pversion
 
 FWUPD_QUBES_DIR = "/usr/share/qubes-fwupd"
 
@@ -315,6 +314,29 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
                 except ValueError:
                     print("Invalid choice.")
 
+    def _parse_lvfs_version(self, version_specifier):
+        """Parses an LVFS-standard version specifier into a packaging.version.Version.
+
+        Keywords arguments:
+        version_specifier - a string following any format listed in the LVFS version specifier standard: https://fwupd.org/lvfs/docs/metainfo/version
+        """
+        # returns a 2-tuple where either:
+        # 1) the first element is a tuple of the numerical components of the version specifier and the second is an empty string, or
+        # 2) the first element is an empty tuple and the second is the raw version specifier passed into this function
+        # this format of 2-tuple can represent any valid LVFS version specifier, including the "plain" format (arbitrary ASCII string),
+        # and defines a total ordering over them that's a strict superset of the semver ordering (because the numerical components are the first element of the tuple)
+        if version_specifier == "":
+            raise ValueError("empty version specifier")
+        numerical_components = []
+        for component in version_specifier.split("."):
+            try:
+                if component == "":
+                    raise ValueError()
+                numerical_components.append(int(component.lstrip("0") or "0", 0))
+            except ValueError:
+                return ((), version_specifier)
+        return (tuple(numerical_components), "")
+
     def _parse_parameters(self, updates_list, choice):
         """Parses device name, url, version and SHA256 checksum of the file list.
 
@@ -325,7 +347,7 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         self.name = updates_list[choice]["Name"]
         self.version = updates_list[choice]["Releases"][0]["Version"]
         for ver_check in updates_list[choice]["Releases"]:
-            if pversion.parse(ver_check["Version"]) >= pversion.parse(self.version):
+            if self._parse_lvfs_version(ver_check["Version"]) >= self._parse_lvfs_version(self.version):
                 self.version = ver_check["Version"]
                 self.url = ver_check["Url"]
                 self.sha = ver_check["Checksum"]
@@ -366,7 +388,7 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
             raise ValueError("No vendor information in firmware metainfo.")
         if vendor not in dmi_info:
             raise ValueError("Wrong firmware provider.")
-        if not downgrade and pversion.parse(version) <= pversion.parse(
+        if not downgrade and self._parse_lvfs_version(version) <= self._parse_lvfs_version(
             self.dmi_version
         ):
             raise ValueError(f"{version} < {self.dmi_version} Downgrade not allowed")
@@ -440,8 +462,8 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
                                 "Checksum": downgrade["Checksum"][-1],
                             }
                             for downgrade in device["Releases"]
-                            if pversion.parse(downgrade["Version"])
-                            < pversion.parse(version)
+                            if self._parse_lvfs_version(downgrade["Version"])
+                            < self._parse_lvfs_version(version)
                         ],
                     }
                 )
@@ -545,7 +567,7 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         ]
         if not candidates:
             raise Exception(f"No eligible release found for device '{device_id}'")
-        best = max(candidates, key=lambda r: pversion.Version(r["Version"]))
+        best = max(candidates, key=lambda r: self._parse_lvfs_version(r["Version"]))
         uri = self._release_uri(best)
         if not uri:
             raise Exception(
@@ -890,8 +912,8 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         if not rel_ver_str:
             return False
         try:
-            rv = pversion.parse(rel_ver_str)
-            cv = pversion.parse(cur_ver_str or "0")
+            rv = self._parse_lvfs_version(rel_ver_str)
+            cv = self._parse_lvfs_version(cur_ver_str or "0")
         except Exception:
             return False
         if rv > cv:

--- a/contrib/qubes/test/logs/firmware.metainfo.xml
+++ b/contrib/qubes/test/logs/firmware.metainfo.xml
@@ -23,8 +23,8 @@
   </custom>
   <releases>
     <release version="P1.1" date="2020-01-22" urgency="critical">
-      <checksum type="sha1" filename="firmware.bin" target="content">b03252481573f600c7f530d7a4c24bd62c810412</checksum>
-      <checksum type="sha256" filename="firmware.bin" target="content">bd866bcd2b5964da4b20d3f57128746efb7afefe648cf7284f2fae399225f1ac</checksum>
+      <checksum type="sha1" filename="firmware.bin" target="content">9332d7951dfba2482715f9ae996fb84501cb7018</checksum>
+      <checksum type="sha256" filename="firmware.bin" target="content">4341936755527ae568af8fdfcb8c1f274512a4600e31c012a7bfe85252055f9f</checksum>
       <description>
         <p>This stable release fixes the following issues:</p>
         <ul>
@@ -34,7 +34,7 @@
           <li>Updated the Intel CPU Microcode.</li>
         </ul>
       </description>
-      <size type="installed">14699068</size>
+      <size type="installed">26</size>
       <issues>
         <issue type="cve">CVE-2019-14607</issue>
         <issue type="cve">CVE-2019-11157</issue>

--- a/contrib/qubes/test/logs/help.log
+++ b/contrib/qubes/test/logs/help.log
@@ -25,6 +25,7 @@ Flags:
 	--allow-older:			Allow installing an older firmware version
 	--allow-reinstall:		Allow reinstalling the same firmware version
 	--force:			Force the firmware update even if not required
+	--ignore-postquantum:		Ignore pkcs7 failures for LVFS CA 2025PQ if at least one other CA signature is verified
 
 Help:
 ======================================================================

--- a/contrib/qubes/test/logs/metainfo_name/firmware.metainfo.xml
+++ b/contrib/qubes/test/logs/metainfo_name/firmware.metainfo.xml
@@ -23,8 +23,8 @@
   </custom>
   <releases>
     <release version="P1.1" date="2020-01-22" urgency="critical">
-      <checksum type="sha1" filename="firmware.bin" target="content">b03252481573f600c7f530d7a4c24bd62c810412</checksum>
-      <checksum type="sha256" filename="firmware.bin" target="content">bd866bcd2b5964da4b20d3f57128746efb7afefe648cf7284f2fae399225f1ac</checksum>
+      <checksum type="sha1" filename="firmware.bin" target="content">9332d7951dfba2482715f9ae996fb84501cb7018</checksum>
+      <checksum type="sha256" filename="firmware.bin" target="content">4341936755527ae568af8fdfcb8c1f274512a4600e31c012a7bfe85252055f9f</checksum>
       <description>
         <p>This stable release fixes the following issues:</p>
         <ul>
@@ -34,7 +34,7 @@
           <li>Updated the Intel CPU Microcode.</li>
         </ul>
       </description>
-      <size type="installed">14699068</size>
+      <size type="installed">26</size>
       <issues>
         <issue type="cve">CVE-2019-14607</issue>
         <issue type="cve">CVE-2019-11157</issue>

--- a/contrib/qubes/test/logs/metainfo_version/firmware.metainfo.xml
+++ b/contrib/qubes/test/logs/metainfo_version/firmware.metainfo.xml
@@ -23,8 +23,8 @@
   </custom>
   <releases>
     <release version="P0.1" date="2020-01-22" urgency="critical">
-      <checksum type="sha1" filename="firmware.bin" target="content">b03252481573f600c7f530d7a4c24bd62c810412</checksum>
-      <checksum type="sha256" filename="firmware.bin" target="content">bd866bcd2b5964da4b20d3f57128746efb7afefe648cf7284f2fae399225f1ac</checksum>
+      <checksum type="sha1" filename="firmware.bin" target="content">9332d7951dfba2482715f9ae996fb84501cb7018</checksum>
+      <checksum type="sha256" filename="firmware.bin" target="content">4341936755527ae568af8fdfcb8c1f274512a4600e31c012a7bfe85252055f9f</checksum>
       <description>
         <p>This stable release fixes the following issues:</p>
         <ul>
@@ -34,7 +34,7 @@
           <li>Updated the Intel CPU Microcode.</li>
         </ul>
       </description>
-      <size type="installed">14699068</size>
+      <size type="installed">26</size>
       <issues>
         <issue type="cve">CVE-2019-14607</issue>
         <issue type="cve">CVE-2019-11157</issue>

--- a/contrib/qubes/test/test_qubes_fwupd_heads.py
+++ b/contrib/qubes/test/test_qubes_fwupd_heads.py
@@ -23,6 +23,10 @@ QUBES_FWUPDMGR_REPO = "./src/qubes_fwupdmgr.py"
 QUBES_FWUPDMGR_BINDIR = "/usr/sbin/qubes-fwupdmgr"
 
 
+def running_in_dom0():
+    return "qubes" in platform.release() and os.path.exists("/etc/qubes-release")
+
+
 class TestQubesFwupdHeads(unittest.TestCase):
     def setUp(self):
         if os.path.exists(QUBES_FWUPDMGR_REPO):
@@ -40,7 +44,7 @@ class TestQubesFwupdHeads(unittest.TestCase):
         self.captured_output = io.StringIO()
         sys.stdout = self.captured_output
 
-    @unittest.skipUnless("qubes" in platform.release(), "Requires Qubes OS")
+    @unittest.skipUnless(running_in_dom0(), "Requires Qubes OS dom0")
     def test_get_hwids(self):
         self.q._get_hwids()
         self.assertNotEqual(self.q.dom0_hwids_info, "")
@@ -55,7 +59,7 @@ class TestQubesFwupdHeads(unittest.TestCase):
         self.q._gather_firmware_version()
         self.assertEqual(self.q.heads_version, "0.2.2-917-g19f0e65")
 
-    @unittest.skipUnless("qubes" in platform.release(), "Requires Qubes OS")
+    @unittest.skipUnless(running_in_dom0(), "Requires Qubes OS dom0")
     def test_parse_metadata(self):
         qmgr = self.qfwupd.QubesFwupdmgr()
         qmgr.metadata_file = CUSTOM_METADATA.replace(
@@ -101,7 +105,7 @@ class TestQubesFwupdHeads(unittest.TestCase):
         )
         self.assertEqual(self.q.heads_update_version, "0.2.3")
 
-    @unittest.skipUnless("qubes" in platform.release(), "Requires Qubes OS")
+    @unittest.skipUnless(running_in_dom0(), "Requires Qubes OS dom0")
     def test_copy_heads_firmware(self):
         qmgr = self.qfwupd.QubesFwupdmgr()
         self.q.heads_update_url = "https://fwupd.org/downloads/e747a435bf24fd6081b77b6704b39cec5fa2dcf62e0ca6b86d8a6460121a1d07-heads_coreboot_x230-v0_2_3.cab"

--- a/contrib/qubes/test/test_qubes_fwupdmgr.py
+++ b/contrib/qubes/test/test_qubes_fwupdmgr.py
@@ -228,6 +228,22 @@ class TestQubesFwupdmgr(unittest.TestCase):
             choice = self.q._user_input(self.q.dom0_updates_list)
         self.assertEqual(choice, 0)
 
+    def test_parse_lvfs_version(self):
+        self.assertLess(self.q._parse_lvfs_version("09"), self.q._parse_lvfs_version("010"))
+        self.assertLess(self.q._parse_lvfs_version("0.4"), self.q._parse_lvfs_version("0.10"))
+        self.assertLess(self.q._parse_lvfs_version("0.000.00004"), self.q._parse_lvfs_version("0.000.000010"))
+        self.assertLess(self.q._parse_lvfs_version("9.0"), self.q._parse_lvfs_version("10.0"))
+        self.assertLess(self.q._parse_lvfs_version("10..0"), self.q._parse_lvfs_version("9..0")) # NOTE: "plain" format due to invalid formatting
+        self.assertLess(self.q._parse_lvfs_version("10a"), self.q._parse_lvfs_version("9a")) # NOTE: "plain" format due to non-digit characters
+        self.assertLess(self.q._parse_lvfs_version("A"), self.q._parse_lvfs_version("B")) # NOTE: "plain" format due to non-digit characters
+        self.assertLess(self.q._parse_lvfs_version("0.20.30.40"), self.q._parse_lvfs_version("1.2.3.4"))
+        self.assertLess(self.q._parse_lvfs_version("0.1001"), self.q._parse_lvfs_version("1.0"))
+        self.assertLess(self.q._parse_lvfs_version("0xABC"), self.q._parse_lvfs_version("0xABD"))
+        self.assertLess(self.q._parse_lvfs_version("0xabc"), self.q._parse_lvfs_version("0xabd"))
+        self.assertLess(self.q._parse_lvfs_version("123456789012345678901234567890123456789012345678901234567890"), self.q._parse_lvfs_version("123456789012345678901234567890123456789012345678901234567891"))
+        with self.assertRaises(ValueError):
+            self.q._parse_lvfs_version("")
+
     def test_parse_parameters(self):
         self.q._parse_dom0_updates_info(UPDATE_INFO)
         self.q._parse_parameters(self.q.dom0_updates_list, 0)

--- a/contrib/qubes/test/test_qubes_fwupdmgr.py
+++ b/contrib/qubes/test/test_qubes_fwupdmgr.py
@@ -255,8 +255,8 @@ class TestQubesFwupdmgr(unittest.TestCase):
             self.q._parse_lvfs_version("10_0"), self.q._parse_lvfs_version("9_0")
         )  # NOTE: "plain" format due to non-digit characters
         self.assertLess(
-            self.q._parse_lvfs_version(" 10"), self.q._parse_lvfs_version(" 9")
-        )  # NOTE: "plain" format due to whitespace
+            self.q._parse_lvfs_version(" 9"), self.q._parse_lvfs_version(" 10")
+        )
         self.assertLess(
             self.q._parse_lvfs_version("0.20.30.40"),
             self.q._parse_lvfs_version("1.2.3.4"),
@@ -280,6 +280,8 @@ class TestQubesFwupdmgr(unittest.TestCase):
         )
         with self.assertRaises(ValueError):
             self.q._parse_lvfs_version("")
+        with self.assertRaises(ValueError):
+            self.q._parse_lvfs_version("      \r\n")
 
     def test_parse_parameters(self):
         self.q._parse_dom0_updates_info(UPDATE_INFO)

--- a/contrib/qubes/test/test_qubes_fwupdmgr.py
+++ b/contrib/qubes/test/test_qubes_fwupdmgr.py
@@ -16,7 +16,6 @@ import importlib.util
 import io
 import platform
 import tempfile
-from packaging.version import Version
 from .fwupd_logs import UPDATE_INFO, GET_DEVICES, DMI_DECODE
 from .fwupd_logs import GET_DEVICES_NO_VERSION
 from unittest.mock import patch
@@ -52,10 +51,17 @@ BIOS_UPDATE_FLAG = os.path.join(FWUPD_DOM0_DIR, "bios_update")
 LVFS_TESTING_DOM0_FLAG = os.path.join(FWUPD_DOM0_DIR, "lvfs_testing")
 CUSTOM_METADATA = "https://fwupd.org/downloads/firmware-3c81bfdc9db5c8a42c09d38091944bc1a05b27b0.xml.gz"
 
+# the fixtures under ./test/logs take the size and hashes of this stub
+STUB_FIRMWARE = b"qubes-fwupd test firmware\n"
+
+
+def running_in_dom0():
+    return "qubes" in platform.release() and os.path.exists("/etc/qubes-release")
+
 
 def device_connected_dom0():
     """Checks if the testing device is connected in dom0"""
-    if "qubes" not in platform.release():
+    if not running_in_dom0():
         return False
     q = qfwupd.QubesFwupdmgr()
     q._get_dom0_devices()
@@ -64,10 +70,11 @@ def device_connected_dom0():
 
 def check_whonix_updatevm():
     """Checks if the sys-whonix is running"""
-    if "qubes" not in platform.release():
+    if not running_in_dom0():
         return False
     q = qfwupd.QubesFwupdmgr()
-    return "sys-whonix" in q.output
+    q.updatevm = "sys-whonix"
+    return q._check_updatevm()
 
 
 class TestQubesFwupdmgr(unittest.TestCase):
@@ -81,7 +88,7 @@ class TestQubesFwupdmgr(unittest.TestCase):
     def tearDown(self):
         sys.stdout = self.orig_stdout
 
-    @unittest.skipUnless("qubes" in platform.release(), "Requires Qubes OS")
+    @unittest.skipUnless(running_in_dom0(), "Requires Qubes OS dom0")
     def test_download_metadata(self):
         self.q.metadata_file = FWUPD_DOM0_METADATA_FILE
         self.q._download_metadata(metadata_url=qfwupd.METADATA_URL)
@@ -107,7 +114,7 @@ class TestQubesFwupdmgr(unittest.TestCase):
             msg="Metadata signature does not exist",
         )
 
-    @unittest.skipUnless("qubes" in platform.release(), "Requires Qubes OS")
+    @unittest.skipUnless(running_in_dom0(), "Requires Qubes OS dom0")
     def test_download_custom_metadata(self):
         self.q.metadata_file = CUSTOM_METADATA.replace(
             "https://fwupd.org/downloads", FWUPD_DOM0_METADATA_DIR
@@ -123,7 +130,7 @@ class TestQubesFwupdmgr(unittest.TestCase):
             msg="Metadata signature does not exist",
         )
 
-    @unittest.skipUnless("qubes" in platform.release(), "Requires Qubes OS")
+    @unittest.skipUnless(running_in_dom0(), "Requires Qubes OS dom0")
     def test_refresh_metadata_dom0(self):
         self.q.refresh_metadata(metadata_url=qfwupd.METADATA_URL)
         self.assertEqual(
@@ -132,7 +139,7 @@ class TestQubesFwupdmgr(unittest.TestCase):
             msg="Metadata refresh failed.",
         )
 
-    @unittest.skipUnless("qubes" in platform.release(), "Requires Qubes OS")
+    @unittest.skipUnless(running_in_dom0(), "Requires Qubes OS dom0")
     @unittest.expectedFailure  # fwupd refuses metadata downgrade
     def test_refresh_metadata_dom0_custom(self):
         self.q.refresh_metadata(metadata_url=CUSTOM_METADATA)
@@ -151,7 +158,7 @@ class TestQubesFwupdmgr(unittest.TestCase):
             msg="Metadata refresh failed.",
         )
 
-    @unittest.skipUnless("qubes" in platform.release(), "Requires Qubes OS")
+    @unittest.skipUnless(running_in_dom0(), "Requires Qubes OS dom0")
     def test_get_dom0_updates(self):
         self.q._get_dom0_updates()
         self.assertIn(
@@ -177,7 +184,7 @@ class TestQubesFwupdmgr(unittest.TestCase):
             msg="Wrong checksum",
         )
 
-    @unittest.skipUnless("qubes" in platform.release(), "Requires Qubes OS")
+    @unittest.skipUnless(running_in_dom0(), "Requires Qubes OS dom0")
     def test_download_firmware_updates(self):
         self.q._download_firmware_updates(
             "https://fwupd.org/downloads/e5ad222bdbd3d3d48d8613e67c7e0a0e194f"
@@ -228,6 +235,54 @@ class TestQubesFwupdmgr(unittest.TestCase):
             choice = self.q._user_input(self.q.dom0_updates_list)
         self.assertEqual(choice, 0)
 
+    @unittest.skipUnless(running_in_dom0(), "Requires fwupdtool (dom0)")
+    def test_compare_versions(self):
+        ascending = [
+            ("09", "010"),
+            ("0.4", "0.10"),
+            ("0.000.00004", "0.000.000010"),
+            ("9.0", "10.0"),
+            ("A", "B"),
+            (" 9", " 10"),
+            ("0.20.30.40", "1.2.3.4"),
+            ("0.1001", "1.0"),
+            ("0xABC", "0xABD"),
+            ("0Xabc", "0Xabd"),
+            ("1.2.3", "1.2.3.0"),
+            ("P0.1", "P1.0"),
+        ]
+        for lower, higher in ascending:
+            with self.subTest(lower=lower, higher=higher):
+                self.assertEqual(self.q._compare_versions(lower, higher), -1)
+                self.assertEqual(self.q._compare_versions(higher, lower), 1)
+                self.assertEqual(self.q._compare_versions(lower, lower), 0)
+                self.assertEqual(self.q._compare_versions(higher, higher), 0)
+
+    @unittest.skipUnless(running_in_dom0(), "Requires fwupdtool (dom0)")
+    def test_compare_versions_numeric_chunks(self):
+        self.assertEqual(self.q._compare_versions("10..0", "9..0"), 1)
+        self.assertEqual(self.q._compare_versions("10a", "9a"), 1)
+        self.assertEqual(self.q._compare_versions("10_0", "9_0"), 1)
+
+    @unittest.skipUnless(running_in_dom0(), "Requires fwupdtool (dom0)")
+    def test_compare_versions_version_format(self):
+        """The device's version format changes the ordering"""
+        self.assertEqual(self.q._compare_versions("10a", "9a"), 1)
+        self.assertEqual(self.q._compare_versions("10a", "9a", "plain"), -1)
+        self.assertEqual(self.q._compare_versions("10a", "9a", "unknown"), 1)
+        self.assertEqual(self.q._compare_versions("2.0.6", "2.0.7", "triplet"), -1)
+        self.assertEqual(self.q._compare_versions("0x1020304", "0x1020305", "hex"), -1)
+
+    def test_compare_versions_invalid(self):
+        """Version specifiers that cannot be compared are rejected"""
+        for invalid in ("", "      \r\n", "1.2\n3", "-1.0", None, 1.0):
+            with self.subTest(version=invalid):
+                with self.assertRaises(ValueError):
+                    self.q._compare_versions(invalid, "1.0")
+                with self.assertRaises(ValueError):
+                    self.q._compare_versions("1.0", invalid)
+
+    @unittest.skipUnless(running_in_dom0(), "Requires fwupdtool (dom0)")
     def test_parse_parameters(self):
         self.q._parse_dom0_updates_info(UPDATE_INFO)
         self.q._parse_parameters(self.q.dom0_updates_list, 0)
@@ -241,7 +296,7 @@ class TestQubesFwupdmgr(unittest.TestCase):
         )
         self.assertEqual(self.q.version, "2.0.7")
 
-    @unittest.skipUnless("qubes" in platform.release(), "Requires Qubes OS")
+    @unittest.skipUnless(running_in_dom0(), "Requires Qubes OS dom0")
     def test_clean_cache_dom0(self):
         self.q.clean_cache()
         self.assertFalse(os.path.exists(FWUPD_DOM0_METADATA_DIR))
@@ -257,12 +312,12 @@ class TestQubesFwupdmgr(unittest.TestCase):
             )
         sys.stdout = self.captured_output
 
-    @unittest.skipUnless("qubes" in platform.release(), "Requires Qubes OS")
+    @unittest.skipUnless(running_in_dom0(), "Requires Qubes OS dom0")
     def test_get_dom0_devices(self):
         self.q._get_dom0_devices()
         self.assertIsNotNone(self.q.dom0_devices_info)
 
-    @unittest.skipUnless("qubes" in platform.release(), "Requires Qubes OS")
+    @unittest.skipUnless(running_in_dom0(), "Requires Qubes OS dom0")
     def test_get_devices_qubes_dom0(self):
         get_devices_output = io.StringIO()
         sys.stdout = get_devices_output
@@ -295,6 +350,7 @@ class TestQubesFwupdmgr(unittest.TestCase):
             )
         sys.stdout = self.captured_output
 
+    @unittest.skipUnless(running_in_dom0(), "Requires fwupdtool (dom0)")
     @patch(
         "test.test_qubes_fwupdmgr.qfwupd.QubesFwupdmgr._read_dmi",
         return_value=DMI_DECODE,
@@ -303,12 +359,22 @@ class TestQubesFwupdmgr(unittest.TestCase):
         self.q.dmi_version = "P.1.0"
         with tempfile.TemporaryDirectory() as tmpdir:
             arch_name = tmpdir + "/firmware.cab"
+            firmware_bin = tmpdir + "/firmware.bin"
+            with open(firmware_bin, "wb") as firmware:
+                firmware.write(STUB_FIRMWARE)
             subprocess.check_call(
-                ["fwupdtool", "build-cabinet", arch_name, "firmware.metainfo.xml"],
+                [
+                    "fwupdtool",
+                    "build-cabinet",
+                    arch_name,
+                    firmware_bin,
+                    "firmware.metainfo.xml",
+                ],
                 cwd="test/logs",
             )
             self.q._verify_dmi(arch_name, "P1.1")
 
+    @unittest.skipUnless(running_in_dom0(), "Requires fwupdtool (dom0)")
     @patch(
         "test.test_qubes_fwupdmgr.qfwupd.QubesFwupdmgr._read_dmi",
         return_value=DMI_DECODE,
@@ -318,13 +384,23 @@ class TestQubesFwupdmgr(unittest.TestCase):
             self.q.dmi_version = "P.1.0"
             with tempfile.TemporaryDirectory() as tmpdir:
                 arch_name = tmpdir + "/firmware.cab"
+                firmware_bin = tmpdir + "/firmware.bin"
+                with open(firmware_bin, "wb") as firmware:
+                    firmware.write(STUB_FIRMWARE)
                 subprocess.check_call(
-                    ["fwupdtool", "build-cabinet", arch_name, "firmware.metainfo.xml"],
+                    [
+                        "fwupdtool",
+                        "build-cabinet",
+                        arch_name,
+                        firmware_bin,
+                        "firmware.metainfo.xml",
+                    ],
                     cwd="test/logs/metainfo_name",
                 )
                 self.q._verify_dmi(arch_name, "P1.1")
         self.assertIn("Wrong firmware provider.", str(wrong_vendor.exception))
 
+    @unittest.skipUnless(running_in_dom0(), "Requires fwupdtool (dom0)")
     @patch(
         "test.test_qubes_fwupdmgr.qfwupd.QubesFwupdmgr._read_dmi",
         return_value=DMI_DECODE,
@@ -334,8 +410,17 @@ class TestQubesFwupdmgr(unittest.TestCase):
         with self.assertRaises(ValueError) as downgrade:
             with tempfile.TemporaryDirectory() as tmpdir:
                 arch_name = tmpdir + "/firmware.cab"
+                firmware_bin = tmpdir + "/firmware.bin"
+                with open(firmware_bin, "wb") as firmware:
+                    firmware.write(STUB_FIRMWARE)
                 subprocess.check_call(
-                    ["fwupdtool", "build-cabinet", arch_name, "firmware.metainfo.xml"],
+                    [
+                        "fwupdtool",
+                        "build-cabinet",
+                        arch_name,
+                        firmware_bin,
+                        "firmware.metainfo.xml",
+                    ],
                     cwd="test/logs/metainfo_version",
                 )
                 self.q._verify_dmi(arch_name, "P0.1")
@@ -360,8 +445,9 @@ class TestQubesFwupdmgr(unittest.TestCase):
         self.q._get_dom0_devices()
         downgrades = self.q._parse_downgrades(self.q.dom0_devices_info)
         new_version = downgrades[number]["Version"]
-        self.assertGreater(Version(old_version), Version(new_version))
+        self.assertEqual(self.q._compare_versions(old_version, new_version), 1)
 
+    @unittest.skipUnless(running_in_dom0(), "Requires fwupdtool (dom0)")
     def test_parse_downgrades(self):
         downgrades = self.q._parse_downgrades(GET_DEVICES)
         self.assertEqual(downgrades[0]["Name"], "ColorHug2")
@@ -376,6 +462,7 @@ class TestQubesFwupdmgr(unittest.TestCase):
             "8cd379eb2e1467e4fda92c20650306dc7e598b1d421841bbe19d9ed6ea01e3ee",
         )
 
+    @unittest.skipUnless(running_in_dom0(), "Requires fwupdtool (dom0)")
     def test_parse_downgrades_no_version(self):
         downgrades = self.q._parse_downgrades(GET_DEVICES_NO_VERSION)
         self.assertEqual(downgrades[0]["Name"], "ColorHug2")
@@ -390,6 +477,7 @@ class TestQubesFwupdmgr(unittest.TestCase):
             "4ee9dfa38df3b810f739d8a19d13da1b3175fb87",
         )
 
+    @unittest.skipUnless(running_in_dom0(), "Requires fwupdtool (dom0)")
     def test_user_input_downgrade_dom0(self):
         user_input = ["1", "6", "sth", "2.2.1", "", " ", "\0", "2"]
         with patch("builtins.input", side_effect=user_input):
@@ -401,6 +489,7 @@ class TestQubesFwupdmgr(unittest.TestCase):
         self.assertEqual(device_choice, 0)
         self.assertEqual(downgrade_choice, 1)
 
+    @unittest.skipUnless(running_in_dom0(), "Requires fwupdtool (dom0)")
     def test_user_input_downgrade_N(self):
         user_input = ["N"]
         with patch("builtins.input", side_effect=user_input):
@@ -435,7 +524,7 @@ class TestQubesFwupdmgr(unittest.TestCase):
                 break
         if new_version is None:
             self.fail("Test device not found")
-        self.assertLess(Version(old_version), Version(new_version))
+        self.assertEqual(self.q._compare_versions(old_version, new_version), -1)
 
 
 if __name__ == "__main__":

--- a/contrib/qubes/test/test_qubes_fwupdmgr.py
+++ b/contrib/qubes/test/test_qubes_fwupdmgr.py
@@ -229,18 +229,55 @@ class TestQubesFwupdmgr(unittest.TestCase):
         self.assertEqual(choice, 0)
 
     def test_parse_lvfs_version(self):
-        self.assertLess(self.q._parse_lvfs_version("09"), self.q._parse_lvfs_version("010"))
-        self.assertLess(self.q._parse_lvfs_version("0.4"), self.q._parse_lvfs_version("0.10"))
-        self.assertLess(self.q._parse_lvfs_version("0.000.00004"), self.q._parse_lvfs_version("0.000.000010"))
-        self.assertLess(self.q._parse_lvfs_version("9.0"), self.q._parse_lvfs_version("10.0"))
-        self.assertLess(self.q._parse_lvfs_version("10..0"), self.q._parse_lvfs_version("9..0")) # NOTE: "plain" format due to invalid formatting
-        self.assertLess(self.q._parse_lvfs_version("10a"), self.q._parse_lvfs_version("9a")) # NOTE: "plain" format due to non-digit characters
-        self.assertLess(self.q._parse_lvfs_version("A"), self.q._parse_lvfs_version("B")) # NOTE: "plain" format due to non-digit characters
-        self.assertLess(self.q._parse_lvfs_version("0.20.30.40"), self.q._parse_lvfs_version("1.2.3.4"))
-        self.assertLess(self.q._parse_lvfs_version("0.1001"), self.q._parse_lvfs_version("1.0"))
-        self.assertLess(self.q._parse_lvfs_version("0xABC"), self.q._parse_lvfs_version("0xABD"))
-        self.assertLess(self.q._parse_lvfs_version("0xabc"), self.q._parse_lvfs_version("0xabd"))
-        self.assertLess(self.q._parse_lvfs_version("123456789012345678901234567890123456789012345678901234567890"), self.q._parse_lvfs_version("123456789012345678901234567890123456789012345678901234567891"))
+        self.assertLess(
+            self.q._parse_lvfs_version("09"), self.q._parse_lvfs_version("010")
+        )
+        self.assertLess(
+            self.q._parse_lvfs_version("0.4"), self.q._parse_lvfs_version("0.10")
+        )
+        self.assertLess(
+            self.q._parse_lvfs_version("0.000.00004"),
+            self.q._parse_lvfs_version("0.000.000010"),
+        )
+        self.assertLess(
+            self.q._parse_lvfs_version("9.0"), self.q._parse_lvfs_version("10.0")
+        )
+        self.assertLess(
+            self.q._parse_lvfs_version("10..0"), self.q._parse_lvfs_version("9..0")
+        )  # NOTE: "plain" format due to invalid formatting
+        self.assertLess(
+            self.q._parse_lvfs_version("10a"), self.q._parse_lvfs_version("9a")
+        )  # NOTE: "plain" format due to non-digit characters
+        self.assertLess(
+            self.q._parse_lvfs_version("A"), self.q._parse_lvfs_version("B")
+        )  # NOTE: "plain" format due to non-digit characters
+        self.assertLess(
+            self.q._parse_lvfs_version("10_0"), self.q._parse_lvfs_version("9_0")
+        )  # NOTE: "plain" format due to non-digit characters
+        self.assertLess(
+            self.q._parse_lvfs_version(" 10"), self.q._parse_lvfs_version(" 9")
+        )  # NOTE: "plain" format due to whitespace
+        self.assertLess(
+            self.q._parse_lvfs_version("0.20.30.40"),
+            self.q._parse_lvfs_version("1.2.3.4"),
+        )
+        self.assertLess(
+            self.q._parse_lvfs_version("0.1001"), self.q._parse_lvfs_version("1.0")
+        )
+        self.assertLess(
+            self.q._parse_lvfs_version("0xABC"), self.q._parse_lvfs_version("0xABD")
+        )
+        self.assertLess(
+            self.q._parse_lvfs_version("0Xabc"), self.q._parse_lvfs_version("0Xabd")
+        )
+        self.assertLess(
+            self.q._parse_lvfs_version(
+                "123456789012345678901234567890123456789012345678901234567890"
+            ),
+            self.q._parse_lvfs_version(
+                "123456789012345678901234567890123456789012345678901234567891"
+            ),
+        )
         with self.assertRaises(ValueError):
             self.q._parse_lvfs_version("")
 


### PR DESCRIPTION
In https://github.com/QubesOS/qubes-issues/issues/11014, I described an issue with `qubes-fwupdmgr`, where Framework publishes its UEFI firmware updates using hexadecimal version numbers, like `0x00000270`, rather than the more common semver version numbers, like `2.0.7`. This was breaking the script because the script parses that hex version specifiers using `packaging.version.parse()`, from the [Packaging library](https://packaging.pypa.io/en/latest/version.html), and that fails because hex version specifiers are not supported.

The underlying problem is that `packaging.version.parse` follows the PyPA version specifier standard (see [PyPA docs](https://packaging.python.org/en/latest/specifications/version-specifiers/#public-version-identifiers)), while LVFS follows a slightly different standard (see [LVFS docs](https://fwupd.org/lvfs/docs/metainfo/version)). There are some LVFS version numbers that are simply not representable by `packaging.version.Version`, such as the `hex` or `plain` formats (arbitrary ASCII strings).

My initial attempt to fix this was to add a wrapper function around `packaging.version.parse`, which would special-case hex version numbers and turn them into decimal, but 1) this felt very hacky and could make debugging hard in the future if people are expecting to see that exact version string in their outputs, and 2) it doesn't work for the "plain" LVFS version specifier format. The "plain" format seems to be extremely rarely used, but still is technically valid, so I gave up on trying to shoehorn `packaging.version.Version` into representing these.

My second attempt, and the one you see in this PR, is a standalone LVFS version parser, and I replaced all usages of `packaging.version.parse` with this new parser. I know that adding a new parser isn't ideal from a maintainability perspective, but I've tried to keep it as short and "obviously correct" as possible and added tests to ensure it works well. If it helps, I can also document the total ordering over all valid LVFS version numbers more explicitly, here or as comments in the code!

Also, I read through https://github.com/fwupd/fwupd/blob/26a44342f3d601f06a5180754216b0fed1cf78ca/CONTRIBUTING.md, is there an equivalent style guide for Python contributions?