### PR TITLE
Move the __COVERITY__ CFLAGS hack from the CI to meson.build

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -43,11 +43,6 @@ jobs:
         run: |-
           ./contrib/ci/fwupd_setup_helpers.py install-dependencies -o debian --yes
       - name: configure
-        env:
-          # FIXME: really ugly trick to make glib set `G_ANALYZER_NORETURN` to something that GCC
-          # can understand. Otherwise, GCC analyzer will complain a lot because it thinks that
-          # `g_assert_nonnull()` doesn't affect control flow.
-          CFLAGS: -D__COVERITY__
         run: |-
           meson setup -Dwerror=true -Dstatic_analysis=true build
       - name: build with `-fanalyzer`

--- a/meson.build
+++ b/meson.build
@@ -141,6 +141,16 @@ add_project_arguments(
   language: 'c',
 )
 
+# FIXME: really ugly trick to make glib set `G_ANALYZER_NORETURN` to something that GCC
+# can understand. Otherwise, GCC analyzer will complain a lot because it thinks that
+# `g_assert_nonnull()` doesn't affect control flow.
+if static_analysis
+  add_project_arguments(
+    ['-D__COVERITY__'],
+    language: 'c',
+  )
+endif
+
 if not meson.is_cross_build()
   add_project_arguments(
     '-fstack-protector-strong',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -174,7 +174,7 @@ option(
   'static_analysis',
   type: 'boolean',
   value: false,
-  description: 'enable GCC static analysis support',
+  description: 'enable GCC static analysis support (use only for debugging, this affects the binary)',
 )
 option(
   'supported_build',


### PR DESCRIPTION
This way it's easier to find and easier to reproduce locally.

Prompted by #10726 and will cause a conflict there so better wait until that one is merged.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
