### PR TITLE
Bump meson requirement to 1.11

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,8 +38,8 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update -qq
+          sudo add-apt-repository -y ppa:peter-hutterer/meson1.11; \
           sudo ./contrib/ci/fwupd_setup_helpers.py install-dependencies --yes -o ubuntu
-          python3 -m pip install --user "meson >= 0.62.0"
 
       - name: Build
         run: |

--- a/contrib/snap/snapcraft.yaml
+++ b/contrib/snap/snapcraft.yaml
@@ -266,6 +266,7 @@ parts:
     after: [build-introspection]
     build-environment:
       - PYTHONPATH: "${CRAFT_STAGE}/usr/lib/python3/dist-packages"
+      - PIP_BREAK_SYSTEM_PACKAGES: "1"
   update-mime:
     plugin: make
     source: contrib/snap/update-mime

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
   'c',
   version: '2.1.8',
   license: 'LGPL-2.1-or-later',
-  meson_version: '>=0.63.0', # limited by RHEL-9
+  meson_version: '>=1.11.0',
   default_options: ['warning_level=2', 'c_std=c17'],
 )
 


### PR DESCRIPTION
We require meson 1.11 for the upcoming Rust support.

PR to narrow down what still needs fixing in the CI (other than centos)

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
