### PR TITLE
trivial: Verify the extracted path in case the firmware allows path t…

### DIFF
--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -3406,6 +3406,8 @@ fu_util_firmware_extract_image(FuUtil *self,
 	} else {
 		fn = g_strdup_printf("img-%s.fw", idxstr);
 	}
+	if (!fu_path_verify_safe(fn, error))
+		return FALSE;
 
 	/* TRANSLATORS: decompressing images from a container firmware */
 	fu_console_print(self->console, "%s : %s", _("Writing file:"), fn);


### PR DESCRIPTION
…raversal

Note, this has also been done parsing-side for cab and zip formats in ca06d90cdd3d741022f2a5804d171a0ed244bcd0, but the check is also included here for other future formats -- and to quieten the security scanners.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
