### PR TITLE
asus-hid: Implement MCU firmware writing

### DIFF
--- a/plugins/asus-hid/README.md
+++ b/plugins/asus-hid/README.md
@@ -12,31 +12,51 @@ devices.
 The daemon will decompress the cabinet archive and extract a firmware blob in
 a packed binary file format.
 
+The last 1kB of the image is a trailer describing which parts of the flash the
+payload covers, and only the first of those regions is written. The rest of the
+image is padding, except for the recovery bootloader that sits between the two
+regions, which the device already holds and which is deliberately not shipped
+in the update.
+
 This plugin supports the following protocol ID:
 
 * `com.asus.hid`
 
 ## GUID Generation
 
-These devices use the a DeviceInstanceId value that also reflects the microcontroller ID.
+These devices use a DeviceInstanceId built from the hidraw vendor and product,
+with the microcontroller product code appended:
 
-* `USB\VID_0B05&PID_1ABE&PART_RC72LA`
+* `HIDRAW\VEN_0B05&DEV_1B4C&PART_RC73XA`
+
+In bootloader mode the part enumerates as an ITE device instead, and the
+microcontroller index is appended rather than the product code:
+
+* `HIDRAW\VEN_048D&DEV_89DC&RECOVERY_0`
 
 ## Update Behavior
 
-The device will restart after update.
+The part is flashed as a whole rather than one microcontroller at a time, which
+is what the vendor tool does. The child devices report the version of each
+microcontroller but are not update targets themselves.
+
+Updating detaches the part into an ITE bootloader, which takes about eight
+seconds and leaves the gamepad, the keyboard and the power button unresponsive
+until it comes back. The device restarts after the update.
 
 ## Vendor ID Security
 
-The vendor ID is set from the USB vendor, in this instance set to `USB:0x0B05`
+The vendor ID is set from the HID vendor, in this instance set to `HIDRAW:0x0B05`
 
 ## External Interface Access
 
-This plugin requires read/write access to `/dev/bus/usb`.
+This plugin requires read/write access to `/dev/hidraw*`.
 
 ## Version Considerations
 
 This plugin has been available since fwupd version `2.0.0`.
+
+Writing firmware has been available since fwupd version `2.1.0`.
 
 ## Quirk Use
 

