### PR TITLE
Copy the file descriptor contents when not sealed

### DIFF
--- a/src/fu-dbus-daemon.c
+++ b/src/fu-dbus-daemon.c
@@ -1056,6 +1056,8 @@ fu_dbus_daemon_invocation_get_input_stream(GDBusMethodInvocation *invocation, GE
 	GUnixFDList *fd_list;
 	g_autofd gint fd = -1;
 	g_autoptr(FuInputStream) stream = NULL;
+	g_autoptr(FuInputStream) stream_safe = NULL;
+	g_autoptr(GError) error_local = NULL;
 
 	/* get the fd */
 	message = g_dbus_method_invocation_get_message(invocation);
@@ -1084,9 +1086,19 @@ fu_dbus_daemon_invocation_get_input_stream(GDBusMethodInvocation *invocation, GE
 	if (stream == NULL)
 		return NULL;
 	if (!fu_unix_seekable_input_stream_require_seal(FU_UNIX_SEEKABLE_INPUT_STREAM(stream),
-							error))
-		return NULL;
-	return g_steal_pointer(&stream);
+							&error_local)) {
+		g_autoptr(GBytes) blob = NULL;
+		g_debug("fd not sealed, falling back to copy: %s", error_local->message);
+		blob = fu_input_stream_read_bytes(stream, 0, G_MAXSIZE, NULL, error);
+		if (blob == NULL)
+			return NULL;
+		stream_safe = fu_memory_input_stream_new_from_bytes(blob);
+	} else {
+		stream_safe = g_object_ref(stream);
+	}
+
+	/* success */
+	return g_steal_pointer(&stream_safe);
 #else
 	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "unsupported feature");
 	return NULL;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -5083,14 +5083,8 @@ fu_engine_update_metadata(FuEngine *self,
 	stream_fd = fu_unix_seekable_input_stream_new(fd, TRUE, error);
 	if (stream_fd == NULL)
 		return FALSE;
-	if (!fu_unix_seekable_input_stream_require_seal(FU_UNIX_SEEKABLE_INPUT_STREAM(stream_fd),
-							error))
-		return FALSE;
 	stream_sig = fu_unix_seekable_input_stream_new(fd_sig, TRUE, error);
 	if (stream_sig == NULL)
-		return FALSE;
-	if (!fu_unix_seekable_input_stream_require_seal(FU_UNIX_SEEKABLE_INPUT_STREAM(stream_sig),
-							error))
 		return FALSE;
 
 	/* read the entire file into memory */

--- a/src/fu-unix-seekable-input-stream.c
+++ b/src/fu-unix-seekable-input-stream.c
@@ -187,8 +187,12 @@ fu_unix_seekable_input_stream_require_seal(FuUnixSeekableInputStream *stream, GE
 	fd = g_unix_input_stream_get_fd(G_UNIX_INPUT_STREAM(stream));
 	seals = fcntl(fd, F_GET_SEALS);
 	if (seals < 0) {
-		/* not supported on this fd */
-		return TRUE;
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "F_GET_SEALS not supported: %s",
+			    strerror(errno));
+		return FALSE;
 	}
 	if ((seals & F_SEAL_SEAL) == 0) {
 		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE, "fd not sealed");
@@ -206,8 +210,14 @@ fu_unix_seekable_input_stream_require_seal(FuUnixSeekableInputStream *stream, GE
 		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE, "no GROW seal");
 		return FALSE;
 	}
-#endif
 	return TRUE;
+#else
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "F_GET_SEALS not supported");
+	return FALSE;
+#endif
 }
 
 static void


### PR DESCRIPTION
This makes fd-passing safe on non-Linux and also fixes build issues when compiling from a tmpfs.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
