### PR TITLE
trivial: Add GError parameter to fu_chunk_array_new_from_bytes()

### DIFF
--- a/libfwupdplugin/fu-cab-firmware.c
+++ b/libfwupdplugin/fu-cab-firmware.c
@@ -815,7 +815,10 @@ fu_cab_firmware_write(FuFirmware *firmware, GError **error)
 	chunks = fu_chunk_array_new_from_bytes(cfdata_linear_blob,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       0x8000);
+					       0x8000,
+					       error);
+	if (chunks == NULL)
+		return NULL;
 	if (fu_chunk_array_length(chunks) > G_MAXUINT16) {
 		g_set_error(error,
 			    FWUPD_ERROR,

--- a/libfwupdplugin/fu-cfi-device.c
+++ b/libfwupdplugin/fu-cfi-device.c
@@ -898,7 +898,10 @@ fu_cfi_device_write_firmware(FuDevice *device,
 	pages = fu_chunk_array_new_from_bytes(fw,
 					      FU_CHUNK_ADDR_OFFSET_NONE,
 					      FU_CHUNK_PAGESZ_NONE,
-					      fu_cfi_device_get_page_size(self));
+					      fu_cfi_device_get_page_size(self),
+					      error);
+	if (pages == NULL)
+		return FALSE;
 	if (!fu_cfi_device_write_pages(self, pages, fu_progress_get_child(progress), error)) {
 		g_prefix_error_literal(error, "failed to write pages: ");
 		return FALSE;

--- a/libfwupdplugin/fu-chunk-array-test.c
+++ b/libfwupdplugin/fu-chunk-array-test.c
@@ -20,7 +20,7 @@ fu_chunk_array_func(void)
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GBytes) fw = g_bytes_new_static("hello world", 11);
 	g_autoptr(FuChunkArray) chunks =
-	    fu_chunk_array_new_from_bytes(fw, 100, FU_CHUNK_PAGESZ_NONE, 5);
+	    fu_chunk_array_new_from_bytes(fw, 100, FU_CHUNK_PAGESZ_NONE, 5, NULL);
 
 	g_assert_cmpint(fu_chunk_array_length(chunks), ==, 3);
 

--- a/libfwupdplugin/fu-chunk-array.c
+++ b/libfwupdplugin/fu-chunk-array.c
@@ -172,21 +172,36 @@ fu_chunk_array_ensure_offsets(FuChunkArray *self)
  * @addr_offset: the hardware address offset, or %FU_CHUNK_ADDR_OFFSET_NONE
  * @page_sz: the hardware page size, typically %FU_CHUNK_PAGESZ_NONE
  * @packet_sz: the packet size, or 0x0
+ * @error: (nullable): optional return location for an error
  *
  * Chunks a linear blob of memory into packets, ensuring each packet is less that a specific
  * transfer size.
  *
- * Returns: (transfer full): a #FuChunkArray
+ * Returns: (transfer full): a #FuChunkArray, or %NULL on error
  *
  * Since: 1.9.6
  **/
 FuChunkArray *
-fu_chunk_array_new_from_bytes(GBytes *blob, gsize addr_offset, gsize page_sz, gsize packet_sz)
+fu_chunk_array_new_from_bytes(GBytes *blob,
+			      gsize addr_offset,
+			      gsize page_sz,
+			      gsize packet_sz,
+			      GError **error)
 {
 	g_autoptr(FuChunkArray) self = g_object_new(FU_TYPE_CHUNK_ARRAY, NULL);
 
 	g_return_val_if_fail(blob != NULL, NULL);
 	g_return_val_if_fail(page_sz == 0 || page_sz >= packet_sz, NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
+	/* sanity check */
+	if (packet_sz == 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "packet size cannot be zero");
+		return NULL;
+	}
 
 	self->addr_offset = addr_offset;
 	self->page_sz = page_sz;
@@ -257,6 +272,15 @@ fu_chunk_array_new_from_stream(FuInputStream *stream,
 	g_return_val_if_fail(FU_IS_INPUT_STREAM(stream), NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 	g_return_val_if_fail(page_sz == 0 || page_sz >= packet_sz, NULL);
+
+	/* sanity check */
+	if (packet_sz == 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "packet size cannot be zero");
+		return NULL;
+	}
 
 	if (!fu_input_stream_size(stream, &self->total_size, error))
 		return NULL;

--- a/libfwupdplugin/fu-chunk-array.h
+++ b/libfwupdplugin/fu-chunk-array.h
@@ -18,8 +18,11 @@ G_DECLARE_FINAL_TYPE(FuChunkArray, fu_chunk_array, FU, CHUNK_ARRAY, GObject)
 FuChunkArray *
 fu_chunk_array_new_virtual(gsize bufsz, gsize addr_offset, gsize page_sz, gsize packet_sz);
 FuChunkArray *
-fu_chunk_array_new_from_bytes(GBytes *blob, gsize addr_offset, gsize page_sz, gsize packet_sz)
-    G_GNUC_NON_NULL(1);
+fu_chunk_array_new_from_bytes(GBytes *blob,
+			      gsize addr_offset,
+			      gsize page_sz,
+			      gsize packet_sz,
+			      GError **error) G_GNUC_NON_NULL(1);
 FuChunkArray *
 fu_chunk_array_new_from_stream(FuInputStream *stream,
 			       gsize addr_offset,

--- a/libfwupdplugin/fu-srec-firmware.c
+++ b/libfwupdplugin/fu-srec-firmware.c
@@ -624,7 +624,10 @@ fu_srec_firmware_write(FuFirmware *firmware, GError **error)
 		    fu_chunk_array_new_from_bytes(buf_blob,
 						  fu_firmware_get_addr(firmware),
 						  FU_CHUNK_PAGESZ_NONE,
-						  64);
+						  64,
+						  error);
+		if (chunks == NULL)
+			return NULL;
 		for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 			g_autoptr(FuChunk) chk = NULL;
 

--- a/plugins/android-boot/fu-android-boot-device.c
+++ b/plugins/android-boot/fu-android-boot-device.c
@@ -217,7 +217,10 @@ fu_android_boot_device_erase(FuAndroidBootDevice *self, FuProgress *progress, GE
 	chunks = fu_chunk_array_new_from_bytes(fw,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       10 * FU_KB);
+					       10 * FU_KB,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	return fu_android_boot_device_write(self, chunks, progress, error);
 }
 

--- a/plugins/aver-hid/fu-aver-safeisp-device.c
+++ b/plugins/aver-hid/fu-aver-safeisp-device.c
@@ -338,7 +338,10 @@ fu_aver_safeisp_device_write_firmware(FuDevice *device,
 	chunks = fu_chunk_array_new_from_bytes(cx3_fw,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       512);
+					       512,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	if (!fu_aver_safeisp_device_upload(self,
 					   chunks,
 					   fu_progress_get_child(progress),
@@ -365,7 +368,10 @@ fu_aver_safeisp_device_write_firmware(FuDevice *device,
 	chunks = fu_chunk_array_new_from_bytes(m12_fw,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       512);
+					       512,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	if (!fu_aver_safeisp_device_upload(self,
 					   chunks,
 					   fu_progress_get_child(progress),

--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -468,7 +468,10 @@ fu_bcm57xx_device_write_firmware(FuDevice *device,
 	chunks = fu_chunk_array_new_from_bytes(blob,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       FU_BCM57XX_BLOCK_SZ);
+					       FU_BCM57XX_BLOCK_SZ,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	if (!fu_bcm57xx_device_write_chunks(self, chunks, fu_progress_get_child(progress), error))
 		return FALSE;
 	fu_progress_step_done(progress);

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-firmware.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-firmware.c
@@ -377,7 +377,10 @@ fu_ccgx_dmc_firmware_write(FuFirmware *firmware, GError **error)
 		chunks = fu_chunk_array_new_from_bytes(img_bytes,
 						       FU_CHUNK_ADDR_OFFSET_NONE,
 						       FU_CHUNK_PAGESZ_NONE,
-						       64);
+						       64,
+						       error);
+		if (chunks == NULL)
+			return NULL;
 		fu_struct_ccgx_dmc_fwct_segmentation_info_set_num_rows(
 		    st_info,
 		    MAX(fu_chunk_array_length(chunks), 1));
@@ -406,7 +409,10 @@ fu_ccgx_dmc_firmware_write(FuFirmware *firmware, GError **error)
 		chunks = fu_chunk_array_new_from_bytes(img_bytes,
 						       FU_CHUNK_ADDR_OFFSET_NONE,
 						       FU_CHUNK_PAGESZ_NONE,
-						       64);
+						       64,
+						       error);
+		if (chunks == NULL)
+			return NULL;
 		img_padded =
 		    fu_bytes_pad(img_bytes, MAX(fu_chunk_array_length(chunks), 1) * 64, 0xFF);
 		fu_byte_array_append_bytes(buf, img_padded);

--- a/plugins/ccgx/fu-ccgx-firmware.c
+++ b/plugins/ccgx/fu-ccgx-firmware.c
@@ -442,7 +442,10 @@ fu_ccgx_firmware_write(FuFirmware *firmware, GError **error)
 	chunks = fu_chunk_array_new_from_bytes(fw,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       0x100);
+					       0x100,
+					       error);
+	if (chunks == NULL)
+		return NULL;
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk = NULL;
 

--- a/plugins/corsair/fu-corsair-device.c
+++ b/plugins/corsair/fu-corsair-device.c
@@ -389,7 +389,10 @@ fu_corsair_device_write_firmware_full(FuCorsairDevice *self,
 					       chk0_size,
 					       FU_CHUNK_PAGESZ_NONE,
 					       self->cmd_write_size -
-						   FU_STRUCT_CORSAIR_WRITE_NEXT_REQ_SIZE);
+						   FU_STRUCT_CORSAIR_WRITE_NEXT_REQ_SIZE,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	if (!fu_corsair_device_write_firmware_chunks(self,
 						     destination,
 						     chk0,

--- a/plugins/dell-kestrel/fu-dell-kestrel-hid-device.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-hid-device.c
@@ -340,7 +340,10 @@ fu_dell_kestrel_hid_device_write_firmware(FuDellKestrelHidDevice *self,
 	chunks = fu_chunk_array_new_from_bytes(fw,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       chunk_sz);
+					       chunk_sz,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
@@ -365,7 +368,10 @@ fu_dell_kestrel_hid_device_write_firmware(FuDellKestrelHidDevice *self,
 		pages = fu_chunk_array_new_from_bytes(buf,
 						      FU_CHUNK_ADDR_OFFSET_NONE,
 						      FU_CHUNK_PAGESZ_NONE,
-						      FU_DELL_KESTREL_HID_DATA_PAGE_SZ);
+						      FU_DELL_KESTREL_HID_DATA_PAGE_SZ,
+						      error);
+		if (pages == NULL)
+			return FALSE;
 
 		/* write pages */
 		if (!fu_dell_kestrel_hid_device_write_firmware_pages(

--- a/plugins/dfu/fu-dfu-target-stm.c
+++ b/plugins/dfu/fu-dfu-target-stm.c
@@ -462,7 +462,10 @@ fu_dfu_target_stm_download_element(FuDfuTarget *target,
 	chunks = fu_chunk_array_new_from_bytes(bytes,
 					       fu_chunk_get_address(chk),
 					       FU_CHUNK_PAGESZ_NONE,
-					       fu_dfu_device_get_transfer_size(proxy));
+					       fu_dfu_device_get_transfer_size(proxy),
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	if (!fu_dfu_target_stm_download_element1(target,
 						 chunks,
 						 sectors_array,

--- a/plugins/egis-moc/fu-egis-moc-device.c
+++ b/plugins/egis-moc/fu-egis-moc-device.c
@@ -441,7 +441,10 @@ fu_egis_moc_device_write_firmware(FuDevice *device,
 	chunks = fu_chunk_array_new_from_bytes(fw,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       FU_EGIS_MOC_FLASH_TRANSFER_BLOCK_SIZE);
+					       FU_EGIS_MOC_FLASH_TRANSFER_BLOCK_SIZE,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	if (!fu_egis_moc_device_write_packets(self, chunks, fu_progress_get_child(progress), error))
 		return FALSE;
 	fu_progress_step_done(progress);

--- a/plugins/elan-ts/fu-elan-ts-device.c
+++ b/plugins/elan-ts/fu-elan-ts-device.c
@@ -1161,7 +1161,10 @@ fu_elan_ts_device_write_page(FuElanTsDevice *self,
 	chunks = fu_chunk_array_new_from_bytes(blob,
 					       base_address,
 					       FU_CHUNK_PAGESZ_NONE,
-					       FU_ELAN_TS_PAGE_FRAME_SIZE);
+					       FU_ELAN_TS_PAGE_FRAME_SIZE,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
@@ -1196,7 +1199,10 @@ fu_elan_ts_device_write_block(FuElanTsDevice *self,
 	chunks = fu_chunk_array_new_from_bytes(blob,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       5 * FU_ELAN_TS_PAGE_FRAME_SIZE);
+					       5 * FU_ELAN_TS_PAGE_FRAME_SIZE,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
@@ -1245,7 +1251,10 @@ fu_elan_ts_device_write_blocks(FuElanTsDevice *self,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
 					       FU_ELAN_TS_FIRMWARE_PAGE_SIZE *
-						   FU_ELAN_TS_FW_PAGES_PER_BLOCK);
+						   FU_ELAN_TS_FW_PAGES_PER_BLOCK,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/plugins/elantp/fu-elantp-hid-haptic-device.c
+++ b/plugins/elantp/fu-elantp-hid-haptic-device.c
@@ -611,7 +611,10 @@ fu_elantp_hid_haptic_device_write_chunks_cb(FuDevice *device, gpointer user_data
 	chunks = fu_chunk_array_new_from_bytes(helper->fw,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       eeprom_fw_page_size);
+					       eeprom_fw_page_size,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	fu_progress_set_id(helper->progress, G_STRLOC);
 	fu_progress_set_steps(helper->progress,
 			      fu_chunk_array_length(chunks) - helper->idx_page_start + 1);

--- a/plugins/elantp/fu-elantp-i2c-device.c
+++ b/plugins/elantp/fu-elantp-i2c-device.c
@@ -472,7 +472,10 @@ fu_elantp_i2c_device_write_firmware(FuDevice *device,
 	chunks = fu_chunk_array_new_from_bytes(fw2,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       self->fw_page_size);
+					       self->fw_page_size,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		guint16 csum_tmp;
 		gsize blksz = self->fw_page_size + 4;

--- a/plugins/ep963x/fu-ep963x-device.c
+++ b/plugins/ep963x/fu-ep963x-device.c
@@ -302,7 +302,10 @@ fu_ep963x_device_write_firmware(FuDevice *device,
 		chunks = fu_chunk_array_new_from_bytes(chk_blob,
 						       fu_chunk_get_address(chk2),
 						       FU_CHUNK_PAGESZ_NONE,
-						       FU_EP963_TRANSFER_CHUNK_SIZE);
+						       FU_EP963_TRANSFER_CHUNK_SIZE,
+						       error);
+		if (chunks == NULL)
+			return FALSE;
 		for (guint j = 0; j < fu_chunk_array_length(chunks); j++) {
 			g_autoptr(FuChunk) chk = NULL;
 			g_autoptr(GError) error_loop = NULL;

--- a/plugins/fastboot/fu-fastboot-device.c
+++ b/plugins/fastboot/fu-fastboot-device.c
@@ -276,7 +276,10 @@ fu_fastboot_device_download(FuFastbootDevice *self,
 	chunks = fu_chunk_array_new_from_bytes(fw,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       self->blocksz);
+					       self->blocksz,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
+++ b/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
@@ -739,7 +739,10 @@ fu_genesys_gl32xx_device_write_firmware(FuDevice *device,
 	chunks = fu_chunk_array_new_from_bytes(fw,
 					       FU_GENESYS_GL32XX_FW_START_ADDR,
 					       FU_CHUNK_PAGESZ_NONE,
-					       self->packetsz);
+					       self->packetsz,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	if (!fu_genesys_gl32xx_device_write_blocks(self,
 						   chunks,
 						   fu_progress_get_child(progress),

--- a/plugins/goodix-moc/fu-goodix-moc-device.c
+++ b/plugins/goodix-moc/fu-goodix-moc-device.c
@@ -369,7 +369,10 @@ fu_goodix_moc_device_write_firmware(FuDevice *device,
 	chunks = fu_chunk_array_new_from_bytes(fw,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       GX_FLASH_TRANSFER_BLOCK_SIZE);
+					       GX_FLASH_TRANSFER_BLOCK_SIZE,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 
 	/* don't auto-boot firmware */
 	if (!fu_goodix_moc_device_update_init(self, &error_local)) {

--- a/plugins/ilitek-its/fu-ilitek-its-device.c
+++ b/plugins/ilitek-its/fu-ilitek-its-device.c
@@ -861,8 +861,11 @@ fu_ilitek_its_device_write_block(FuIlitekItsDevice *self,
 	blob = fu_firmware_get_bytes(block_img, error);
 	if (blob == NULL)
 		return FALSE;
-	chunks =
-	    fu_chunk_array_new_from_bytes(blob, 0, 0, FU_STRUCT_ILITEK_ITS_LONG_HID_CMD_SIZE_DATA);
+	chunks = fu_chunk_array_new_from_bytes(blob,
+					       0,
+					       0,
+					       FU_STRUCT_ILITEK_ITS_LONG_HID_CMD_SIZE_DATA,
+					       error);
 	if (chunks == NULL)
 		return FALSE;
 

--- a/plugins/intel-usb4/fu-intel-usb4-device.c
+++ b/plugins/intel-usb4/fu-intel-usb4-device.c
@@ -379,7 +379,10 @@ fu_intel_usb4_device_nvm_write(FuIntelUsb4Device *self,
 	chunks = fu_chunk_array_new_from_bytes(blob,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       64);
+					       64,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);

--- a/plugins/kinetic-dp/fu-kinetic-dp-puma-device.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-puma-device.c
@@ -139,8 +139,13 @@ fu_kinetic_dp_puma_device_enter_code_loading_mode(FuKineticDpPumaDevice *self, G
 static gboolean
 fu_kinetic_dp_puma_device_send_chunk(FuKineticDpPumaDevice *self, GBytes *fw, GError **error)
 {
-	g_autoptr(FuChunkArray) chunks =
-	    fu_chunk_array_new_from_bytes(fw, FU_CHUNK_ADDR_OFFSET_NONE, FU_CHUNK_PAGESZ_NONE, 16);
+	g_autoptr(FuChunkArray) chunks = fu_chunk_array_new_from_bytes(fw,
+								       FU_CHUNK_ADDR_OFFSET_NONE,
+								       FU_CHUNK_PAGESZ_NONE,
+								       16,
+								       error);
+	if (chunks == NULL)
+		return FALSE;
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk = NULL;
 
@@ -174,7 +179,10 @@ fu_kinetic_dp_puma_device_send_payload(FuKineticDpPumaDevice *self,
 	g_autoptr(FuChunkArray) chunks = fu_chunk_array_new_from_bytes(fw,
 								       FU_CHUNK_ADDR_OFFSET_NONE,
 								       FU_CHUNK_PAGESZ_NONE,
-								       PUMA_DPCD_DATA_SIZE);
+								       PUMA_DPCD_DATA_SIZE,
+								       error);
+	if (chunks == NULL)
+		return FALSE;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/kinetic-dp/fu-kinetic-dp-secure-device.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-secure-device.c
@@ -357,8 +357,13 @@ fu_kinetic_dp_secure_device_send_chunk(FuKineticDpSecureDevice *self,
 				       FuProgress *progress,
 				       GError **error)
 {
-	g_autoptr(FuChunkArray) chunks =
-	    fu_chunk_array_new_from_bytes(fw, FU_CHUNK_ADDR_OFFSET_NONE, FU_CHUNK_PAGESZ_NONE, 16);
+	g_autoptr(FuChunkArray) chunks = fu_chunk_array_new_from_bytes(fw,
+								       FU_CHUNK_ADDR_OFFSET_NONE,
+								       FU_CHUNK_PAGESZ_NONE,
+								       16,
+								       error);
+	if (chunks == NULL)
+		return FALSE;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
@@ -397,7 +402,10 @@ fu_kinetic_dp_secure_device_send_payload(FuKineticDpSecureDevice *self,
 	g_autoptr(FuChunkArray) chunks = fu_chunk_array_new_from_bytes(fw,
 								       FU_CHUNK_ADDR_OFFSET_NONE,
 								       FU_CHUNK_PAGESZ_NONE,
-								       DPCD_SIZE_KT_AUX_WIN);
+								       DPCD_SIZE_KT_AUX_WIN,
+								       error);
+	if (chunks == NULL)
+		return FALSE;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
+++ b/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
@@ -503,7 +503,10 @@ fu_mediatek_scaler_device_set_data(FuMediatekScalerDevice *self, FuChunk *chk, G
 	chk_slices = fu_chunk_array_new_from_bytes(chk_bytes,
 						   FU_CHUNK_ADDR_OFFSET_NONE,
 						   FU_CHUNK_PAGESZ_NONE,
-						   DDC_DATA_FRAGEMENT_SIZE);
+						   DDC_DATA_FRAGEMENT_SIZE,
+						   error);
+	if (chk_slices == NULL)
+		return FALSE;
 	for (guint i = 0; i < fu_chunk_array_length(chk_slices); i++) {
 		g_autoptr(FuChunk) chk_slice = NULL;
 		g_autoptr(FuStructDdcCmd) st_req = fu_struct_ddc_cmd_new();

--- a/plugins/modem-manager/fu-mm-qdu-mbim-device.c
+++ b/plugins/modem-manager/fu-mm-qdu-mbim-device.c
@@ -140,7 +140,10 @@ fu_mm_qdu_mbim_device_write(FuMmQduMbimDevice *self,
 	chunks = fu_chunk_array_new_from_bytes(blob,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       out_max_transfer_size);
+					       out_max_transfer_size,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	if (!fu_mm_qdu_mbim_device_write_chunks(self,
 						chunks,
 						fu_progress_get_child(progress),

--- a/plugins/novatek-ts/fu-novatek-ts-device.c
+++ b/plugins/novatek-ts/fu-novatek-ts-device.c
@@ -926,7 +926,10 @@ fu_novatek_ts_device_gcm_write_flash(FuNovatekTsDevice *self,
 	chunks = fu_chunk_array_new_from_bytes(blob,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       FLASH_PAGE_SIZE);
+					       FLASH_PAGE_SIZE,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
@@ -987,7 +990,10 @@ fu_novatek_ts_device_gcm_verify_flash(FuNovatekTsDevice *self,
 	chunks = fu_chunk_array_new_from_bytes(blob,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       FLASH_SECTOR_SIZE);
+					       FLASH_SECTOR_SIZE,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -572,7 +572,10 @@ fu_nvme_device_write_firmware(FuDevice *device,
 	chunks = fu_chunk_array_new_from_bytes(fw2,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       block_size);
+					       block_size,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk = NULL;
 

--- a/plugins/pixart-rf/fu-pixart-rf-ble-device.c
+++ b/plugins/pixart-rf/fu-pixart-rf-ble-device.c
@@ -308,7 +308,10 @@ fu_pixart_rf_ble_device_check_support_resume(FuPixartRfBleDevice *self,
 	chunks = fu_chunk_array_new_from_bytes(fw,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       FU_PIXART_RF_DEVICE_OBJECT_SIZE_MAX);
+					       FU_PIXART_RF_DEVICE_OBJECT_SIZE_MAX,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	if (self->fwstate.offset > fu_chunk_array_length(chunks)) {
 		g_set_error(error,
 			    FWUPD_ERROR,
@@ -471,7 +474,10 @@ fu_pixart_rf_ble_device_write_chunk(FuPixartRfBleDevice *self, FuChunk *chk, GEr
 	chunks = fu_chunk_array_new_from_bytes(chk_bytes,
 					       fu_chunk_get_address(chk),
 					       FU_CHUNK_PAGESZ_NONE,
-					       self->fwstate.mtu_size);
+					       self->fwstate.mtu_size,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk2 = NULL;
 
@@ -697,7 +703,10 @@ fu_pixart_rf_ble_device_write_firmware(FuDevice *device,
 	chunks = fu_chunk_array_new_from_bytes(fw,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       FU_PIXART_RF_DEVICE_OBJECT_SIZE_MAX);
+					       FU_PIXART_RF_DEVICE_OBJECT_SIZE_MAX,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	if (!fu_pixart_rf_ble_device_check_support_resume(self,
 							  firmware,
 							  fu_progress_get_child(progress),

--- a/plugins/pixart-rf/fu-pixart-rf-receiver-device.c
+++ b/plugins/pixart-rf/fu-pixart-rf-receiver-device.c
@@ -342,7 +342,10 @@ fu_pixart_rf_receiver_device_write_chunk(FuPixartRfReceiverDevice *self,
 	chunks = fu_chunk_array_new_from_bytes(chk_bytes,
 					       fu_chunk_get_address(chk),
 					       FU_CHUNK_PAGESZ_NONE,
-					       self->fwstate.mtu_size);
+					       self->fwstate.mtu_size,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk2 = NULL;
@@ -528,7 +531,10 @@ fu_pixart_rf_receiver_device_write_firmware(FuDevice *device,
 	chunks = fu_chunk_array_new_from_bytes(fw,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       FU_PIXART_RF_DEVICE_OBJECT_SIZE_MAX);
+					       FU_PIXART_RF_DEVICE_OBJECT_SIZE_MAX,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	/* prepare write fw into device */
 	self->fwstate.offset = 0;
 	self->fwstate.checksum = 0;

--- a/plugins/pixart-rf/fu-pixart-rf-wireless-device.c
+++ b/plugins/pixart-rf/fu-pixart-rf-wireless-device.c
@@ -326,7 +326,10 @@ fu_pixart_rf_wireless_device_write_chunk(FuPixartRfWirelessDevice *self,
 	chunks = fu_chunk_array_new_from_bytes(chk_bytes,
 					       fu_chunk_get_address(chk),
 					       FU_CHUNK_PAGESZ_NONE,
-					       self->fwstate.mtu_size);
+					       self->fwstate.mtu_size,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk2 = NULL;
@@ -693,7 +696,10 @@ fu_pixart_rf_wireless_device_write_firmware(FuDevice *device,
 	chunks = fu_chunk_array_new_from_bytes(fw,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       FU_PIXART_RF_DEVICE_OBJECT_SIZE_MAX);
+					       FU_PIXART_RF_DEVICE_OBJECT_SIZE_MAX,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	/* prepare write fw into device */
 	self->fwstate.offset = 0;
 	self->fwstate.checksum = 0;

--- a/plugins/pixart-tp/fu-pixart-tp-device.c
+++ b/plugins/pixart-tp/fu-pixart-tp-device.c
@@ -1009,7 +1009,10 @@ fu_pixart_tp_device_write_sector(FuPixartTpDevice *self,
 	g_autoptr(GBytes) blob = fu_chunk_get_bytes(chk_sector);
 
 	/* pages 1..15 */
-	chunks = fu_chunk_array_new_from_bytes(blob, 0x0, 0x0, FU_PIXART_TP_DEVICE_PAGE_SIZE);
+	chunks =
+	    fu_chunk_array_new_from_bytes(blob, 0x0, 0x0, FU_PIXART_TP_DEVICE_PAGE_SIZE, error);
+	if (chunks == NULL)
+		return FALSE;
 	if (fu_chunk_array_length(chunks) > G_MAXUINT8) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,

--- a/plugins/pixart-tp/fu-pixart-tp-haptic-device.c
+++ b/plugins/pixart-tp/fu-pixart-tp-haptic-device.c
@@ -612,7 +612,10 @@ fu_pixart_tp_haptic_device_tf_write_firmware(FuPixartTpHapticDevice *self,
 	chunks = fu_chunk_array_new_from_bytes(blob,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       32);
+					       32,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	if (!fu_pixart_tp_haptic_device_tf_write_packets(self,
 							 chunks,
 							 send_interval,

--- a/plugins/qc-firehose/fu-qc-firehose-impl.c
+++ b/plugins/qc-firehose/fu-qc-firehose-impl.c
@@ -651,7 +651,10 @@ fu_qc_firehose_impl_program(FuQcFirehoseImpl *self,
 
 	/* write data */
 	blob_padded = fu_bytes_pad(blob, num_sectors * sector_size, 0xFF);
-	chunks = fu_chunk_array_new_from_bytes(blob_padded, 0x0, 0x0, helper->max_payload_size);
+	chunks =
+	    fu_chunk_array_new_from_bytes(blob_padded, 0x0, 0x0, helper->max_payload_size, error);
+	if (chunks == NULL)
+		return FALSE;
 	if (!fu_qc_firehose_impl_write_blocks(self, chunks, progress, error))
 		return FALSE;
 	if (!fu_qc_firehose_impl_read_xml(self, 30000, helper, error))

--- a/plugins/qc-s5gen2/fu-qc-s5gen2-device.c
+++ b/plugins/qc-s5gen2/fu-qc-s5gen2-device.c
@@ -501,7 +501,10 @@ fu_qc_s5gen2_device_write_bucket(FuQcS5gen2Device *self,
 	chunks = fu_chunk_array_new_from_bytes(data,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       data_sz);
+					       data_sz,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuStructQcData) st_pkt = fu_struct_qc_data_new();

--- a/plugins/qsi-dock/fu-qsi-dock-mcu-device.c
+++ b/plugins/qsi-dock/fu-qsi-dock-mcu-device.c
@@ -280,7 +280,10 @@ fu_qsi_dock_mcu_device_write_chunk(FuQsiDockMcuDevice *self,
 	chunks = fu_chunk_array_new_from_bytes(chk_bytes,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       FU_QSI_DOCK_TX_ISP_LENGTH_MCU);
+					       FU_QSI_DOCK_TX_ISP_LENGTH_MCU,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
@@ -521,7 +524,10 @@ fu_qsi_dock_mcu_device_write_firmware_with_idx(FuQsiDockMcuDevice *self,
 	chunks = fu_chunk_array_new_from_bytes(fw_align,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       FU_QSI_DOCK_EXTERN_FLASH_PAGE_SIZE);
+					       FU_QSI_DOCK_EXTERN_FLASH_PAGE_SIZE,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	if (!fu_qsi_dock_mcu_device_write_chunks(self,
 						 chunks,
 						 &checksum_val,

--- a/plugins/realtek-mst/fu-realtek-mst-device.c
+++ b/plugins/realtek-mst/fu-realtek-mst-device.c
@@ -459,7 +459,9 @@ fu_realtek_mst_device_flash_iface_write(FuRealtekMstDevice *self,
 {
 	gsize total_size = g_bytes_get_size(data);
 	g_autoptr(FuChunkArray) chunks =
-	    fu_chunk_array_new_from_bytes(data, address, FU_CHUNK_PAGESZ_NONE, 256);
+	    fu_chunk_array_new_from_bytes(data, address, FU_CHUNK_PAGESZ_NONE, 256, error);
+	if (chunks == NULL)
+		return FALSE;
 
 	g_debug("write %#zx bytes at %#08x", total_size, address);
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/plugins/steelseries/fu-steelseries-fizz.c
+++ b/plugins/steelseries/fu-steelseries-fizz.c
@@ -138,7 +138,10 @@ fu_steelseries_fizz_write_fs(FuSteelseriesFizz *self,
 	chunks = fu_chunk_array_new_from_bytes(fw,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       FU_STEELSERIES_BUFFER_TRANSFER_SIZE);
+					       FU_STEELSERIES_BUFFER_TRANSFER_SIZE,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/plugins/steelseries/fu-steelseries-gamepad.c
+++ b/plugins/steelseries/fu-steelseries-gamepad.c
@@ -232,7 +232,10 @@ fu_steelseries_gamepad_write_firmware(FuDevice *device,
 	    fu_chunk_array_new_from_bytes(blob,
 					  FU_CHUNK_ADDR_OFFSET_NONE,
 					  FU_CHUNK_PAGESZ_NONE,
-					  FU_STRUCT_STEELSERIES_GAMEPAD_WRITE_CHUNK_REQ_SIZE_DATA);
+					  FU_STRUCT_STEELSERIES_GAMEPAD_WRITE_CHUNK_REQ_SIZE_DATA,
+					  error);
+	if (chunks == NULL)
+		return FALSE;
 	if (fu_chunk_array_length(chunks) > (G_MAXUINT16 + 1)) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,

--- a/plugins/steelseries/fu-steelseries-sonic.c
+++ b/plugins/steelseries/fu-steelseries-sonic.c
@@ -267,7 +267,10 @@ fu_steelseries_sonic_write_to_ram(FuSteelseriesSonic *self,
 	    fu_chunk_array_new_from_bytes(fw,
 					  FU_CHUNK_ADDR_OFFSET_NONE,
 					  FU_CHUNK_PAGESZ_NONE,
-					  FU_STRUCT_STEELSERIES_SONIC_WRITE_TO_RAM_REQ_SIZE_DATA);
+					  FU_STRUCT_STEELSERIES_SONIC_WRITE_TO_RAM_REQ_SIZE_DATA,
+					  error);
+	if (chunks == NULL)
+		return FALSE;
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
 	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
@@ -336,7 +339,10 @@ fu_steelseries_sonic_write_to_flash(FuSteelseriesSonic *self,
 	chunks = fu_chunk_array_new_from_bytes(fw,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       FU_STEELSERIES_BUFFER_FLASH_TRANSFER_SIZE);
+					       FU_STEELSERIES_BUFFER_FLASH_TRANSFER_SIZE,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
 	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -711,7 +711,10 @@ fu_synaptics_mst_device_update_esm(FuSynapticsMstDevice *self,
 	helper->chunks = fu_chunk_array_new_from_bytes(helper->fw,
 						       EEPROM_ESM_OFFSET,
 						       FU_CHUNK_PAGESZ_NONE,
-						       BLOCK_UNIT);
+						       BLOCK_UNIT,
+						       error);
+	if (helper->chunks == NULL)
+		return FALSE;
 	return fu_device_retry(FU_DEVICE(self),
 			       fu_synaptics_mst_device_update_esm_cb,
 			       MAX_RETRY_COUNTS,
@@ -803,7 +806,10 @@ fu_synaptics_mst_device_update_tesla_leaf_firmware(FuSynapticsMstDevice *self,
 	helper->chunks = fu_chunk_array_new_from_bytes(fw,
 						       FU_CHUNK_ADDR_OFFSET_NONE,
 						       FU_CHUNK_PAGESZ_NONE,
-						       BLOCK_UNIT);
+						       BLOCK_UNIT,
+						       error);
+	if (helper->chunks == NULL)
+		return FALSE;
 	return fu_device_retry(FU_DEVICE(self),
 			       fu_synaptics_mst_device_update_tesla_leaf_firmware_cb,
 			       MAX_RETRY_COUNTS,
@@ -1088,7 +1094,10 @@ fu_synaptics_mst_device_update_panamera_firmware(FuSynapticsMstDevice *self,
 	helper->chunks = fu_chunk_array_new_from_bytes(helper->fw,
 						       EEPROM_BANK_OFFSET * helper->bank_to_update,
 						       FU_CHUNK_PAGESZ_NONE,
-						       BLOCK_UNIT);
+						       BLOCK_UNIT,
+						       error);
+	if (helper->chunks == NULL)
+		return FALSE;
 	if (!fu_device_retry_full(FU_DEVICE(self),
 				  fu_synaptics_mst_device_update_panamera_firmware_cb,
 				  MAX_RETRY_COUNTS,
@@ -1313,7 +1322,10 @@ fu_synaptics_mst_device_update_firmware(FuSynapticsMstDevice *self,
 	helper->chunks = fu_chunk_array_new_from_bytes(helper->fw,
 						       FU_CHUNK_ADDR_OFFSET_NONE,
 						       FU_CHUNK_PAGESZ_NONE,
-						       BLOCK_UNIT);
+						       BLOCK_UNIT,
+						       error);
+	if (helper->chunks == NULL)
+		return FALSE;
 	if (!fu_device_retry(FU_DEVICE(self),
 			     fu_synaptics_mst_device_update_firmware_cb,
 			     MAX_RETRY_COUNTS,

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-v5-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-v5-device.c
@@ -366,11 +366,17 @@ fu_synaptics_rmi_v5_device_write_firmware(FuSynapticsRmiDevice *self,
 	chunks_bin = fu_chunk_array_new_from_bytes(firmware_bin,
 						   FU_CHUNK_ADDR_OFFSET_NONE,
 						   FU_CHUNK_PAGESZ_NONE,
-						   flash->block_size);
+						   flash->block_size,
+						   error);
+	if (chunks_bin == NULL)
+		return FALSE;
 	chunks_cfg = fu_chunk_array_new_from_bytes(bytes_cfg,
 						   FU_CHUNK_ADDR_OFFSET_NONE,
 						   FU_CHUNK_PAGESZ_NONE,
-						   flash->block_size);
+						   flash->block_size,
+						   error);
+	if (chunks_cfg == NULL)
+		return FALSE;
 	for (guint i = 0; i < fu_chunk_array_length(chunks_bin); i++) {
 		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks_bin, i, error);
 		if (chk == NULL)
@@ -399,7 +405,10 @@ fu_synaptics_rmi_v5_device_write_firmware(FuSynapticsRmiDevice *self,
 		chunks_sig = fu_chunk_array_new_from_bytes(signature_bin,
 							   FU_CHUNK_ADDR_OFFSET_NONE,
 							   FU_CHUNK_PAGESZ_NONE,
-							   flash->block_size);
+							   flash->block_size,
+							   error);
+		if (chunks_sig == NULL)
+			return FALSE;
 		if (!fu_synaptics_rmi_device_write(self,
 						   f34->data_base,
 						   req_addr,

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-v7-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-v7-device.c
@@ -234,7 +234,10 @@ fu_synaptics_rmi_v7_device_write_blocks(FuSynapticsRmiDevice *self,
 	chunks = fu_chunk_array_new_from_bytes(fw,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       flash->block_size);
+					       flash->block_size,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk = NULL;
 		g_autoptr(GByteArray) req = g_byte_array_new();
@@ -315,7 +318,10 @@ fu_synaptics_rmi_v7_device_write_partition_signature(FuSynapticsRmiDevice *self,
 	    fu_chunk_array_new_from_bytes(bytes,
 					  FU_CHUNK_ADDR_OFFSET_NONE,
 					  FU_CHUNK_PAGESZ_NONE,
-					  (gsize)flash->payload_length * (gsize)flash->block_size);
+					  (gsize)flash->payload_length * (gsize)flash->block_size,
+					  error);
+	if (chunks == NULL)
+		return FALSE;
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk = NULL;
 		g_autoptr(GByteArray) req_cmd = g_byte_array_new();
@@ -403,7 +409,10 @@ fu_synaptics_rmi_v7_device_write_partition(FuSynapticsRmiDevice *self,
 	    fu_chunk_array_new_from_bytes(bytes,
 					  FU_CHUNK_ADDR_OFFSET_NONE,
 					  FU_CHUNK_PAGESZ_NONE,
-					  (gsize)flash->payload_length * (gsize)flash->block_size);
+					  (gsize)flash->payload_length * (gsize)flash->block_size,
+					  error);
+	if (chunks == NULL)
+		return FALSE;
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_set_steps(progress, fu_chunk_array_length(chunks) + 1);
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/plugins/telink-dfu/fu-telink-dfu-ble-device.c
+++ b/plugins/telink-dfu/fu-telink-dfu-ble-device.c
@@ -170,7 +170,10 @@ fu_telink_dfu_ble_device_write_blob(FuTelinkDfuBleDevice *self,
 	chunks = fu_chunk_array_new_from_bytes(blob,
 					       FU_TELINK_DFU_HID_DEVICE_START_ADDR,
 					       FU_CHUNK_PAGESZ_NONE,
-					       FU_STRUCT_TELINK_DFU_BLE_PKT_SIZE_PAYLOAD);
+					       FU_STRUCT_TELINK_DFU_BLE_PKT_SIZE_PAYLOAD,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	if (!fu_telink_dfu_ble_device_write_blocks(self,
 						   chunks,
 						   fu_progress_get_child(progress),

--- a/plugins/telink-dfu/fu-telink-dfu-hid-device.c
+++ b/plugins/telink-dfu/fu-telink-dfu-hid-device.c
@@ -310,7 +310,10 @@ fu_telink_dfu_hid_device_write_blob(FuTelinkDfuHidDevice *self,
 	chunks = fu_chunk_array_new_from_bytes(blob,
 					       FU_TELINK_DFU_HID_DEVICE_START_ADDR,
 					       FU_CHUNK_PAGESZ_NONE,
-					       FU_STRUCT_TELINK_DFU_HID_PKT_PAYLOAD_SIZE_OTA_DATA);
+					       FU_STRUCT_TELINK_DFU_HID_PKT_PAYLOAD_SIZE_OTA_DATA,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	if (!fu_telink_dfu_hid_device_write_blocks(self,
 						   chunks,
 						   fu_progress_get_child(progress),

--- a/plugins/usi-dock/fu-usi-dock-mcu-device.c
+++ b/plugins/usi-dock/fu-usi-dock-mcu-device.c
@@ -548,7 +548,10 @@ fu_usi_dock_mcu_device_write_page(FuUsiDockMcuDevice *self, FuChunk *chk_page, G
 	chunks = fu_chunk_array_new_from_bytes(chk_blob,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       FU_STRUCT_USI_DOCK_HID_REQ_SIZE_BUF);
+					       FU_STRUCT_USI_DOCK_HID_REQ_SIZE_BUF,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk = NULL;
 

--- a/plugins/vli/fu-vli-pd-parade-device.c
+++ b/plugins/vli/fu-vli-pd-parade-device.c
@@ -505,7 +505,10 @@ fu_vli_pd_parade_device_write_firmware(FuDevice *device,
 	blocks = fu_chunk_array_new_from_bytes(fw,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       0x10000);
+					       0x10000,
+					       error);
+	if (blocks == NULL)
+		return FALSE;
 	for (guint i = 1; i < fu_chunk_array_length(blocks); i++) {
 		g_autoptr(FuChunk) chk = fu_chunk_array_index(blocks, i, error);
 		if (chk == NULL)

--- a/plugins/wacom-raw/fu-wacom-raw-device.c
+++ b/plugins/wacom-raw/fu-wacom-raw-device.c
@@ -217,7 +217,10 @@ fu_wacom_raw_device_write_firmware(FuDevice *device,
 	chunks = fu_chunk_array_new_from_bytes(fw,
 					       priv->flash_base_addr,
 					       FU_CHUNK_PAGESZ_NONE,
-					       priv->flash_block_size);
+					       priv->flash_block_size,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	return klass->write_firmware(device, chunks, progress, error);
 }
 

--- a/plugins/wacom-usb/fu-wacom-usb-device.c
+++ b/plugins/wacom-usb/fu-wacom-usb-device.c
@@ -569,7 +569,10 @@ fu_wacom_usb_device_write_firmware(FuDevice *device,
 		chunks = fu_chunk_array_new_from_bytes(blob_block,
 						       fd->start_addr,
 						       FU_CHUNK_PAGESZ_NONE,
-						       self->write_block_sz);
+						       self->write_block_sz,
+						       error);
+		if (chunks == NULL)
+			return FALSE;
 		for (guint j = 0; j < fu_chunk_array_length(chunks); j++) {
 			g_autoptr(FuChunk) chk = NULL;
 			g_autoptr(GBytes) blob_chunk = NULL;

--- a/plugins/wch-ch341a/fu-wch-ch341a-cfi-device.c
+++ b/plugins/wch-ch341a/fu-wch-ch341a-cfi-device.c
@@ -217,7 +217,10 @@ fu_wch_ch341a_cfi_device_write_page(FuWchCh341aCfiDevice *self, FuChunk *page, G
 	chunks = fu_chunk_array_new_from_bytes(page_blob,
 					       FU_CHUNK_ADDR_OFFSET_NONE,
 					       FU_CHUNK_PAGESZ_NONE,
-					       WCH_CH341A_PAYLOAD_SIZE);
+					       WCH_CH341A_PAYLOAD_SIZE,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk = NULL;
 		guint8 buf2[WCH_CH341A_PAYLOAD_SIZE] = {0x0};
@@ -376,7 +379,10 @@ fu_wch_ch341a_cfi_device_write_firmware(FuDevice *device,
 	pages = fu_chunk_array_new_from_bytes(fw,
 					      FU_CHUNK_ADDR_OFFSET_NONE,
 					      FU_CHUNK_PAGESZ_NONE,
-					      fu_cfi_device_get_page_size(FU_CFI_DEVICE(self)));
+					      fu_cfi_device_get_page_size(FU_CFI_DEVICE(self)),
+					      error);
+	if (pages == NULL)
+		return FALSE;
 	if (!fu_wch_ch341a_cfi_device_write_pages(self,
 						  pages,
 						  fu_progress_get_child(progress),

--- a/plugins/wch-ch347/fu-wch-ch347-device.c
+++ b/plugins/wch-ch347/fu-wch-ch347-device.c
@@ -165,7 +165,10 @@ fu_wch_ch347_device_send_command(FuWchCh347Device *self,
 		    fu_chunk_array_new_from_bytes(wblob,
 						  FU_CHUNK_ADDR_OFFSET_NONE,
 						  FU_CHUNK_PAGESZ_NONE,
-						  FU_WCH_CH347_PAYLOAD_SIZE);
+						  FU_WCH_CH347_PAYLOAD_SIZE,
+						  error);
+		if (chunks == NULL)
+			return FALSE;
 		for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 			guint8 buf[1] = {0x0};
 			g_autoptr(FuChunk) chk = NULL;


### PR DESCRIPTION
Return NULL with FWUPD_ERROR_INVALID_DATA if packet_sz is zero, and update all callers to propagate the error.

There are two security issues identified by AISLE that would have been impossible with this sanity check.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
