### PR TITLE
Bump meson requirement to 1.11

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -113,11 +113,12 @@ jobs:
       - name: Refresh dependencies
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+          sudo add-apt-repository -y ppa:peter-hutterer/meson1.11
           sudo apt update -qq
       - name: Install dependencies
         run: |
+          sudo apt install -qq --yes meson
           sudo ./contrib/ci/fwupd_setup_helpers.py install-dependencies -o ubuntu --yes
-          sudo ./contrib/ci/fwupd_setup_helpers.py test-meson
       - name: Build
         run: |
           meson setup build \

--- a/contrib/ci/Dockerfile-ubuntu.in
+++ b/contrib/ci/Dockerfile-ubuntu.in
@@ -6,7 +6,10 @@ RUN echo fubar > /etc/machine-id
 RUN set -euxo pipefail; \
     export DEBIAN_FRONTEND=noninteractive; \
     apt-get update -qq; \
+    apt-get install -qq --yes --no-install-recommends software-properties-common; \
+    add-apt-repository -y ppa:peter-hutterer/meson1.11; \
     apt-get install -qq --yes --no-install-recommends \
+    meson \
     python3-apt \
     sudo \
 %%%DEPENDENCIES%%%; \


### PR DESCRIPTION
Required for Rust workspaces, let's bump this and sort out the CI first.

Debian, Arch and Fedora are already on 1.11, for Ubuntu we have my PPA that contains a single package: meson 1.11 "backported" from Debian (read: rebuilt without changes). For Centos we'll use a COPR for the same purpose.

This *will* currently fail the CI because centos isn't handled. Let's see how the other jobs go.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