--- a/plugins/asus-hid/fu-asus-hid-child-device.c
+++ b/plugins/asus-hid/fu-asus-hid-child-device.c
@@ -78,10 +78,9 @@ fu_asus_hid_child_device_ensure_manufacturer(FuAsusHidChildDevice *self, GError 
 		return FALSE;
 
 	man = fu_struct_asus_man_result_get_data(st_result);
-	/* FIXME? I think this was supposed to be "ASUS Tech.Inc." i.e. with a space --
-	 * it appears that we set the short string in FuStructAsusManCommand which the
-	 * device seems to copy back in FuStructAsusManResult ¯\_ (ツ)_/¯ */
-	if (g_strcmp0(man, "ASUSTech.Inc.") != 0) {
+	/* the device echoes back whatever was sent, so this only proves it is
+	 * listening -- the vendor tool compares against the same fixed string */
+	if (g_strcmp0(man, "ASUS Tech.Inc.") != 0) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_NOT_SUPPORTED,

--- a/plugins/asus-hid/fu-asus-hid-child-device.c
+++ b/plugins/asus-hid/fu-asus-hid-child-device.c
@@ -160,11 +160,13 @@ fu_asus_hid_child_device_setup(FuDevice *device, GError **error)
 		g_autofree gchar *recovery_str = g_strdup_printf("%d", self->idx);
 		/* RC71LS = 0, RC71LM = 1 */
 		fu_device_add_instance_strsafe(FU_DEVICE(self), "RECOVERY", recovery_str);
+		/* the parent is a hidraw device, so there are no USB instance
+		 * attributes to build an ID from */
 		fu_device_build_instance_id(FU_DEVICE(self),
 					    NULL,
-					    "USB",
-					    "VID",
-					    "PID",
+					    "HIDRAW",
+					    "VEN",
+					    "DEV",
 					    "RECOVERY",
 					    NULL);
 		fu_device_set_logical_id(FU_DEVICE(self), recovery_str);

--- a/plugins/asus-hid/fu-asus-hid-device.c
+++ b/plugins/asus-hid/fu-asus-hid-device.c
@@ -21,6 +21,11 @@ G_DEFINE_TYPE(FuAsusHidDevice, fu_asus_hid_device, FU_TYPE_HIDRAW_DEVICE)
 #define FU_ASUS_HID_DEVICE_TIMEOUT	    200 /* ms */
 #define FU_ASUS_HID_DEVICE_PRE_UPDATE_DELAY 50	/* ms */
 #define FU_ASUS_HID_DEVICE_RETRIES	    50
+#define FU_ASUS_HID_DEVICE_ERASE_DELAY	    200 /* ms */
+#define FU_ASUS_HID_DEVICE_BLOCK_START_DELAY 5	 /* ms */
+#define FU_ASUS_HID_DEVICE_CHUNK_DELAY	     2	 /* ms */
+#define FU_ASUS_HID_DEVICE_COMMIT_DELAY	     50	 /* ms */
+#define FU_ASUS_HID_DEVICE_BLOCK_SIZE	    0x400
 
 static gboolean
 fu_asus_hid_device_transfer_feature(FuAsusHidDevice *self,
@@ -365,6 +370,142 @@ fu_asus_hid_device_dump_firmware(FuDevice *device, FuProgress *progress, GError 
 }
 
 static gboolean
+fu_asus_hid_device_write_block(FuAsusHidDevice *self,
+			       guint32 address,
+			       const guint8 *buf,
+			       gsize bufsz,
+			       GError **error)
+{
+	g_autoptr(FuChunkArray) chunks = NULL;
+	g_autoptr(FuStructAsusCommitFlashCommand) st_commit =
+	    fu_struct_asus_commit_flash_command_new();
+	g_autoptr(FuStructAsusFlashBlockStart) st_start = fu_struct_asus_flash_block_start_new();
+	g_autoptr(GBytes) blob = g_bytes_new_static(buf, bufsz);
+
+	if (!fu_asus_hid_device_transfer_feature(self,
+						 st_start->buf,
+						 NULL,
+						 FU_ASUS_HID_REPORT_ID_FLASHING,
+						 error))
+		return FALSE;
+	fu_device_sleep(FU_DEVICE(self), FU_ASUS_HID_DEVICE_BLOCK_START_DELAY);
+
+	/* the block is filled a fragment at a time before being committed */
+	chunks = fu_chunk_array_new_from_bytes(blob,
+					       0x0,
+					       0x0,
+					       FU_STRUCT_ASUS_WRITE_FLASH_COMMAND_SIZE_DATA,
+					       error);
+	if (chunks == NULL)
+		return FALSE;
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = NULL;
+		g_autoptr(FuStructAsusWriteFlashCommand) st =
+		    fu_struct_asus_write_flash_command_new();
+
+		chk = fu_chunk_array_index(chunks, i, error);
+		if (chk == NULL)
+			return FALSE;
+		fu_struct_asus_write_flash_command_set_offset(st, fu_chunk_get_address(chk));
+		fu_struct_asus_write_flash_command_set_datasz(st, fu_chunk_get_data_sz(chk));
+		if (!fu_struct_asus_write_flash_command_set_data(st,
+								 fu_chunk_get_data(chk),
+								 fu_chunk_get_data_sz(chk),
+								 error))
+			return FALSE;
+		if (!fu_asus_hid_device_transfer_feature(self,
+							 st->buf,
+							 NULL,
+							 FU_ASUS_HID_REPORT_ID_FLASHING,
+							 error))
+			return FALSE;
+		fu_device_sleep(FU_DEVICE(self), FU_ASUS_HID_DEVICE_CHUNK_DELAY);
+	}
+
+	fu_struct_asus_commit_flash_command_set_offset(st_commit, address);
+	fu_struct_asus_commit_flash_command_set_datasz(st_commit, bufsz);
+	if (!fu_asus_hid_device_transfer_feature(self,
+						 st_commit->buf,
+						 NULL,
+						 FU_ASUS_HID_REPORT_ID_FLASHING,
+						 error))
+		return FALSE;
+	fu_device_sleep(FU_DEVICE(self), FU_ASUS_HID_DEVICE_COMMIT_DELAY);
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_asus_hid_device_write_firmware(FuDevice *device,
+				  FuFirmware *firmware,
+				  FuProgress *progress,
+				  FwupdInstallFlags flags,
+				  GError **error)
+{
+	FuAsusHidDevice *self = FU_ASUS_HID_DEVICE(device);
+	const guint8 *buf;
+	gsize bufsz = 0;
+	guint32 address;
+	guint blocks;
+	g_autoptr(FuFirmware) img = NULL;
+	g_autoptr(GBytes) blob = NULL;
+	g_autoptr(FuStructAsusEraseFlashCommand) st_erase =
+	    fu_struct_asus_erase_flash_command_new();
+
+	img = fu_firmware_get_image_by_id(firmware, FU_FIRMWARE_ID_PAYLOAD, error);
+	if (img == NULL)
+		return FALSE;
+	blob = fu_firmware_get_bytes(img, error);
+	if (blob == NULL)
+		return FALSE;
+	buf = g_bytes_get_data(blob, &bufsz);
+	address = fu_firmware_get_addr(img);
+	if (bufsz % FU_ASUS_HID_DEVICE_BLOCK_SIZE != 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_FILE,
+			    "payload of 0x%x bytes is not a multiple of the 0x%x block size",
+			    (guint)bufsz,
+			    (guint)FU_ASUS_HID_DEVICE_BLOCK_SIZE);
+		return FALSE;
+	}
+	blocks = bufsz / FU_ASUS_HID_DEVICE_BLOCK_SIZE;
+
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 5, NULL);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 95, NULL);
+
+	/* the whole region goes in one command, and the count is in blocks */
+	fu_struct_asus_erase_flash_command_set_offset(st_erase, address);
+	fu_struct_asus_erase_flash_command_set_blocks(st_erase, blocks);
+	if (!fu_asus_hid_device_transfer_feature(self,
+						 st_erase->buf,
+						 NULL,
+						 FU_ASUS_HID_REPORT_ID_FLASHING,
+						 error))
+		return FALSE;
+	fu_device_sleep(FU_DEVICE(self), FU_ASUS_HID_DEVICE_ERASE_DELAY);
+	fu_progress_step_done(progress);
+
+	fu_progress_set_id(fu_progress_get_child(progress), G_STRLOC);
+	fu_progress_set_steps(fu_progress_get_child(progress), blocks);
+	for (guint i = 0; i < blocks; i++) {
+		if (!fu_asus_hid_device_write_block(self,
+						    address + (i * FU_ASUS_HID_DEVICE_BLOCK_SIZE),
+						    buf + (i * FU_ASUS_HID_DEVICE_BLOCK_SIZE),
+						    FU_ASUS_HID_DEVICE_BLOCK_SIZE,
+						    error))
+			return FALSE;
+		fu_progress_step_done(fu_progress_get_child(progress));
+	}
+	fu_progress_step_done(progress);
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
 fu_asus_hid_device_set_quirk_kv(FuDevice *device,
 				const gchar *key,
 				const gchar *value,
@@ -427,4 +568,5 @@ fu_asus_hid_device_class_init(FuAsusHidDeviceClass *klass)
 	device_class->detach = fu_asus_hid_device_detach;
 	device_class->attach = fu_asus_hid_device_attach;
 	device_class->dump_firmware = fu_asus_hid_device_dump_firmware;
+	device_class->write_firmware = fu_asus_hid_device_write_firmware;
 }

--- a/plugins/asus-hid/fu-asus-hid-device.c
+++ b/plugins/asus-hid/fu-asus-hid-device.c
@@ -8,6 +8,7 @@
 
 #include "fu-asus-hid-child-device.h"
 #include "fu-asus-hid-device.h"
+#include "fu-asus-hid-firmware.h"
 #include "fu-asus-hid-struct.h"
 
 struct _FuAsusHidDevice {
@@ -22,9 +23,9 @@ G_DEFINE_TYPE(FuAsusHidDevice, fu_asus_hid_device, FU_TYPE_HIDRAW_DEVICE)
 #define FU_ASUS_HID_DEVICE_PRE_UPDATE_DELAY 50	/* ms */
 #define FU_ASUS_HID_DEVICE_RETRIES	    50
 #define FU_ASUS_HID_DEVICE_ERASE_DELAY	    200 /* ms */
-#define FU_ASUS_HID_DEVICE_BLOCK_START_DELAY 5	 /* ms */
-#define FU_ASUS_HID_DEVICE_CHUNK_DELAY	     2	 /* ms */
-#define FU_ASUS_HID_DEVICE_COMMIT_DELAY	     50	 /* ms */
+#define FU_ASUS_HID_DEVICE_BLOCK_START_DELAY 5	/* ms */
+#define FU_ASUS_HID_DEVICE_CHUNK_DELAY	    2	/* ms */
+#define FU_ASUS_HID_DEVICE_COMMIT_DELAY	    50	/* ms */
 #define FU_ASUS_HID_DEVICE_BLOCK_SIZE	    0x400
 
 static gboolean
@@ -210,6 +211,32 @@ fu_asus_hid_device_probe(FuDevice *device, GError **error)
 	return TRUE;
 }
 
+/* the vendor tool flashes the part as a whole rather than per-microcontroller,
+ * so the version of the primary one is what gets compared against the release */
+static gboolean
+fu_asus_hid_device_ensure_version(FuAsusHidDevice *self, GError **error)
+{
+	g_autofree gchar *version = NULL;
+	g_autoptr(FuStructAsusHidCommand) st = fu_struct_asus_hid_command_new();
+	g_autoptr(FuStructAsusHidDesc) st_desc = NULL;
+	g_autoptr(FuStructAsusHidFwInfo) st_result = fu_struct_asus_hid_fw_info_new();
+
+	fu_struct_asus_hid_command_set_cmd(st, FU_ASUS_HID_COMMAND_FW_VERSION);
+	fu_struct_asus_hid_command_set_length(st, FU_STRUCT_ASUS_HID_RESULT_SIZE);
+	if (!fu_asus_hid_device_transfer_feature(self,
+						 st->buf,
+						 st_result->buf,
+						 FU_ASUS_HID_REPORT_ID_INFO,
+						 error))
+		return FALSE;
+	st_desc = fu_struct_asus_hid_fw_info_get_description(st_result);
+	version = fu_struct_asus_hid_desc_get_version(st_desc);
+	fu_device_set_version(FU_DEVICE(self), version);
+
+	/* success */
+	return TRUE;
+}
+
 static gboolean
 fu_asus_hid_device_setup(FuDevice *device, GError **error)
 {
@@ -225,8 +252,17 @@ fu_asus_hid_device_setup(FuDevice *device, GError **error)
 	if (!fu_asus_hid_device_init_seq(self, error))
 		return FALSE;
 
+	if (!fu_asus_hid_device_ensure_version(self, error))
+		return FALSE;
+
 	/* success */
 	return TRUE;
+}
+
+static gboolean
+fu_asus_hid_device_reload(FuDevice *device, GError **error)
+{
+	return fu_asus_hid_device_ensure_version(FU_ASUS_HID_DEVICE(device), error);
 }
 
 static gboolean
@@ -450,8 +486,7 @@ fu_asus_hid_device_write_firmware(FuDevice *device,
 	guint blocks;
 	g_autoptr(FuFirmware) img = NULL;
 	g_autoptr(GBytes) blob = NULL;
-	g_autoptr(FuStructAsusEraseFlashCommand) st_erase =
-	    fu_struct_asus_erase_flash_command_new();
+	g_autoptr(FuStructAsusEraseFlashCommand) st_erase = fu_struct_asus_erase_flash_command_new();
 
 	img = fu_firmware_get_image_by_id(firmware, FU_FIRMWARE_ID_PAYLOAD, error);
 	if (img == NULL)
@@ -549,6 +584,11 @@ fu_asus_hid_device_init(FuAsusHidDevice *self)
 	/* TODO: automatic backup */
 	/* fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_BACKUP_BEFORE_INSTALL); */
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INTERNAL);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
+	fu_device_add_protocol(FU_DEVICE(self), "com.asus.hid");
+	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PLAIN);
+	fu_device_set_firmware_gtype(FU_DEVICE(self), FU_TYPE_ASUS_HID_FIRMWARE);
 	/* the device comes back with the counterpart GUID rather than the one
 	 * it left with, so the replug is only matched with this */
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_REPLUG_MATCH_GUID);
@@ -568,6 +608,7 @@ fu_asus_hid_device_class_init(FuAsusHidDeviceClass *klass)
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	object_class->dispose = fu_asus_hid_device_dispose;
 	device_class->setup = fu_asus_hid_device_setup;
