### PR TITLE
Bump the release version to be 2.2.1

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,7 +17,7 @@ Write release entries:
 Commit changes to git:
 
     # MAKE SURE THIS IS CORRECT
-    export release_ver="2.1.8"
+    export release_ver="2.2.1"
     ninja fwupd-pot
     git commit -a -m "Release fwupd ${release_ver}" --no-verify
     git tag -s -f -m "Release fwupd ${release_ver}" "${release_ver}"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,16 +5,17 @@ If you have any concerns please [let us know](https://github.com/fwupd/fwupd/sec
 
 ## Supported Versions
 
-The `main` and `2_0_X` branches are fully supported by the upstream authors and releases are
+The `main` and `2_1_X` branches are fully supported by the upstream authors and releases are
 tagged approximately monthly.
 
-Additionally, the `1_9_X` branch is supported just for security fixes, although no further releases
-will be tagged.
+Additionally, the `2_0_X` and `1_9_X` branches are supported just for security fixes, although it
+is unlikely further releases will be tagged.
 
 | Version | Supported          | EOL        |
 | ------- | ------------------ | ---------- |
+| 2.2.x   | :heavy_check_mark: | 2029-01-01 |
 | 2.1.x   | :heavy_check_mark: | 2029-01-01 |
-| 2.0.x   | :heavy_check_mark: | 2028-01-01 |
+| 2.0.x   | :white_check_mark: | 2028-01-01 |
 | 1.9.x   | :white_check_mark: | 2027-01-01 |
 | 1.8.x   | :x:                | 2026-01-01 |
 | 1.7.x   | :x:                | 2024-06-01 |

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'fwupd',
   'c',
-  version: '2.1.8',
+  version: '2.2.1',
   license: 'LGPL-2.1-or-later',
   meson_version: '>=1.11.0',
   default_options: ['warning_level=2', 'c_std=c17'],


### PR DESCRIPTION
This means we can branch and tag just before the previous commit if the meson or rustc deps are problematic.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
