### PR TITLE
logitech-hidpp: implement prepare_firmware() for Texas bootloader

### DIFF
--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-nordic.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-nordic.c
@@ -285,6 +285,19 @@ fu_logitech_hidpp_bootloader_nordic_write_pkts(FuLogitechHidppBootloader *self,
 	return TRUE;
 }
 
+static FuFirmware *
+fu_logitech_hidpp_bootloader_nordic_prepare_firmware(FuDevice *device,
+						     FuInputStream *stream,
+						     FuProgress *progress,
+						     FuFirmwareParseFlags flags,
+						     GError **error)
+{
+	g_autoptr(FuFirmware) firmware = fu_ihex_firmware_new();
+	if (!fu_firmware_tokenize(firmware, stream, flags, error))
+		return NULL;
+	return g_steal_pointer(&firmware);
+}
+
 static gboolean
 fu_logitech_hidpp_bootloader_nordic_write_firmware(FuDevice *device,
 						   FuFirmware *firmware,
@@ -364,6 +377,7 @@ fu_logitech_hidpp_bootloader_nordic_class_init(FuLogitechHidppBootloaderNordicCl
 {
 	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	device_class->write_firmware = fu_logitech_hidpp_bootloader_nordic_write_firmware;
+	device_class->prepare_firmware = fu_logitech_hidpp_bootloader_nordic_prepare_firmware;
 	device_class->setup = fu_logitech_hidpp_bootloader_nordic_setup;
 }
 

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-texas.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-texas.c
@@ -216,6 +216,19 @@ fu_logitech_hidpp_bootloader_texas_write_pkts(FuLogitechHidppBootloader *self,
 	return TRUE;
 }
 
+static FuFirmware *
+fu_logitech_hidpp_bootloader_texas_prepare_firmware(FuDevice *device,
+						    FuInputStream *stream,
+						    FuProgress *progress,
+						    FuFirmwareParseFlags flags,
+						    GError **error)
+{
+	g_autoptr(FuFirmware) firmware = fu_ihex_firmware_new();
+	if (!fu_firmware_tokenize(firmware, stream, flags, error))
+		return NULL;
+	return g_steal_pointer(&firmware);
+}
+
 static gboolean
 fu_logitech_hidpp_bootloader_texas_write_firmware(FuDevice *device,
 						  FuFirmware *firmware,
@@ -289,6 +302,7 @@ fu_logitech_hidpp_bootloader_texas_class_init(FuLogitechHidppBootloaderTexasClas
 {
 	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	device_class->write_firmware = fu_logitech_hidpp_bootloader_texas_write_firmware;
+	device_class->prepare_firmware = fu_logitech_hidpp_bootloader_texas_prepare_firmware;
 	device_class->setup = fu_logitech_hidpp_bootloader_texas_setup;
 }
 


### PR DESCRIPTION
## Summary

Implement `prepare_firmware()` for the Texas HID++ bootloader plugin.

The bootloader expects Intel HEX records during firmware update, but it did not
override `prepare_firmware()`.

Without this override, the firmware remains a generic `FuFirmware`
instead of `FuIhexFirmware`, so the Texas bootloader does not receive
the parsed Intel HEX records it expects.

This patch creates a `FuIhexFirmware`, tokenizes the input stream, and returns
it to the update path, matching the runtime plugin behaviour.

## Testing

Tested on a Logitech Unifying Receiver that entered Texas bootloader mode
(USB VID:PID 046d:aaac).

Before this change:

- firmware update could not complete successfully
- the Texas bootloader received a generic `FuFirmware` instead of parsed Intel HEX records

After this change:

- firmware update completed successfully
- receiver rebooted into runtime mode
- firmware was successfully updated to `RQR24.11_B0036`