### PR TITLE
wacom-usb: release the sub-CPU chunks with g_object_unref

### DIFF
--- a/plugins/wacom-usb/fu-wacom-usb-module-sub-cpu.c
+++ b/plugins/wacom-usb/fu-wacom-usb-module-sub-cpu.c
@@ -83,13 +83,14 @@ fu_wacom_usb_module_sub_cpu_parse_chunks(FuSrecFirmware *srec_firmware,
 					 guint32 *data_len,
 					 GError **error)
 {
-	g_autoptr(GPtrArray) chunks = g_ptr_array_new_with_free_func(g_free);
+	g_autoptr(GPtrArray) chunks =
+	    g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
 	guint record_num = 0;
 	GPtrArray *records = fu_srec_firmware_get_records(srec_firmware);
 
 	*data_len = 0;
 	while (record_num < records->len) {
-		g_autofree FuChunk *chunk =
+		g_autoptr(FuChunk) chunk =
 		    fu_wacom_usb_module_sub_cpu_create_chunk(records, &record_num, error);
 		if (chunk == NULL)
 			return NULL;


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

fu_wacom_usb_module_sub_cpu_parse_chunks fills its transfer list with the FuChunk instances returned
by fu_wacom_usb_module_sub_cpu_create_chunk, but the array is created with g_free as the element free
function and the local is g_autofree. FuChunk is a GObject, so g_free drops the instance without
running fu_chunk_finalize, and the GBytes payload the chunk holds is never released. the array is an
autoptr in fu_wacom_usb_module_sub_cpu_write_firmware, so that happens for every block on each
sub-CPU write, and the block count follows the address discontinuities in the srec image being
flashed. g_object_unref and g_autoptr also make the ownership behaviour easier to follow here. i
could not find another array in the tree with a g_free free function holding GObjects, so this looks
like the only site.
