### PR TITLE
Add rust to our CI images

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -41,6 +41,7 @@ jobs:
           persist-credentials: false
       - name: ensure up-to-date dependencies are installed
         run: |-
+          apt-get update -qq
           ./contrib/ci/fwupd_setup_helpers.py install-dependencies -o debian --yes
       - name: configure
         run: |-

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -910,6 +910,34 @@
       <package variant="amd64" />
     </distro>
   </dependency>
+  <dependency id="rustc">
+    <distro id="arch">
+      <package variant="x86_64">rust</package>
+    </distro>
+    <distro id="centos">
+      <package variant="x86_64" />
+    </distro>
+    <distro id="debian">
+      <package />
+    </distro>
+    <distro id="fedora">
+      <package variant="x86_64" />
+      <package variant="aarch64" />
+      <package variant="mingw64" />
+    </distro>
+    <distro id="freebsd">
+      <package variant="amd64">rust</package>
+    </distro>
+    <distro id="ubuntu">
+      <package variant="x86_64" />
+      <package variant="aarch64" />
+    </distro>
+  </dependency>
+  <dependency id="rust-std-static-x86_64-pc-windows-gnu">
+    <distro id="fedora">
+      <package variant="mingw64" />
+    </distro>
+  </dependency>
   <dependency id="mingw-w64-tools">
     <distro id="centos">
       <package variant="x86_64" />

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -918,6 +918,7 @@
       <package variant="x86_64" />
     </distro>
     <distro id="debian">
+      <native />
       <package />
     </distro>
     <distro id="fedora">
@@ -931,6 +932,12 @@
     <distro id="ubuntu">
       <package variant="x86_64" />
       <package variant="aarch64" />
+    </distro>
+  </dependency>
+  <dependency id="libstd-rust-dev">
+    <distro id="debian">
+      <multi-arch />
+      <package />
     </distro>
   </dependency>
   <dependency id="rust-std-static-x86_64-pc-windows-gnu">

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -10,6 +10,9 @@ ifeq ($(DEB_HOST_ARCH_BITS),32)
 	export DEB_CFLAGS_MAINT_APPEND = -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
 endif
 
+DEB_BUILD_ARCH ?= $(shell dpkg-architecture -qDEB_BUILD_ARCH)
+DEB_HOST_ARCH  ?= $(shell dpkg-architecture -qDEB_HOST_ARCH)
+
 CONFARGS =
 
 ifneq ($(CI),)
@@ -20,6 +23,19 @@ endif
 
 ifneq ($(DEB_BUILD_ARCH),$(DEB_HOST_ARCH))
 	CONFARGS += -Dtests=false
+	CONFARGS += --cross-file=$(CURDIR)/debian/rust-cross.ini
+
+	# Map Debian host architectures to Rust target triples.
+	DEBIAN_RUST_TARGET_amd64     := x86_64-unknown-linux-gnu
+	DEBIAN_RUST_TARGET_arm64     := aarch64-unknown-linux-gnu
+	DEBIAN_RUST_TARGET_armhf     := arm-unknown-linux-gnueabihf
+	DEBIAN_RUST_TARGET_i386      := i686-unknown-linux-gnu
+	DEBIAN_RUST_TARGET_riscv64   := riscv64gc-unknown-linux-gnu
+	DEBIAN_RUST_TARGET_s390x     := s390x-unknown-linux-gnu
+	RUST_TARGET := $(DEBIAN_RUST_TARGET_$(DEB_HOST_ARCH))
+ifeq ($(strip $(RUST_TARGET)),)
+$(error Unable to determine Rust target triple for host arch '$(DEB_HOST_ARCH)')
+endif
 endif
 
 ifneq ($(QUBES_OPTION),)
@@ -47,6 +63,10 @@ override_dh_auto_clean:
 	rm -fr debian/build
 
 override_dh_auto_configure:
+ifneq ($(DEB_BUILD_ARCH),$(DEB_HOST_ARCH))
+	printf '[binaries]\nrust = ['\''rustc'\'', '\''--target'\'', '\''$(RUST_TARGET)'\'']\n' \
+		>$(CURDIR)/debian/rust-cross.ini
+endif
 	dh_auto_configure -- $(CONFARGS)
 
 override_dh_install:


### PR DESCRIPTION
Splitting this up to get the container build before we rely on it - this adds rustc to the containers. The second patch (cross compilation) was created by claude, it *looks* correct but this is completely outside anything I've ever done.


Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