+	device_class->reload = fu_asus_hid_device_reload;
 	device_class->probe = fu_asus_hid_device_probe;
 	device_class->set_quirk_kv = fu_asus_hid_device_set_quirk_kv;
 	device_class->detach = fu_asus_hid_device_detach;

--- a/plugins/asus-hid/fu-asus-hid-device.c
+++ b/plugins/asus-hid/fu-asus-hid-device.c
@@ -549,7 +549,12 @@ fu_asus_hid_device_init(FuAsusHidDevice *self)
 	/* TODO: automatic backup */
 	/* fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_BACKUP_BEFORE_INSTALL); */
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INTERNAL);
-	fu_device_set_remove_delay(FU_DEVICE(self), 10000);
+	/* the device comes back with the counterpart GUID rather than the one
+	 * it left with, so the replug is only matched with this */
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_REPLUG_MATCH_GUID);
+	/* switching modes takes about eight seconds on a RC73XA, in either
+	 * direction, so ten was not enough of a margin */
+	fu_device_set_remove_delay(FU_DEVICE(self), 30000);
 	self->child_added_id = g_signal_connect(FU_DEVICE(self),
 						"child-added",
 						G_CALLBACK(fu_asus_hid_device_child_added_cb),

--- a/plugins/asus-hid/fu-asus-hid-device.c
+++ b/plugins/asus-hid/fu-asus-hid-device.c
@@ -18,7 +18,9 @@ struct _FuAsusHidDevice {
 
 G_DEFINE_TYPE(FuAsusHidDevice, fu_asus_hid_device, FU_TYPE_HIDRAW_DEVICE)
 
-#define FU_ASUS_HID_DEVICE_TIMEOUT 200 /* ms */
+#define FU_ASUS_HID_DEVICE_TIMEOUT	    200 /* ms */
+#define FU_ASUS_HID_DEVICE_PRE_UPDATE_DELAY 50	/* ms */
+#define FU_ASUS_HID_DEVICE_RETRIES	    50
 
 static gboolean
 fu_asus_hid_device_transfer_feature(FuAsusHidDevice *self,
@@ -68,6 +70,92 @@ fu_asus_hid_device_init_seq(FuAsusHidDevice *self, GError **error)
 	}
 
 	return TRUE;
+}
+
+static gboolean
+fu_asus_hid_device_ensure_manufacturer_cb(FuDevice *device, gpointer user_data, GError **error)
+{
+	g_autofree gchar *data = NULL;
+	g_autoptr(FuStructAsusManCommand) st = fu_struct_asus_man_command_new();
+	g_autoptr(FuStructAsusManResult) st_result = fu_struct_asus_man_result_new();
+
+	if (!fu_asus_hid_device_transfer_feature(FU_ASUS_HID_DEVICE(device),
+						 st->buf,
+						 st_result->buf,
+						 FU_ASUS_HID_REPORT_ID_INFO,
+						 error))
+		return FALSE;
+	data = fu_struct_asus_man_result_get_data(st_result);
+	if (g_strcmp0(data, "ASUS Tech.Inc.") != 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "device did not echo the manufacturer, got %s",
+			    data);
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+/* the query returns a byte that the MCU expects to see masked and sent straight
+ * back to it, and it refuses to leave runtime mode if that does not happen */
+static gboolean
+fu_asus_hid_device_pre_update_pair(FuAsusHidDevice *self,
+				   FuAsusHidCommand cmd_query,
+				   FuAsusHidCommand cmd_apply,
+				   guint8 mask,
+				   GError **error)
+{
+	const guint8 *buf;
+	gsize bufsz = 0;
+	guint8 value = 0;
+	g_autoptr(FuStructAsusHidPreUpdateCommand) st = fu_struct_asus_hid_pre_update_command_new();
+	g_autoptr(FuStructAsusHidResult) st_result = fu_struct_asus_hid_result_new();
+
+	fu_struct_asus_hid_pre_update_command_set_cmd(st, cmd_query);
+	fu_struct_asus_hid_pre_update_command_set_length(st, 0x1);
+	if (!fu_asus_hid_device_transfer_feature(self,
+						 st->buf,
+						 st_result->buf,
+						 FU_ASUS_HID_REPORT_ID_INFO,
+						 error))
+		return FALSE;
+	buf = fu_struct_asus_hid_result_get_data(st_result, &bufsz);
+	if (!fu_memread_uint8_safe(buf, bufsz, 0x5, &value, error))
+		return FALSE;
+	value |= mask;
+
+	fu_struct_asus_hid_pre_update_command_set_cmd(st, cmd_apply);
+	fu_struct_asus_hid_pre_update_command_set_length(st, 0x1);
+	if (!fu_struct_asus_hid_pre_update_command_set_data(st, &value, sizeof(value), error))
+		return FALSE;
+	if (!fu_asus_hid_device_transfer_feature(self,
+						 st->buf,
+						 NULL,
+						 FU_ASUS_HID_REPORT_ID_INFO,
+						 error))
+		return FALSE;
+	fu_device_sleep(FU_DEVICE(self), FU_ASUS_HID_DEVICE_PRE_UPDATE_DELAY);
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_asus_hid_device_read_info(FuAsusHidDevice *self, FuAsusHidCommand cmd, GError **error)
+{
+	g_autoptr(FuStructAsusHidPreUpdateCommand) st = fu_struct_asus_hid_pre_update_command_new();
+	g_autoptr(FuStructAsusHidResult) st_result = fu_struct_asus_hid_result_new();
+
+	fu_struct_asus_hid_pre_update_command_set_cmd(st, cmd);
+	fu_struct_asus_hid_pre_update_command_set_length(st, FU_STRUCT_ASUS_HID_RESULT_SIZE);
+	return fu_asus_hid_device_transfer_feature(self,
+						   st->buf,
+						   st_result->buf,
+						   FU_ASUS_HID_REPORT_ID_INFO,
+						   error);
 }
 
 static void
@@ -163,88 +251,46 @@ fu_asus_hid_device_detach(FuDevice *device, FuProgress *progress, GError **error
 {
 	FuAsusHidDevice *self = FU_ASUS_HID_DEVICE(device);
 	g_autoptr(FuStructAsusHidPreUpdateCommand) st = fu_struct_asus_hid_pre_update_command_new();
-	g_autoptr(FuStructAsusHidResult) st_result = fu_struct_asus_hid_result_new();
-	guint32 previous_result;
 
 	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER))
 		return TRUE;
 
-	fu_struct_asus_hid_pre_update_command_set_cmd(st, FU_ASUS_HID_COMMAND_PRE_UPDATE);
-	fu_struct_asus_hid_pre_update_command_set_length(st, FU_STRUCT_ASUS_HID_RESULT_SIZE);
-	if (!fu_asus_hid_device_transfer_feature(self,
-						 st->buf,
-						 st_result->buf,
-						 FU_ASUS_HID_REPORT_ID_INFO,
-						 error))
+	/* everything below is ignored until the MCU has echoed this back */
+	if (!fu_device_retry_full(device,
+				  fu_asus_hid_device_ensure_manufacturer_cb,
+				  FU_ASUS_HID_DEVICE_RETRIES,
+				  FU_ASUS_HID_DEVICE_PRE_UPDATE_DELAY,
+				  NULL,
+				  error))
 		return FALSE;
 
-	/* TODO save some bits from result here for data for next command */
-	fu_struct_asus_hid_pre_update_command_set_cmd(st, FU_ASUS_HID_COMMAND_PRE_UPDATE2);
-	fu_struct_asus_hid_pre_update_command_set_length(st, 1);
-	if (!fu_asus_hid_device_transfer_feature(self,
-						 st->buf,
-						 st_result->buf,
-						 FU_ASUS_HID_REPORT_ID_INFO,
-						 error))
+	/* the vendor tool reads these back before starting, and the MCU stays in
+	 * runtime mode if they are skipped */
+	if (!fu_asus_hid_device_read_info(self, FU_ASUS_HID_COMMAND_FW_VERSION, error))
+		return FALSE;
+	if (!fu_asus_hid_device_read_info(self, FU_ASUS_HID_COMMAND_GET_FW_CONFIG, error))
+		return FALSE;
+	if (!fu_asus_hid_device_read_info(self, FU_ASUS_HID_COMMAND_PRE_UPDATE, error))
 		return FALSE;
 
-	/* TODO save some bits from result here for data for next command */
-	previous_result = 0x1;
-	fu_struct_asus_hid_pre_update_command_set_cmd(st, FU_ASUS_HID_COMMAND_PRE_UPDATE3);
-	fu_struct_asus_hid_pre_update_command_set_length(st, 1);
-	if (!fu_struct_asus_hid_pre_update_command_set_data(st,
-							    (guint8 *)&previous_result,
-							    sizeof(previous_result),
-							    error))
+	if (!fu_asus_hid_device_pre_update_pair(self,
+						FU_ASUS_HID_COMMAND_PRE_UPDATE2,
+						FU_ASUS_HID_COMMAND_PRE_UPDATE3,
+						0x0F,
+						error))
 		return FALSE;
-	if (!fu_asus_hid_device_transfer_feature(self,
-						 st->buf,
-						 NULL,
-						 FU_ASUS_HID_REPORT_ID_INFO,
-						 error))
+	if (!fu_asus_hid_device_pre_update_pair(self,
+						FU_ASUS_HID_COMMAND_PRE_UPDATE4,
+						FU_ASUS_HID_COMMAND_PRE_UPDATE5,
+						0x02,
+						error))
 		return FALSE;
 
-	previous_result = 0x0;
-	fu_struct_asus_hid_pre_update_command_set_cmd(st, FU_ASUS_HID_COMMAND_PRE_UPDATE4);
-	fu_struct_asus_hid_pre_update_command_set_length(st, FU_STRUCT_ASUS_HID_RESULT_SIZE);
-	if (!fu_struct_asus_hid_pre_update_command_set_data(st,
-							    (guint8 *)&previous_result,
-							    sizeof(previous_result),
-							    error))
-		return FALSE;
-	if (!fu_asus_hid_device_transfer_feature(self,
-						 st->buf,
-						 st_result->buf,
-						 FU_ASUS_HID_REPORT_ID_INFO,
-						 error))
-		return FALSE;
-
-	/* TODO save some bits from result here for data for next command */
-
-	previous_result = 0x2;
-	fu_struct_asus_hid_pre_update_command_set_cmd(st, FU_ASUS_HID_COMMAND_PRE_UPDATE5);
-	fu_struct_asus_hid_pre_update_command_set_length(st, 0x01);
-	if (!fu_struct_asus_hid_pre_update_command_set_data(st,
-							    (guint8 *)&previous_result,
-							    sizeof(previous_result),
-							    error))
-		return FALSE;
-	if (!fu_asus_hid_device_transfer_feature(self,
-						 st->buf,
-						 NULL,
-						 FU_ASUS_HID_REPORT_ID_INFO,
-						 error))
-		return FALSE;
-
-	/* maybe this command unlocks for flashing mode? */
-	previous_result = 0x0;
+	/* this is what actually switches to the bootloader, and it is not
+	 * acknowledged -- the device drops off the bus straight away and takes
+	 * several seconds to enumerate again with the counterpart GUID */
 	fu_struct_asus_hid_pre_update_command_set_cmd(st, FU_ASUS_HID_COMMAND_PRE_UPDATE6);
 	fu_struct_asus_hid_pre_update_command_set_length(st, 0x0);
-	if (!fu_struct_asus_hid_pre_update_command_set_data(st,
-							    (guint8 *)&previous_result,
-							    sizeof(previous_result),
-							    error))
-		return FALSE;
 	if (!fu_asus_hid_device_transfer_feature(self,
 						 st->buf,
 						 NULL,

--- a/plugins/asus-hid/fu-asus-hid-device.c
+++ b/plugins/asus-hid/fu-asus-hid-device.c
@@ -262,6 +262,8 @@ fu_asus_hid_device_setup(FuDevice *device, GError **error)
 static gboolean
 fu_asus_hid_device_reload(FuDevice *device, GError **error)
 {
+	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER))
+		return TRUE;
 	return fu_asus_hid_device_ensure_version(FU_ASUS_HID_DEVICE(device), error);
 }
 
@@ -502,6 +504,15 @@ fu_asus_hid_device_write_firmware(FuDevice *device,
 			    FWUPD_ERROR_INVALID_FILE,
 			    "payload of 0x%x bytes is not a multiple of the 0x%x block size",
 			    (guint)bufsz,
+			    (guint)FU_ASUS_HID_DEVICE_BLOCK_SIZE);
+		return FALSE;
+	}
+	if (address % FU_ASUS_HID_DEVICE_BLOCK_SIZE != 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_FILE,
+			    "payload address 0x%x is not aligned to the 0x%x block size",
+			    address,
 			    (guint)FU_ASUS_HID_DEVICE_BLOCK_SIZE);
 		return FALSE;
 	}

--- a/plugins/asus-hid/fu-asus-hid-firmware.c
+++ b/plugins/asus-hid/fu-asus-hid-firmware.c
@@ -9,7 +9,8 @@
 #include "fu-asus-hid-firmware.h"
 #include "fu-asus-hid-struct.h"
 
-#define FGA_OFFSET 0x2010
+#define FGA_OFFSET     0x2010
+#define TRAILER_OFFSET 0x400 /* from the end */
 
 struct _FuAsusHidFirmware {
 	FuFirmware parent_instance;
@@ -37,7 +38,11 @@ fu_asus_hid_firmware_parse(FuFirmware *firmware,
 			   GError **error)
 {
 	FuAsusHidFirmware *self = FU_ASUS_HID_FIRMWARE(firmware);
+	gsize streamsz = 0;
+	guint32 region_end;
+	guint32 region_start;
 	g_autoptr(FuStructAsusHidDesc) st = NULL;
+	g_autoptr(FuStructAsusHidTrailer) st_trailer = NULL;
 	g_autoptr(FuFirmware) img_payload = fu_firmware_new();
 	g_autoptr(FuInputStream) stream_payload = NULL;
 
@@ -48,11 +53,44 @@ fu_asus_hid_firmware_parse(FuFirmware *firmware,
 	self->product = fu_struct_asus_hid_desc_get_product(st);
 	self->version = fu_struct_asus_hid_desc_get_version(st);
 
-	stream_payload = fu_partial_input_stream_new(stream, 0x2000, G_MAXSIZE, error);
+	/* the trailer says which part of the flash this payload may be written
+	 * to -- the rest of the image is padding, except for the recovery
+	 * bootloader region which the device already holds and which is not
+	 * shipped in the update at all */
+	if (!fu_input_stream_size(stream, &streamsz, error))
+		return FALSE;
+	if (streamsz < TRAILER_OFFSET) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_FILE,
+			    "image is 0x%x bytes, too small to hold a trailer",
+			    (guint)streamsz);
+		return FALSE;
+	}
+	st_trailer =
+	    fu_struct_asus_hid_trailer_parse_stream(stream, streamsz - TRAILER_OFFSET, error);
+	if (st_trailer == NULL)
+		return FALSE;
+	region_start = fu_struct_asus_hid_trailer_get_region1_start(st_trailer);
+	region_end = fu_struct_asus_hid_trailer_get_region1_end(st_trailer);
+	if (region_start >= region_end || region_end >= streamsz) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_FILE,
+			    "trailer region 0x%x..0x%x is not within the 0x%x byte image",
+			    region_start,
+			    region_end,
+			    (guint)streamsz);
+		return FALSE;
+	}
+
+	stream_payload =
+	    fu_partial_input_stream_new(stream, region_start, region_end - region_start + 1, error);
 	if (stream_payload == NULL)
 		return FALSE;
 	if (!fu_firmware_parse_stream(img_payload, stream_payload, 0x0, flags, error))
 		return FALSE;
