### PR TITLE
Make systemd-pcrlock plugin conditional on libsystemd >= 258

### DIFF
--- a/plugins/systemd-pcrlock/meson.build
+++ b/plugins/systemd-pcrlock/meson.build
@@ -1,5 +1,6 @@
 host_machine.system() == 'linux' or subdir_done()
 libsystemd.found() or subdir_done()
+libsystemd.version().version_compare('>= 258') or subdir_done()
 cc.has_header('systemd/sd-varlink.h', dependencies: libsystemd) or subdir_done()
 
 cargs = ['-DG_LOG_DOMAIN="FuPluginSystemdPcrlock"']


### PR DESCRIPTION
The varlink APIs were added in v258 released in 2025/09, add a meson version check and disable the plugin if the local libsystemd is older.

Follow-up for 57b4cf5c4f08844dd8b4885a48f974b8e2bfa6bc

Fixes https://github.com/fwupd/fwupd/issues/10757

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
