### PR TITLE
uefi-capsule: Add ESRT rollback protection HSI

### DIFF
--- a/libfwupdplugin/fu-security-attrs-test.c
+++ b/libfwupdplugin/fu-security-attrs-test.c
@@ -206,6 +206,25 @@ fu_security_attrs_test_add_attr(FuSecurityAttrs *attrs,
 	fu_security_attrs_append(attrs, attr);
 }
 
+static FwupdSecurityAttr *
+fu_security_attrs_test_get_attr(FuSecurityAttrs *attrs,
+				const gchar *appstream_id,
+				const gchar *plugin)
+{
+	g_autoptr(GPtrArray) attrs_arr = fu_security_attrs_get_all_mutable(attrs);
+
+	for (guint i = 0; i < attrs_arr->len; i++) {
+		FwupdSecurityAttr *attr = g_ptr_array_index(attrs_arr, i);
+
+		if (g_strcmp0(fwupd_security_attr_get_appstream_id(attr), appstream_id) != 0)
+			continue;
+		if (g_strcmp0(fwupd_security_attr_get_plugin(attr), plugin) == 0)
+			return g_object_ref(attr);
+	}
+
+	return NULL;
+}
+
 static void
 fu_security_attrs_hsi_suspend_to_ram_func(void)
 {
@@ -324,6 +343,88 @@ fu_security_attrs_hsi_suspend_to_ram_func(void)
 	}
 }
 
+static void
+fu_security_attrs_hsi_bios_rollback_esrt_func(void)
+{
+	g_autoptr(FuSecurityAttrs) attrs = fu_security_attrs_new();
+	g_autoptr(FwupdSecurityAttr) attr_esrt = NULL;
+
+	fu_security_attrs_test_add_attr(attrs,
+					FWUPD_SECURITY_ATTR_ID_BIOS_ROLLBACK_PROTECTION,
+					"uefi_capsule",
+					FWUPD_SECURITY_ATTR_RESULT_ENABLED,
+					TRUE);
+	attr_esrt = fu_security_attrs_test_get_attr(attrs,
+						    FWUPD_SECURITY_ATTR_ID_BIOS_ROLLBACK_PROTECTION,
+						    "uefi_capsule");
+	g_assert_nonnull(attr_esrt);
+	fu_security_attrs_depsolve(attrs);
+	g_assert_false(fwupd_security_attr_has_flag(attr_esrt, FWUPD_SECURITY_ATTR_FLAG_OBSOLETED));
+}
+
+static void
+fu_security_attrs_hsi_bios_rollback_bios_func(void)
+{
+	g_autoptr(FuSecurityAttrs) attrs = fu_security_attrs_new();
+	g_autoptr(FwupdSecurityAttr) attr_bios = NULL;
+	g_autoptr(FwupdSecurityAttr) attr_esrt = NULL;
+
+	fu_security_attrs_test_add_attr(attrs,
+					FWUPD_SECURITY_ATTR_ID_BIOS_ROLLBACK_PROTECTION,
+					"uefi_capsule",
+					FWUPD_SECURITY_ATTR_RESULT_ENABLED,
+					TRUE);
+	fu_security_attrs_test_add_attr(attrs,
+					FWUPD_SECURITY_ATTR_ID_BIOS_ROLLBACK_PROTECTION,
+					"dell",
+					FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED,
+					FALSE);
+	attr_esrt = fu_security_attrs_test_get_attr(attrs,
+						    FWUPD_SECURITY_ATTR_ID_BIOS_ROLLBACK_PROTECTION,
+						    "uefi_capsule");
+	attr_bios = fu_security_attrs_test_get_attr(attrs,
+						    FWUPD_SECURITY_ATTR_ID_BIOS_ROLLBACK_PROTECTION,
+						    "dell");
+	g_assert_nonnull(attr_esrt);
+	g_assert_nonnull(attr_bios);
+	fwupd_security_attr_add_obsolete(attr_bios,
+					 FWUPD_SECURITY_ATTR_ID_BIOS_ROLLBACK_PROTECTION);
+	fu_security_attrs_depsolve(attrs);
+	g_assert_true(fwupd_security_attr_has_flag(attr_esrt, FWUPD_SECURITY_ATTR_FLAG_OBSOLETED));
+	g_assert_false(fwupd_security_attr_has_flag(attr_bios, FWUPD_SECURITY_ATTR_FLAG_OBSOLETED));
+}
+
+static void
+fu_security_attrs_hsi_bios_rollback_amd_func(void)
+{
+	g_autoptr(FuSecurityAttrs) attrs = fu_security_attrs_new();
+	g_autoptr(FwupdSecurityAttr) attr_amd = NULL;
+	g_autoptr(FwupdSecurityAttr) attr_esrt = NULL;
+
+	fu_security_attrs_test_add_attr(attrs,
+					FWUPD_SECURITY_ATTR_ID_BIOS_ROLLBACK_PROTECTION,
+					"uefi_capsule",
+					FWUPD_SECURITY_ATTR_RESULT_ENABLED,
+					TRUE);
+	fu_security_attrs_test_add_attr(attrs,
+					FWUPD_SECURITY_ATTR_ID_AMD_ROLLBACK_PROTECTION,
+					"pci_psp",
+					FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED,
+					FALSE);
+	attr_esrt = fu_security_attrs_test_get_attr(attrs,
+						    FWUPD_SECURITY_ATTR_ID_BIOS_ROLLBACK_PROTECTION,
+						    "uefi_capsule");
+	attr_amd = fu_security_attrs_test_get_attr(attrs,
+						   FWUPD_SECURITY_ATTR_ID_AMD_ROLLBACK_PROTECTION,
+						   "pci_psp");
+	g_assert_nonnull(attr_esrt);
+	g_assert_nonnull(attr_amd);
+	fwupd_security_attr_add_obsolete(attr_amd, FWUPD_SECURITY_ATTR_ID_BIOS_ROLLBACK_PROTECTION);
+	fu_security_attrs_depsolve(attrs);
+	g_assert_true(fwupd_security_attr_has_flag(attr_esrt, FWUPD_SECURITY_ATTR_FLAG_OBSOLETED));
+	g_assert_false(fwupd_security_attr_has_flag(attr_amd, FWUPD_SECURITY_ATTR_FLAG_OBSOLETED));
+}
+
 int
 main(int argc, char **argv)
 {
@@ -332,5 +433,11 @@ main(int argc, char **argv)
 	g_test_add_func("/fwupd/security-attrs/hsi", fu_security_attrs_hsi_func);
 	g_test_add_func("/fwupd/security-attrs/hsi-suspend-to-ram",
 			fu_security_attrs_hsi_suspend_to_ram_func);
+	g_test_add_func("/fwupd/security-attrs/hsi-bios-rollback/esrt",
+			fu_security_attrs_hsi_bios_rollback_esrt_func);
+	g_test_add_func("/fwupd/security-attrs/hsi-bios-rollback/bios",
+			fu_security_attrs_hsi_bios_rollback_bios_func);
+	g_test_add_func("/fwupd/security-attrs/hsi-bios-rollback/amd",
+			fu_security_attrs_hsi_bios_rollback_amd_func);
 	return g_test_run();
 }

