### PR TITLE
ci: add merge_group as CI trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  merge_group:
+    branches: [main]
   push:
     branches: [main]
 


### PR DESCRIPTION
See the github documentation, this is required to check that the MR passes CI after it has been added to a merge queue.

https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#merge_group

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
