### PR TITLE
ci: run apt-get update before trying to install dependencies

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -41,6 +41,7 @@ jobs:
           persist-credentials: false
       - name: ensure up-to-date dependencies are installed
         run: |-
+          apt-get update -qq
           ./contrib/ci/fwupd_setup_helpers.py install-dependencies -o debian --yes
       - name: configure
         run: |-


### PR DESCRIPTION
Otherwise install-dependencies may complain about unknown packages, especially as the time between image generation and this CI run increases.

Arguably this should be done as part of fwupd_setup_helpers.py but for now this gets us past the immediate issues.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