--- a/plugins/dell/fu-dell-plugin.c
+++ b/plugins/dell/fu-dell-plugin.c
@@ -212,6 +212,7 @@ fu_dell_plugin_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *attrs)
 	attr = fu_plugin_security_attr_new(plugin, FWUPD_SECURITY_ATTR_ID_BIOS_ROLLBACK_PROTECTION);
 	fu_security_attr_add_bios_target_value(attr, BIOS_SETTING_BIOS_DOWNGRADE, "Disabled");
 	fwupd_security_attr_set_result_success(attr, FWUPD_SECURITY_ATTR_RESULT_ENABLED);
+	fwupd_security_attr_add_obsolete(attr, FWUPD_SECURITY_ATTR_ID_BIOS_ROLLBACK_PROTECTION);
 	fu_security_attrs_append(attrs, attr);
 
 	if (g_strcmp0(fwupd_bios_setting_get_current_value(bios_attr), "Enabled") == 0) {

--- a/plugins/lenovo-thinklmi/fu-lenovo-thinklmi-plugin.c
+++ b/plugins/lenovo-thinklmi/fu-lenovo-thinklmi-plugin.c
@@ -102,6 +102,7 @@ fu_lenovo_thinklmi_plugin_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *
 	attr = fu_plugin_security_attr_new(plugin, FWUPD_SECURITY_ATTR_ID_BIOS_ROLLBACK_PROTECTION);
 	fu_security_attr_add_bios_target_value(attr, BIOS_SETTING_SECURE_ROLLBACK, "enable");
 	fwupd_security_attr_set_result_success(attr, FWUPD_SECURITY_ATTR_RESULT_ENABLED);
+	fwupd_security_attr_add_obsolete(attr, FWUPD_SECURITY_ATTR_ID_BIOS_ROLLBACK_PROTECTION);
 	fu_security_attrs_append(attrs, attr);
 
 	if (g_strcmp0(fwupd_bios_setting_get_current_value(bios_attr), "Disable") == 0) {

--- a/plugins/pci-psp/fu-pci-psp-device.c
+++ b/plugins/pci-psp/fu-pci-psp-device.c
@@ -337,6 +337,7 @@ fu_pci_psp_device_add_security_attrs_rollback_protection(FuPciPspDevice *self,
 	}
 
 	fu_pci_psp_device_set_valid_data(self, attrs);
+	fwupd_security_attr_add_obsolete(attr, FWUPD_SECURITY_ATTR_ID_BIOS_ROLLBACK_PROTECTION);
 
 	if (!val) {
 		g_debug("rollback protection not enforced");

--- a/plugins/uefi-capsule/fu-self-test.c
+++ b/plugins/uefi-capsule/fu-self-test.c
@@ -10,6 +10,7 @@
 #include "fu-context-private.h"
 #include "fu-efivars-private.h"
 #include "fu-plugin-private.h"
+#include "fu-security-attrs-private.h"
 #include "fu-uefi-bgrt.h"
 #include "fu-uefi-capsule-backend.h"
 #include "fu-uefi-capsule-plugin.h"
@@ -1040,6 +1041,118 @@ fu_uefi_update_info_func(void)
 			"/EFI/fedora/fw/fwupd-697bd920-12cf-4da9-8385-996909bc6559.cap");
 }
 
+static FwupdSecurityAttr *
+fu_uefi_capsule_test_get_bios_rollback_attr(FuUefiCapsuleDeviceKind kind,
+					    guint32 fw_version,
+					    guint32 fw_version_lowest)
+{
+	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuSecurityAttrs) attrs = fu_security_attrs_new();
+	g_autoptr(FuUefiCapsuleDevice) dev = NULL;
+
+	dev = g_object_new(FU_TYPE_UEFI_CAPSULE_DEVICE,
+			   "context",
+			   ctx,
+			   "fw-class",
+			   "ddc0ee61-e7f0-4e7d-acc5-c070a398838e",
+			   "kind",
+			   kind,
+			   "fw-version",
+			   fw_version,
+			   "fw-version-lowest",
+			   fw_version_lowest,
+			   NULL);
+	fu_device_set_plugin(FU_DEVICE(dev), "uefi_capsule");
+	fu_device_add_security_attrs(FU_DEVICE(dev), attrs);
+	return fu_security_attrs_get_by_appstream_id(
+	    attrs,
+	    FWUPD_SECURITY_ATTR_ID_BIOS_ROLLBACK_PROTECTION,
+	    NULL);
+}
+
+static void
+fu_uefi_capsule_security_attrs_func(void)
+{
+	g_autoptr(FwupdSecurityAttr) attr = NULL;
+
+	attr =
+	    fu_uefi_capsule_test_get_bios_rollback_attr(FU_UEFI_CAPSULE_DEVICE_KIND_SYSTEM_FIRMWARE,
+							65586,
+							65586);
+	g_assert_nonnull(attr);
+	g_assert_cmpint(fwupd_security_attr_get_result(attr),
+			==,
+			FWUPD_SECURITY_ATTR_RESULT_ENABLED);
+	g_assert_true(fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS));
+	g_clear_object(&attr);
+
+	attr =
+	    fu_uefi_capsule_test_get_bios_rollback_attr(FU_UEFI_CAPSULE_DEVICE_KIND_SYSTEM_FIRMWARE,
+							65586,
+							65582);
+	g_assert_nonnull(attr);
+	g_assert_cmpint(fwupd_security_attr_get_result(attr),
+			==,
+			FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED);
+	g_assert_false(fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS));
+	g_assert_true(
+	    fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONTACT_OEM));
+	g_assert_true(
+	    fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_FW));
+	g_clear_object(&attr);
+
+	attr =
+	    fu_uefi_capsule_test_get_bios_rollback_attr(FU_UEFI_CAPSULE_DEVICE_KIND_SYSTEM_FIRMWARE,
+							65582,
+							65586);
+	g_assert_nonnull(attr);
+	g_assert_cmpint(fwupd_security_attr_get_result(attr),
+			==,
+			FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED);
+	g_assert_false(fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS));
+	g_assert_true(
+	    fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONTACT_OEM));
+	g_assert_false(
+	    fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_FW));
+	g_clear_object(&attr);
+
+	attr =
+	    fu_uefi_capsule_test_get_bios_rollback_attr(FU_UEFI_CAPSULE_DEVICE_KIND_SYSTEM_FIRMWARE,
+							0,
+							65586);
+	g_assert_nonnull(attr);
+	g_assert_cmpint(fwupd_security_attr_get_result(attr),
+			==,
+			FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED);
+	g_assert_false(fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS));
+	g_assert_true(
+	    fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONTACT_OEM));
+	g_assert_false(
+	    fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_FW));
+	g_clear_object(&attr);
+
+	attr =
+	    fu_uefi_capsule_test_get_bios_rollback_attr(FU_UEFI_CAPSULE_DEVICE_KIND_SYSTEM_FIRMWARE,
+							65586,
+							0);
+	g_assert_nonnull(attr);
+	g_assert_cmpint(fwupd_security_attr_get_result(attr),
+			==,
+			FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED);
+	g_assert_false(fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS));
+	g_assert_true(
+	    fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONTACT_OEM));
+	g_assert_false(
+	    fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_FW));
+	g_clear_object(&attr);
+
+	attr =
+	    fu_uefi_capsule_test_get_bios_rollback_attr(FU_UEFI_CAPSULE_DEVICE_KIND_DEVICE_FIRMWARE,
+							65586,
+							65586);
+	g_assert_null(attr);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -1059,6 +1172,7 @@ main(int argc, char **argv)
 	g_test_add_func("/uefi-capsule/cod-device", fu_uefi_cod_device_func);
 	g_test_add_func("/uefi-capsule/update-info", fu_uefi_update_info_func);
 	g_test_add_func("/uefi-capsule/update-info/xml", fu_uefi_update_info_xml_func);
