### PR TITLE
ci: Suppress asyncio DeprecationWarning

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -47,12 +47,14 @@ jobs:
         env:
           CI_NETWORK: true
           VERSION: ${{ needs.library.outputs.version }}
+          PYTHONWARNINGS: "ignore::DeprecationWarning:gi.events"
         run: |
           docker run --privileged -t \
               -e "CI=$CI" \
               -e "CI_NETWORK=$CI_NETWORK" \
               -e "VARIANT=$VARIANT" \
               -e "VERSION=$VERSION" \
+              -e "PYTHONWARNINGS=$PYTHONWARNINGS" \
               -v "$GITHUB_WORKSPACE:/github/workspace" \
               "ghcr.io/fwupd/fwupd/fwupd-${{ matrix.env.CONTAINER || join(matrix.env.*, '-') }}:latest" \
               "./contrib/ci/$DISTRO${VARIANT:+-$VARIANT}.sh"
@@ -77,12 +79,14 @@ jobs:
         if: steps.supported.outputs.supported == 'true'
         env:
           CI_NETWORK: true
+          PYTHONWARNINGS: "ignore::DeprecationWarning:gi.events"
         run: |
           docker run --privileged -t \
               -e "CI=$CI" \
               -e "CI_NETWORK=$CI_NETWORK" \
               -e "VARIANT=$VARIANT" \
               -e "VERSION=$VERSION" \
+              -e "PYTHONWARNINGS=$PYTHONWARNINGS" \
               -v "$GITHUB_WORKSPACE:/github/workspace" \
               "ghcr.io/fwupd/fwupd/fwupd-${{ matrix.env.CONTAINER || join(matrix.env.*, '-') }}:latest" \
               "./contrib/ci/$DISTRO${VARIANT:+-$VARIANT}-test.sh"
@@ -103,6 +107,8 @@ jobs:
 
   library:
     runs-on: ubuntu-latest
+    env:
+      PYTHONWARNINGS: "ignore::DeprecationWarning:gi.events"
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:

--- a/.github/workflows/openbmc.yml
+++ b/.github/workflows/openbmc.yml
@@ -6,6 +6,9 @@ on: workflow_call
 permissions:
   contents: read
 
+env:
+  PYTHONWARNINGS: "ignore::DeprecationWarning:gi.events"
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -3,6 +3,9 @@ on: workflow_call
 permissions:
   contents: read
 
+env:
+  PYTHONWARNINGS: "ignore::DeprecationWarning:gi.events"
+
 jobs:
   clang-tidy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
PyGObject's gi.events module calls asyncio.get_event_loop_policy() which is deprecated since Python 3.14. This produces a stream of
```
        /usr/lib/python3/dist-packages/gi/events.py:890:
        DeprecationWarning: 'asyncio.get_event_loop_policy' is deprecated
        and slated for removal in Python 3.16
```
There's nothing we can do in fwupd about that warning except wait for an updated PyGObject to fix it. So let's supress it so our CI logs become readable again.

Fixes: #10773

Assisted-by: Claude:claude-opus-4-6

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