+	fu_firmware_set_addr(img_payload, region_start);
 	fu_firmware_set_id(img_payload, FU_FIRMWARE_ID_PAYLOAD);
 	return fu_firmware_add_image(firmware, img_payload, error);
 }

--- a/plugins/asus-hid/fu-asus-hid.rs
+++ b/plugins/asus-hid/fu-asus-hid.rs
@@ -57,7 +57,7 @@ struct FuStructAsusHidCommand {
     length: u8,
 }
 
-#[derive(Default, New)]
+#[derive(Default, New, Getters)]
 #[repr(C, packed)]
 struct FuStructAsusHidResult {
     report_id: FuAsusHidReportId == Info,

--- a/plugins/asus-hid/fu-asus-hid.rs
+++ b/plugins/asus-hid/fu-asus-hid.rs
@@ -111,3 +111,58 @@ struct FuStructAsusReadFlashCommand {
     datasz: u8,
     data: [u8; 58],
 }
+
+// erases whole 1kB blocks, so `blocks` is a count and not a length in bytes
+#[derive(Default, New)]
+#[repr(C, packed)]
+struct FuStructAsusEraseFlashCommand {
+    report_id: FuAsusHidReportId == Flashing,
+    command: u8 == 0xc2,
+    offset: u24le,
+    blocks: u16le,
+    reserved: [u8; 57],
+}
+
+#[derive(Default, New)]
+#[repr(C, packed)]
+struct FuStructAsusFlashBlockStart {
+    report_id: FuAsusHidReportId == Flashing,
+    command: u8 == 0xc0,
+    reserved: [u8; 62],
+}
+
+// `offset` is relative to the start of the 1kB block being filled
+#[derive(Default, New)]
+#[repr(C, packed)]
+struct FuStructAsusWriteFlashCommand {
+    report_id: FuAsusHidReportId == Flashing,
+    command: u8 == 0xc1,
+    offset: u16le,
+    datasz: u8,
+    data: [u8; 59],
+}
+
+#[derive(Default, New)]
+#[repr(C, packed)]
+struct FuStructAsusCommitFlashCommand {
+    report_id: FuAsusHidReportId == Flashing,
+    command: u8 == 0xc3,
+    offset: u24le,
+    datasz: u16le,
+    reserved: [u8; 57],
+}
+
+// the last 1kB block of the image describes which parts of the flash the
+// payload is allowed to touch -- notably it does not cover the recovery
+// bootloader that sits between the two regions
+#[derive(Getters, ParseStream)]
+#[repr(C, packed)]
+struct FuStructAsusHidTrailer {
+    reserved: [u8; 4],
+    region1_end: u32le,
+    region1_start: u32le,
+    reserved: [u8; 4],
+    region2_end: u32le,
+    region2_start: u32le,
+    device_id: u32le,
+}

--- a/plugins/asus-hid/fu-asus-hid.rs
+++ b/plugins/asus-hid/fu-asus-hid.rs
@@ -97,6 +97,7 @@ struct FuStructAsusHidPreUpdateCommand {
 #[derive(Default, New)]
 #[repr(C, packed)]
 struct FuStructAsusFlashReset {
+    report_id: FuAsusHidReportId == Flashing,
     command: u8 == 0xc4,
     reserved: [u8; 62],
 }
@@ -104,6 +105,7 @@ struct FuStructAsusFlashReset {
 #[derive(Default, New, Getters)]
 #[repr(C, packed)]
 struct FuStructAsusReadFlashCommand {
+    report_id: FuAsusHidReportId == Flashing,
     command: u8 == 0xd1,
     offset: u24le,
     datasz: u8,

--- a/plugins/asus-hid/fu-asus-hid.rs
+++ b/plugins/asus-hid/fu-asus-hid.rs
@@ -38,7 +38,7 @@ enum FuAsusHidReportId {
 #[repr(C, packed)]
 struct FuStructAsusManCommand {
     report_id: FuAsusHidReportId == Info,
-    data: [char; 14] == "ASUSTech.Inc.", // FIXME: Was this supposed to be "ASUS Tech.Inc."?
+    data: [char; 14] == "ASUS Tech.Inc.",
     terminator: u8 == 0,
 }
 

--- a/plugins/asus-hid/tests/asus-hid-setup.json
+++ b/plugins/asus-hid/tests/asus-hid-setup.json
@@ -165,12 +165,20 @@
           "DataOut": "WtEBAQEA"
         },
         {
-          "Id": "Ioctl:Request=0xc0104806,Data=WkFTVVNUZWNoLkluYy4AAA==,Length=0x10",
-          "DataOut": "WkFTVVNUZWNoLkluYy4AAA=="
+          "Id": "Ioctl:Request=0xc0064806,Data=WgUDMQAg,Length=0x6",
+          "DataOut": "WgUDMQAg"
         },
         {
           "Id": "Ioctl:Request=0xc0204807,Data=WgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=,Length=0x20",
-          "DataOut": "WkFTVVNUZWNoLkluYy4AAFJDNzFMTS4zMTkAAgAYAAA="
+          "DataOut": "WgUDMQAaE0ZHQTgwMTAwLlJDNzFMUy4zMTkAAgAYAAA="
+        },
+        {
+          "Id": "Ioctl:Request=0xc0104806,Data=WkFTVVMgVGVjaC5JbmMuAA==,Length=0x10",
+          "DataOut": "WkFTVVMgVGVjaC5JbmMuAA=="
+        },
+        {
+          "Id": "Ioctl:Request=0xc0204807,Data=WgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=,Length=0x20",
+          "DataOut": "WkFTVVMgVGVjaC5JbmMuAFJDNzFMTS4zMTkAAgAYAAA="
         },
         {
           "Id": "Ioctl:Request=0xc0064806,Data=WgUDMQAg,Length=0x6",
@@ -181,12 +189,12 @@
           "DataOut": "WgUDMQAaE0ZHQTgwMTAwLlJDNzFMUy4zMTkAAgAYAAA="
         },
         {
-          "Id": "Ioctl:Request=0xc0104806,Data=WkFTVVNUZWNoLkluYy4AAA==,Length=0x10",
-          "DataOut": "WkFTVVNUZWNoLkluYy4AAA=="
+          "Id": "Ioctl:Request=0xc0104806,Data=WkFTVVMgVGVjaC5JbmMuAA==,Length=0x10",
+          "DataOut": "WkFTVVMgVGVjaC5JbmMuAA=="
         },
         {
           "Id": "Ioctl:Request=0xc0204807,Data=WgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=,Length=0x20",
-          "DataOut": "WkFTVVNUZWNoLkluYy4AAFJDNzFMUy4zMTkAAgAYAAA="
+          "DataOut": "WkFTVVMgVGVjaC5JbmMuAFJDNzFMUy4zMTkAAgAYAAA="
         },
         {
           "Id": "Ioctl:Request=0xc0064806,Data=WgUEMQAg,Length=0x6",


### PR DESCRIPTION
Addresses #10746, and follows up on the gate set in #7782:

> Until this has been validated end to end either on real hardware or on emulation the plugin should not be allowed to issue upgrades.

The write path is now implemented and has been validated end to end on real
hardware: a ROG Xbox Ally X (`RC73XA`, `0B05:1B4C`, one MCU) was flashed from
`fwupdtool install-blob` with the vendor `FGA80100.RC73XA.325` image. The flash
was then read back over `0xD1` and compares byte for byte with the vendor image
over the whole declared region, and the device reports the expected version
afterwards.

## The series

The first four commits are fixes to things that were never exercised because
nothing ever detached the device:

* the flashing structs were missing their report ID, so the command byte was
  being used as one, and `0xd1` replies were parsed one byte off
* the manufacturer string really is `ASUS Tech.Inc.` with a space, which is what
  the 14 character field width was already sized for
* the pre-update queries return a byte that has to be masked and echoed back,
  which answers the two `TODO`s in `detach()`; sending a constant leaves the part
  in runtime mode
* `PRE_UPDATE6` is what actually switches, it is never acknowledged, and the
  device drops off the bus for about eight seconds

Then the write path itself, the bootloader instance ID, replug matching across
the mode switch, and the documentation.

## Two things worth flagging for review

**The recovery bootloader is not in the update image.** The part carries about
4.9kB at `0x1E000` that reads `0xFF` in the vendor image: an `ITE8297-BBK`
recovery loader sitting in the gap between the two regions the trailer declares.
The vendor's own write loop skips those blocks unconditionally. An
implementation that diffs image against chip and writes the differences would
erase it, so the payload is now bounded by the trailer rather than running to
the end of the file.

**The part is the update target, not the individual microcontrollers.** The
vendor tool closes its handle, reopens the part in bootloader mode and flashes
it in one go, keeping track of which microcontroller it is dealing with in its
own state rather than asking the hardware. Marking a child updatable instead
means fwupd has to follow it across a switch where it changes GUID with nothing
tying the two together, and the install fails looking for a device ID that no
longer exists.

## Not covered

I only have a one-MCU `RC73XA`. The two-MCU path (`0B05:1ABE`, counterpart
`048D:89DB`) is untouched but unverified, and I cannot test whether flashing the
part as a whole covers both microcontrollers there.

The `Since:` version in the README is a guess, please correct it.

I would be glad to record emulation data for this device so the write path can
be exercised in CI without hardware, which seemed to be the preferred route in
#7782. Just say which capture you want.

## Testing

```
fwupdtool install-blob FGA80100.RC73XA.325.bin <device> --plugins asus_hid
```

runs through detach, erase, write and attach without intervention, and the
device comes back reporting `325`. Read-back after the update matches the vendor
image exactly over `0x2000-0x1DFFF`, and the boot area, the recovery bootloader,
the manifest and the trailer are all unchanged.

Every commit builds on its own.