+	g_test_add_func("/uefi-capsule/security-attrs", fu_uefi_capsule_security_attrs_func);
 	g_test_add_func("/uefi-capsule/no-coalesce", fu_uefi_capsule_no_coalesce_func);
 	g_test_add_func("/uefi-capsule/no-flashes-left", fu_uefi_capsule_no_flashes_func);
 	g_test_add_func("/uefi-capsule/nvram", fu_uefi_capsule_nvram_func);

--- a/plugins/uefi-capsule/fu-uefi-capsule-device.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-device.c
@@ -628,6 +628,42 @@ fu_uefi_capsule_device_probe(FuDevice *device, GError **error)
 }
 
 static void
+fu_uefi_capsule_device_add_security_attrs(FuDevice *device, FuSecurityAttrs *attrs)
+{
+	FuUefiCapsuleDevice *self = FU_UEFI_CAPSULE_DEVICE(device);
+	FuUefiCapsuleDevicePrivate *priv = GET_PRIVATE(self);
+	g_autoptr(FwupdSecurityAttr) attr = NULL;
+
+	if (priv->kind != FU_UEFI_CAPSULE_DEVICE_KIND_SYSTEM_FIRMWARE)
+		return;
+
+	attr = fu_device_security_attr_new(device, FWUPD_SECURITY_ATTR_ID_BIOS_ROLLBACK_PROTECTION);
+	fwupd_security_attr_set_result_success(attr, FWUPD_SECURITY_ATTR_RESULT_ENABLED);
+	fu_security_attrs_append(attrs, attr);
+
+	if (priv->fw_version == 0 || priv->fw_version_lowest == 0 ||
+	    priv->fw_version_lowest > priv->fw_version) {
+		g_debug("ESRT rollback protection data invalid: 0x%x/0x%x",
+			priv->fw_version,
+			priv->fw_version_lowest);
+		fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED);
+		fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONTACT_OEM);
+		return;
+	}
+	if (priv->fw_version != priv->fw_version_lowest) {
+		g_debug("ESRT rollback protection not enforced: 0x%x/0x%x",
+			priv->fw_version,
+			priv->fw_version_lowest);
+		fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED);
+		fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONTACT_OEM);
+		fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_FW);
+		return;
+	}
+
+	fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
+}
+
+static void
 fu_uefi_capsule_device_capture_efi_debugging(FuUefiCapsuleDevice *self)
 {
 	FuContext *ctx = fu_device_get_context(FU_DEVICE(self));
@@ -943,6 +979,7 @@ fu_uefi_capsule_device_class_init(FuUefiCapsuleDeviceClass *klass)
 	device_class->report_metadata_pre = fu_uefi_capsule_device_report_metadata_pre;
 	device_class->report_metadata_post = fu_uefi_capsule_device_report_metadata_post;
 	device_class->get_results = fu_uefi_capsule_device_get_results;
+	device_class->add_security_attrs = fu_uefi_capsule_device_add_security_attrs;
 	device_class->set_progress = fu_uefi_capsule_device_set_progress;
 	device_class->convert_version = fu_uefi_capsule_device_convert_version;
 	fu_device_register_private_flag(device_class, FU_UEFI_CAPSULE_DEVICE_FLAG_NO_UX_CAPSULE);


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

## Summary
- add a generic ESRT fallback for BIOS rollback protection
- fail the HSI check when ESRT current/minimum version data is missing or weird
- keep Dell/Lenovo BIOS settings and AMD PSP rollback protection ahead of ESRT

## Testing
- git diff --check origin/main..HEAD
- meson test -C builddir fwupdplugin-security-attrs-test uefi-self-test --print-errorlogs