### PR TITLE
Add fu_context_timeout_add_seconds() that uses the GMainContext for idle

### DIFF
--- a/libfwupdplugin/fu-context.c
+++ b/libfwupdplugin/fu-context.c
@@ -319,6 +319,62 @@ fu_context_get_main_context(FuContext *self)
 }
 
 /**
+ * fu_context_add_timeout_seconds:
+ * @self: a #FuContext
+ * @interval: timeout interval in seconds
+ * @function: (scope call): function to call
+ * @data: data to pass to @function
+ *
+ * Creates a new timeout source and attaches it to the main context.
+ *
+ * Returns: (transfer full): the #GSource, which must be removed with g_source_unref()
+ *
+ * Since: 2.1.8
+ **/
+GSource *
+fu_context_add_timeout_seconds(FuContext *self, guint interval, GSourceFunc function, gpointer data)
+{
+	FuContextPrivate *priv = GET_PRIVATE(self);
+	g_autoptr(GSource) source = g_timeout_source_new_seconds(interval);
+
+	g_return_val_if_fail(FU_IS_CONTEXT(self), NULL);
+	g_return_val_if_fail(interval != 0, NULL);
+	g_return_val_if_fail(function != NULL, NULL);
+
+	g_source_set_callback(source, function, data, NULL);
+	g_source_attach(source, priv->main_ctx);
+	return g_steal_pointer(&source);
+}
+
+/**
+ * fu_context_add_timeout:
+ * @self: a #FuContext
+ * @interval_ms: timeout interval in ms
+ * @function: (scope call): function to call
+ * @data: data to pass to @function
+ *
+ * Creates a new timeout source and attaches it to the main context.
+ *
+ * Returns: (transfer full): the #GSource, which must be removed with g_source_unref()
+ *
+ * Since: 2.1.8
+ **/
+GSource *
+fu_context_add_timeout(FuContext *self, guint interval_ms, GSourceFunc function, gpointer data)
+{
+	FuContextPrivate *priv = GET_PRIVATE(self);
+	g_autoptr(GSource) source = g_timeout_source_new(interval_ms);
+
+	g_return_val_if_fail(FU_IS_CONTEXT(self), NULL);
+	g_return_val_if_fail(interval_ms != 0, NULL);
+	g_return_val_if_fail(function != NULL, NULL);
+
+	g_source_set_callback(source, function, data, NULL);
+	g_source_attach(source, priv->main_ctx);
+	return g_steal_pointer(&source);
+}
+
+/**
  * fu_context_set_main_context:
  * @self: a #FuContext
  * @main_ctx: (nullable): a #GMainContext

--- a/libfwupdplugin/fu-context.h
+++ b/libfwupdplugin/fu-context.h
@@ -160,6 +160,13 @@ gboolean
 fu_context_efivars_check_free_space(FuContext *self, gsize count, GError **error)
     G_GNUC_NON_NULL(1);
 
+GSource *
+fu_context_add_timeout(FuContext *self, guint interval_ms, GSourceFunc function, gpointer data)
+    G_GNUC_NON_NULL(1, 3);
+GSource *
+fu_context_add_timeout_seconds(FuContext *self, guint interval, GSourceFunc function, gpointer data)
+    G_GNUC_NON_NULL(1, 3);
+
 GPtrArray *
 fu_context_get_esp_files(FuContext *self, FuContextEspFileFlags flags, GError **error)
     G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -24,6 +24,7 @@
 #include "fu-input-stream.h"
 #include "fu-memory-input-stream.h"
 #include "fu-output-stream.h"
+#include "fu-progress-private.h"
 #include "fu-quirks.h"
 #include "fu-security-attr.h"
 #include "fu-string.h"
@@ -78,10 +79,11 @@ typedef struct {
 	guint event_idx;
 	guint remove_delay;    /* ms */
 	guint acquiesce_delay; /* ms */
+	guint poll_interval;   /* ms */
 	guint request_cnts[FWUPD_REQUEST_KIND_LAST];
 	gint order;
 	guint priority;
-	guint poll_id;
+	GSource *poll_source;
 	gint poll_locker_cnt;
 	gboolean done_probe;
 	gboolean done_setup;
@@ -791,6 +793,29 @@ fu_device_sleep_full(FuDevice *self, guint delay_ms, FuProgress *progress)
 }
 
 /**
+ * fu_device_sleep_idle:
+ * @self: a #FuDevice
+ * @duration_ms: duration in milliseconds
+ * @progress: a #FuProgress
+ *
+ * Sleeps, setting the device progress from 0..100% as time continues.
+ *
+ * Since: 2.1.8
+ **/
+void
+fu_device_sleep_idle(FuDevice *self, guint duration_ms, FuProgress *progress)
+{
+	FuDevicePrivate *priv = GET_PRIVATE(self);
+
+	g_return_if_fail(FU_IS_DEVICE(self));
+	g_return_if_fail(FU_IS_CONTEXT(priv->ctx));
+	g_return_if_fail(duration_ms < 1000000);
+	g_return_if_fail(FU_IS_PROGRESS(progress));
+
+	fu_progress_sleep_idle(progress, fu_context_get_main_context(priv->ctx), duration_ms);
+}
+
+/**
  * fu_device_set_contents:
  * @self: a #FuDevice
  * @filename: full path to a file
@@ -1279,10 +1304,36 @@ fu_device_poll_cb(gpointer user_data)
 
 	if (!fu_device_poll(self, &error_local)) {
 		g_warning("disabling polling: %s", error_local->message);
-		priv->poll_id = 0;
+		g_clear_pointer(&priv->poll_source, g_source_unref);
 		return G_SOURCE_REMOVE;
 	}
 	return G_SOURCE_CONTINUE;
+}
+
+static void
+fu_device_ensure_poll_interval(FuDevice *self)
+{
+	FuDevicePrivate *priv = GET_PRIVATE(self);
+
+	/* called from _init(); will call again from _constructed() */
+	if (priv->ctx == NULL)
+		return;
+
+	if (priv->poll_source != NULL) {
+		g_source_destroy(priv->poll_source);
+		g_clear_pointer(&priv->poll_source, g_source_unref);
+	}
+	if (priv->poll_interval == 0)
+		return;
+	if (priv->poll_interval % 1000 == 0) {
+		priv->poll_source = fu_context_add_timeout_seconds(priv->ctx,
+								   priv->poll_interval / 1000,
+								   fu_device_poll_cb,
+								   self);
+	} else {
+		priv->poll_source =
+		    fu_context_add_timeout(priv->ctx, priv->poll_interval, fu_device_poll_cb, self);
+	}
 }
 
 /**
@@ -1300,17 +1351,11 @@ void
 fu_device_set_poll_interval(FuDevice *self, guint interval)
 {
 	FuDevicePrivate *priv = GET_PRIVATE(self);
-
 	g_return_if_fail(FU_IS_DEVICE(self));
-
-	g_clear_handle_id(&priv->poll_id, g_source_remove);
-	if (interval == 0)
+	if (priv->poll_interval == interval)
 		return;
-	if (interval % 1000 == 0) {
-		priv->poll_id = g_timeout_add_seconds(interval / 1000, fu_device_poll_cb, self);
-	} else {
-		priv->poll_id = g_timeout_add(interval, fu_device_poll_cb, self);
-	}
+	priv->poll_interval = interval;
+	fu_device_ensure_poll_interval(self);
 }
 
 /**
@@ -5362,6 +5407,7 @@ fu_device_to_string_impl(FuDevice *self, guint idt, GString *str)
 	fwupd_codec_string_append(str, idt, "ProxyGuid", priv->proxy_guid);
 	fwupd_codec_string_append_int(str, idt, "RemoveDelay", priv->remove_delay);
 	fwupd_codec_string_append_int(str, idt, "AcquiesceDelay", priv->acquiesce_delay);
+	fwupd_codec_string_append_int(str, idt, "PollInterval", priv->poll_interval);
 	fwupd_codec_string_append(str, idt, "CustomFlags", priv->custom_flags);
 	if (priv->specialized_gtype != G_TYPE_INVALID)
 		fwupd_codec_string_append(str, idt, "GType", g_type_name(priv->specialized_gtype));
@@ -8377,6 +8423,14 @@ fu_device_from_json(FuDevice *self, FwupdJsonObject *json_obj, GError **error)
 }
 
 static void
+fu_device_constructed(GObject *obj)
+{
+	FuDevice *self = FU_DEVICE(obj);
+	fu_device_ensure_poll_interval(self);
+	G_OBJECT_CLASS(fu_device_parent_class)->constructed(obj);
+}
+
+static void
 fu_device_dispose(GObject *object)
 {
 	FuDevice *self = FU_DEVICE(object);
@@ -8457,6 +8511,7 @@ fu_device_class_init(FuDeviceClass *klass)
 	    FU_DEVICE_PRIVATE_FLAG_STRICT_EMULATION_ORDER,
 	};
 
+	object_class->constructed = fu_device_constructed;
 	object_class->dispose = fu_device_dispose;
 	object_class->finalize = fu_device_finalize;
 	object_class->get_property = fu_device_get_property;
@@ -8763,8 +8818,10 @@ fu_device_finalize(GObject *object)
 	}
 	if (priv->backend != NULL)
 		g_object_remove_weak_pointer(G_OBJECT(priv->backend), (gpointer *)&priv->backend);
-	if (priv->poll_id != 0)
-		g_source_remove(priv->poll_id);
+	if (priv->poll_source != NULL) {
+		g_source_destroy(priv->poll_source);
+		g_source_unref(priv->poll_source);
+	}
 	if (priv->metadata != NULL)
 		g_hash_table_unref(priv->metadata);
 	if (priv->inhibits != NULL)

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -1288,6 +1288,8 @@ void
 fu_device_sleep(FuDevice *self, guint delay_ms) G_GNUC_NON_NULL(1);
 void
 fu_device_sleep_full(FuDevice *self, guint delay_ms, FuProgress *progress) G_GNUC_NON_NULL(1);
+void
+fu_device_sleep_idle(FuDevice *self, guint duration_ms, FuProgress *progress) G_GNUC_NON_NULL(1);
 gboolean
 fu_device_bind_driver(FuDevice *self, const gchar *subsystem, const gchar *driver, GError **error)
     G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-progress-private.h
+++ b/libfwupdplugin/fu-progress-private.h
@@ -10,3 +10,5 @@
 
 gdouble
 fu_progress_get_global_fraction(FuProgress *self) G_GNUC_NON_NULL(1);
+void
+fu_progress_sleep_idle(FuProgress *self, GMainContext *main_ctx, guint delay_ms) G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-progress-test.c
+++ b/libfwupdplugin/fu-progress-test.c
@@ -72,7 +72,7 @@ fu_progress_idle_func(void)
 
 	g_assert_cmpfloat_with_epsilon(fu_progress_get_duration(progress), 0.f, 0.001);
 
-	fu_progress_sleep_idle(progress, 500);
+	fu_progress_sleep_idle(progress, NULL, 500);
 	g_assert_cmpint(helper.last_percentage, ==, 0);
 
 	fu_test_loop_run_with_timeout(600);

--- a/libfwupdplugin/fu-progress.c
+++ b/libfwupdplugin/fu-progress.c
@@ -76,7 +76,7 @@ struct _FuProgress {
 	guint step_done;
 	guint step_scaling;
 	FuProgress *parent; /* no-ref */
-	guint sleep_timeout_id;
+	GSource *sleep_timeout_source;
 };
 
 enum { SIGNAL_PERCENTAGE_CHANGED, SIGNAL_STATUS_CHANGED, SIGNAL_LAST };
@@ -235,9 +235,10 @@ fu_progress_remove_flag(FuProgress *self, FuProgressFlags flag)
 static void
 fu_progress_sleep_idle_stop(FuProgress *self)
 {
-	if (self->sleep_timeout_id == 0)
-		return;
-	g_clear_handle_id(&self->sleep_timeout_id, g_source_remove);
+	if (self->sleep_timeout_source != NULL) {
+		g_source_destroy(self->sleep_timeout_source);
+		g_clear_pointer(&self->sleep_timeout_source, g_source_unref);
+	}
 }
 
 /**
@@ -1007,24 +1008,30 @@ fu_progress_sleep_idle_cb(gpointer user_data)
 /**
  * fu_progress_sleep_idle:
  * @self: a #FuProgress
+ * @main_ctx: a #GMainContext
  * @delay_ms: delay in milliseconds
  *
  * Sleeps, setting the device progress from 0..100% as time continues. If the parent progress
  * percentage is changed or finalized then the idle action will be cancelled.
  *
- * Since: 2.1.2
+ * Since: 2.1.8
  **/
 void
-fu_progress_sleep_idle(FuProgress *self, guint delay_ms)
+fu_progress_sleep_idle(FuProgress *self, GMainContext *main_ctx, guint delay_ms)
 {
+	g_autoptr(GSource) source = NULL;
+
 	g_return_if_fail(FU_IS_PROGRESS(self));
 	g_return_if_fail(delay_ms > 0);
 
 	fu_progress_sleep_idle_stop(self);
 	fu_progress_set_percentage(self, 0.0);
 	fu_progress_set_duration(self, (gdouble)delay_ms / 1000.f);
-	self->sleep_timeout_id =
-	    g_timeout_add(MAX(delay_ms / 1000, 1), fu_progress_sleep_idle_cb, self);
+
+	source = g_timeout_source_new(MAX(delay_ms / 100, 1));
+	g_source_set_callback(source, fu_progress_sleep_idle_cb, self, NULL);
+	g_source_attach(source, main_ctx);
+	self->sleep_timeout_source = g_steal_pointer(&source);
 }
 
 static void
@@ -1150,8 +1157,10 @@ fu_progress_finalize(GObject *object)
 	g_ptr_array_unref(self->children);
 	g_timer_destroy(self->timer);
 	g_timer_destroy(self->timer_child);
-	if (self->sleep_timeout_id != 0)
-		g_source_remove(self->sleep_timeout_id);
+	if (self->sleep_timeout_source != NULL) {
+		g_source_destroy(self->sleep_timeout_source);
+		g_source_unref(self->sleep_timeout_source);
+	}
 
 	G_OBJECT_CLASS(fu_progress_parent_class)->finalize(object);
 }

--- a/libfwupdplugin/fu-progress.h
+++ b/libfwupdplugin/fu-progress.h
@@ -65,7 +65,5 @@ FuProgress *
 fu_progress_get_child(FuProgress *self) G_GNUC_NON_NULL(1);
 void
 fu_progress_sleep(FuProgress *self, guint delay_ms) G_GNUC_NON_NULL(1);
-void
-fu_progress_sleep_idle(FuProgress *self, guint delay_ms) G_GNUC_NON_NULL(1);
 gchar *
 fu_progress_traceback(FuProgress *self) G_GNUC_NON_NULL(1);

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-device.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-device.c
@@ -724,7 +724,7 @@ fu_ccgx_dmc_device_attach(FuDevice *device, FuProgress *progress, GError **error
 	}
 
 	/* increment the progressbar when waiting for replug */
-	fu_progress_sleep_idle(progress, fu_device_get_remove_delay(device));
+	fu_device_sleep_idle(device, fu_device_get_remove_delay(device), progress);
 
 	/* success */
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);

--- a/plugins/hughski-colorhug/fu-hughski-colorhug-device.c
+++ b/plugins/hughski-colorhug/fu-hughski-colorhug-device.c
@@ -288,7 +288,7 @@ fu_hughski_colorhug_device_detach(FuDevice *device, FuProgress *progress, GError
 	}
 
 	/* this takes some time */
-	fu_progress_sleep_idle(progress, 1000);
+	fu_device_sleep_idle(device, 1000, progress);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 	return TRUE;
 }
@@ -320,7 +320,7 @@ fu_hughski_colorhug_device_attach(FuDevice *device, FuProgress *progress, GError
 	}
 
 	/* this takes some time */
-	fu_progress_sleep_idle(progress, 1000);
+	fu_device_sleep_idle(device, 1000, progress);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 	return TRUE;
 }

--- a/plugins/usi-dock/fu-usi-dock-mcu-device.c
+++ b/plugins/usi-dock/fu-usi-dock-mcu-device.c
@@ -837,7 +837,7 @@ fu_usi_dock_mcu_device_reload(FuDevice *device, GError **error)
 static gboolean
 fu_usi_dock_mcu_device_attach(FuDevice *device, FuProgress *progress, GError **error)
 {
-	fu_progress_sleep_idle(progress, 900000);
+	fu_device_sleep_idle(device, 900000, progress);
 
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 
@@ -897,7 +897,7 @@ fu_usi_dock_mcu_device_cleanup(FuDevice *device,
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_BUSY);
 
-	fu_progress_sleep_idle(progress, 180000);
+	fu_device_sleep_idle(device, 180000, progress);
 
 	/* interactive request to start the SPI write */
 	fwupd_request_set_kind(request, FWUPD_REQUEST_KIND_IMMEDIATE);

--- a/plugins/wistron-dock/fu-wistron-dock-device.c
+++ b/plugins/wistron-dock/fu-wistron-dock-device.c
@@ -20,7 +20,7 @@ struct _FuWistronDockDevice {
 	guint8 imgmode;
 	gchar *icp_bbinfo;
 	gchar *icp_userinfo;
-	guint device_insert_id;
+	GSource *device_insert_source;
 };
 
 G_DEFINE_TYPE(FuWistronDockDevice, fu_wistron_dock_device, FU_TYPE_HID_DEVICE)
@@ -737,7 +737,7 @@ fu_wistron_dock_device_insert_cb(gpointer user_data)
 		g_warning("%s", error_local->message);
 
 	/* success */
-	self->device_insert_id = 0;
+	g_clear_pointer(&self->device_insert_source, g_source_unref);
 	return G_SOURCE_REMOVE;
 }
 
@@ -750,7 +750,10 @@ fu_wistron_dock_device_cleanup(FuDevice *device,
 	FuWistronDockDevice *self = FU_WISTRON_DOCK_DEVICE(device);
 
 	/* ensure the timeout has been cleared, even on error */
-	g_clear_handle_id(&self->device_insert_id, g_source_remove);
+	if (self->device_insert_source != NULL) {
+		g_source_destroy(self->device_insert_source);
+		g_clear_pointer(&self->device_insert_source, g_source_unref);
+	}
 	return TRUE;
 }
 
@@ -758,6 +761,7 @@ static gboolean
 fu_wistron_dock_device_attach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuWistronDockDevice *self = FU_WISTRON_DOCK_DEVICE(device);
+	FuContext *ctx = fu_device_get_context(device);
 	guint8 cmd[8] = {FU_WISTRON_DOCK_ID_IMG_CONTROL, FU_WISTRON_DOCK_CMD_DFU_EXIT};
 	g_autoptr(FwupdRequest) request = fwupd_request_new();
 
@@ -782,7 +786,8 @@ fu_wistron_dock_device_attach(FuDevice *device, FuProgress *progress, GError **e
 	/* set a timeout, which will trigger as we're waiting for the device --
 	 * no sync sleep is possible as the device will re-enumerate one more time */
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_BUSY);
-	self->device_insert_id = g_timeout_add_seconds(20, fu_wistron_dock_device_insert_cb, self);
+	self->device_insert_source =
+	    fu_context_add_timeout_seconds(ctx, 20, fu_wistron_dock_device_insert_cb, self);
 
 	/* success */
 	return TRUE;
@@ -821,8 +826,10 @@ static void
 fu_wistron_dock_device_finalize(GObject *object)
 {
 	FuWistronDockDevice *self = FU_WISTRON_DOCK_DEVICE(object);
-	if (self->device_insert_id != 0)
-		g_source_remove(self->device_insert_id);
+	if (self->device_insert_source != NULL) {
+		g_source_destroy(self->device_insert_source);
+		g_source_unref(self->device_insert_source);
+	}
 	g_free(self->icp_bbinfo);
 	g_free(self->icp_userinfo);
 	G_OBJECT_CLASS(fu_wistron_dock_device_parent_class)->finalize(object);

--- a/src/fu-bluez-backend.c
+++ b/src/fu-bluez-backend.c
@@ -133,7 +133,7 @@ typedef struct {
 	GMainLoop *loop;
 	GError **error;
 	GCancellable *cancellable;
-	guint timeout_id;
+	GSource *timeout_source;
 } FuBluezBackendHelper;
 
 static void
@@ -141,8 +141,10 @@ fu_bluez_backend_helper_free(FuBluezBackendHelper *helper)
 {
 	if (helper->object_manager != NULL)
 		g_object_unref(helper->object_manager);
-	if (helper->timeout_id != 0)
-		g_source_remove(helper->timeout_id);
+	if (helper->timeout_source != NULL) {
+		g_source_destroy(helper->timeout_source);
+		g_source_unref(helper->timeout_source);
+	}
 	g_cancellable_cancel(helper->cancellable);
 	g_main_loop_unref(helper->loop);
 	g_free(helper);
@@ -164,7 +166,7 @@ fu_bluez_backend_timeout_cb(gpointer user_data)
 {
 	FuBluezBackendHelper *helper = (FuBluezBackendHelper *)user_data;
 	g_cancellable_cancel(helper->cancellable);
-	helper->timeout_id = 0;
+	g_clear_pointer(&helper->timeout_source, g_source_unref);
 	return G_SOURCE_REMOVE;
 }
 
@@ -175,15 +177,20 @@ fu_bluez_backend_setup(FuBackend *backend,
 		       GError **error)
 {
 	FuBluezBackend *self = FU_BLUEZ_BACKEND(backend);
+	FuContext *ctx = fu_backend_get_context(backend);
+	GMainContext *main_ctx = fu_context_get_main_context(ctx);
 	g_autoptr(FuBluezBackendHelper) helper = g_new0(FuBluezBackendHelper, 1);
 
 	/* in some circumstances the bluez daemon will just hang... do not wait
 	 * forever and make fwupd startup also fail */
 	helper->error = error;
-	helper->loop = g_main_loop_new(NULL, FALSE);
+	helper->loop = g_main_loop_new(main_ctx, FALSE);
 	helper->cancellable = g_cancellable_new();
-	helper->timeout_id =
-	    g_timeout_add(FU_BLUEZ_BACKEND_TIMEOUT, fu_bluez_backend_timeout_cb, helper);
+	helper->timeout_source = fu_context_add_timeout(ctx,
+							FU_BLUEZ_BACKEND_TIMEOUT,
+							fu_bluez_backend_timeout_cb,
+							helper);
+	g_main_context_push_thread_default(main_ctx);
 	g_dbus_object_manager_client_new_for_bus(G_BUS_TYPE_SYSTEM,
 						 G_DBUS_OBJECT_MANAGER_CLIENT_FLAGS_NONE,
 						 "org.bluez",
@@ -194,6 +201,7 @@ fu_bluez_backend_setup(FuBackend *backend,
 						 helper->cancellable,
 						 fu_bluez_backend_connect_cb,
 						 helper);
+	g_main_context_pop_thread_default(main_ctx);
 	g_main_loop_run(helper->loop);
 	if (helper->object_manager == NULL)
 		return FALSE;

--- a/src/fu-daemon.c
+++ b/src/fu-daemon.c
@@ -21,7 +21,7 @@
 typedef struct {
 	FuEngine *engine;
 	GMainLoop *loop;
-	guint housekeeping_id;
+	GSource *housekeeping_source;
 	gboolean update_in_progress;
 	gboolean pending_stop;
 	guint process_quit_id;
@@ -179,7 +179,7 @@ fu_daemon_schedule_housekeeping_cb(gpointer user_data)
 	fu_context_housekeeping(ctx);
 
 	/* success */
-	priv->housekeeping_id = 0;
+	g_clear_pointer(&priv->housekeeping_source, g_source_unref);
 	return G_SOURCE_REMOVE;
 }
 
@@ -187,15 +187,19 @@ void
 fu_daemon_schedule_housekeeping(FuDaemon *self)
 {
 	FuDaemonPrivate *priv = GET_PRIVATE(self);
+	FuEngine *engine = fu_daemon_get_engine(self);
+	FuContext *ctx = fu_engine_get_context(engine);
 	guint delay = FU_DAEMON_HOUSEKEEPING_DELAY;
 	if (priv->update_in_progress)
 		return;
-	if (priv->housekeeping_id != 0)
-		g_source_remove(priv->housekeeping_id);
+	if (priv->housekeeping_source != NULL) {
+		g_source_destroy(priv->housekeeping_source);
+		g_source_unref(priv->housekeeping_source);
+	}
 	if (g_getenv("CI") != NULL)
 		delay = 1;
-	priv->housekeeping_id =
-	    g_timeout_add_seconds(delay, fu_daemon_schedule_housekeeping_cb, self);
+	priv->housekeeping_source =
+	    fu_context_add_timeout_seconds(ctx, delay, fu_daemon_schedule_housekeeping_cb, self);
 }
 
 static gboolean
@@ -400,7 +404,7 @@ fu_daemon_init(FuDaemon *self)
 	FuDaemonPrivate *priv = GET_PRIVATE(self);
 	g_autoptr(FuContext) ctx = fu_context_new();
 	priv->engine = fu_engine_new(ctx);
-	priv->loop = g_main_loop_new(NULL, FALSE);
+	priv->loop = g_main_loop_new(fu_context_get_main_context(ctx), FALSE);
 	priv->status = FWUPD_STATUS_IDLE;
 }
 
@@ -412,8 +416,10 @@ fu_daemon_finalize(GObject *obj)
 
 	if (priv->loop != NULL)
 		g_main_loop_unref(priv->loop);
-	if (priv->housekeeping_id != 0)
-		g_source_remove(priv->housekeeping_id);
+	if (priv->housekeeping_source != NULL) {
+		g_source_destroy(priv->housekeeping_source);
+		g_source_unref(priv->housekeeping_source);
+	}
 	if (priv->process_quit_id != 0)
 		g_source_remove(priv->process_quit_id);
 	if (priv->set_status_id != 0)

--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -51,7 +51,7 @@ typedef struct {
 	FuDevice *device;
 	FuDevice *device_old;
 	FuDeviceList *self; /* no ref */
-	guint remove_id;
+	GSource *remove_source;
 } FuDeviceItem;
 
 static void
@@ -118,7 +118,7 @@ fu_device_list_add_string(FwupdCodec *codec, guint idt, GString *str)
 				       "%u [%p] %s\n",
 				       i,
 				       item,
-				       item->remove_id != 0 ? "IN_TIMEOUT" : "");
+				       item->remove_source != 0 ? "IN_TIMEOUT" : "");
 		wfr = fu_device_has_flag(item->device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 		g_string_append_printf(str,
 				       "new: %s [%p] %s\n",
@@ -465,7 +465,7 @@ fu_device_list_get_by_guids_removed(FuDeviceList *self, GPtrArray *guids)
 	g_return_val_if_fail(locker != NULL, NULL);
 	for (guint i = 0; i < self->devices->len; i++) {
 		FuDeviceItem *item = g_ptr_array_index(self->devices, i);
-		if (item->remove_id == 0)
+		if (item->remove_source == 0)
 			continue;
 		for (guint j = 0; j < guids->len; j++) {
 			const gchar *guid = g_ptr_array_index(guids, j);
@@ -481,7 +481,7 @@ fu_device_list_get_by_guids_removed(FuDeviceList *self, GPtrArray *guids)
 		FuDeviceItem *item = g_ptr_array_index(self->devices, i);
 		if (item->device_old == NULL)
 			continue;
-		if (item->remove_id == 0)
+		if (item->remove_source == 0)
 			continue;
 		for (guint j = 0; j < guids->len; j++) {
 			const gchar *guid = g_ptr_array_index(guids, j);
@@ -503,7 +503,7 @@ fu_device_list_device_delayed_remove_cb(gpointer user_data)
 	FuDeviceList *self = FU_DEVICE_LIST(item->self);
 
 	/* no longer valid */
-	item->remove_id = 0;
+	g_clear_pointer(&item->remove_source, g_source_unref);
 
 	/* remove any children associated with device */
 	if (!fu_device_has_private_flag(item->device,
@@ -534,7 +534,7 @@ fu_device_list_device_delayed_remove_cb(gpointer user_data)
 }
 
 static void
-fu_device_list_remove_with_delay(FuDeviceItem *item)
+fu_device_list_remove_with_delay(FuDeviceList *self, FuDeviceItem *item)
 {
 	g_autofree gchar *id_display = fu_device_get_id_display(item->device);
 	/* give the hardware time to re-enumerate or the user time to
@@ -542,9 +542,10 @@ fu_device_list_remove_with_delay(FuDeviceItem *item)
 	g_info("waiting %ums for %s device removal",
 	       fu_device_get_remove_delay(item->device),
 	       id_display);
-	item->remove_id = g_timeout_add(fu_device_get_remove_delay(item->device),
-					fu_device_list_device_delayed_remove_cb,
-					item);
+	item->remove_source = fu_context_add_timeout(self->ctx,
+						     fu_device_get_remove_delay(item->device),
+						     fu_device_list_device_delayed_remove_cb,
+						     item);
 }
 
 /* nocheck:name */
@@ -594,11 +595,14 @@ fu_device_list_remove(FuDeviceList *self, FuDevice *device)
 	fu_device_add_private_flag(item->device, FU_DEVICE_PRIVATE_FLAG_UNCONNECTED);
 
 	/* ensure never fired if the remove delay is changed */
-	g_clear_handle_id(&item->remove_id, g_source_remove);
+	if (item->remove_source != NULL) {
+		g_source_destroy(item->remove_source);
+		g_clear_pointer(&item->remove_source, g_source_unref);
+	}
 
 	/* delay the removal and check for replug */
 	if (fu_device_list_should_remove_with_delay(item->device)) {
-		fu_device_list_remove_with_delay(item);
+		fu_device_list_remove_with_delay(self, item);
 		return;
 	}
 
@@ -713,7 +717,10 @@ fu_device_list_clear_wait_for_replug(FuDeviceList *self, FuDeviceItem *item)
 	g_autofree gchar *str = NULL;
 
 	/* clear timeout if scheduled */
-	g_clear_handle_id(&item->remove_id, g_source_remove);
+	if (item->remove_source != NULL) {
+		g_source_destroy(item->remove_source);
+		item->remove_source = NULL;
+	}
 
 	/* remove flag on both old and new devices */
 	if (fu_device_has_flag(item->device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG)) {
@@ -899,7 +906,7 @@ fu_device_list_add(FuDeviceList *self, FuDevice *device)
 	item = fu_device_list_find_by_connection(self,
 						 fu_device_get_physical_id(device),
 						 fu_device_get_logical_id(device));
-	if (item != NULL && item->remove_id != 0) {
+	if (item != NULL && item->remove_source != NULL) {
 		g_info("found physical device %s recently removed, reusing "
 		       "item from plugin %s for plugin %s",
 		       fu_device_get_id(item->device),
@@ -1109,8 +1116,8 @@ fu_device_list_get_by_id(FuDeviceList *self, const gchar *device_id, GError **er
 static void
 fu_device_list_item_free(FuDeviceItem *item)
 {
-	if (item->remove_id != 0)
-		g_source_remove(item->remove_id);
+	if (item->remove_source != NULL)
+		g_source_destroy(item->remove_source);
 	if (item->device_old != NULL)
 		g_object_unref(item->device_old);
 	fu_device_list_item_set_device(item, NULL);

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -121,9 +121,9 @@ struct _FuEngine {
 	FuSecurityAttrs *host_security_attrs;
 	GPtrArray *local_monitors; /* (element-type GFileMonitor) */
 	GMainLoop *acquiesce_loop;
-	guint acquiesce_id;
+	GSource *acquiesce_source;
 	guint acquiesce_delay;
-	guint update_motd_id;
+	GSource *update_motd_source;
 	FuEngineEmulatorPhase emulator_phase;
 	guint emulator_write_cnt;
 	guint emulator_composite_cnt;
@@ -193,7 +193,7 @@ fu_engine_update_motd_timeout_cb(gpointer user_data)
 	/* update now */
 	if (!fu_engine_update_motd(self, &error_local))
 		g_info("failed to update MOTD: %s", error_local->message);
-	self->update_motd_id = 0;
+	g_clear_pointer(&self->update_motd_source, g_source_unref);
 	return G_SOURCE_REMOVE;
 }
 
@@ -201,11 +201,14 @@ static void
 fu_engine_update_motd_reset(FuEngine *self)
 {
 	g_info("resetting update motd timeout");
-	if (self->update_motd_id != 0)
-		g_source_remove(self->update_motd_id);
-	self->update_motd_id = g_timeout_add_seconds(FU_ENGINE_UPDATE_MOTD_DELAY,
-						     fu_engine_update_motd_timeout_cb,
-						     self);
+	if (self->update_motd_source != NULL) {
+		g_source_destroy(self->update_motd_source);
+		g_source_unref(self->update_motd_source);
+	}
+	self->update_motd_source = fu_context_add_timeout_seconds(self->ctx,
+								  FU_ENGINE_UPDATE_MOTD_DELAY,
+								  fu_engine_update_motd_timeout_cb,
+								  self);
 }
 
 static void
@@ -629,7 +632,7 @@ fu_engine_acquiesce_timeout_cb(gpointer user_data)
 	FuEngine *self = FU_ENGINE(user_data);
 	g_info("system acquiesced after %ums", self->acquiesce_delay);
 	g_main_loop_quit(self->acquiesce_loop);
-	self->acquiesce_id = 0;
+	g_clear_pointer(&self->acquiesce_source, g_source_unref);
 	return G_SOURCE_REMOVE;
 }
 
@@ -639,10 +642,14 @@ fu_engine_acquiesce_reset(FuEngine *self)
 	if (!g_main_loop_is_running(self->acquiesce_loop))
 		return;
 	g_info("resetting system acquiesce timeout");
-	if (self->acquiesce_id != 0)
-		g_source_remove(self->acquiesce_id);
-	self->acquiesce_id =
-	    g_timeout_add(self->acquiesce_delay, fu_engine_acquiesce_timeout_cb, self);
+	if (self->acquiesce_source != NULL) {
+		g_source_destroy(self->acquiesce_source);
+		g_source_unref(self->acquiesce_source);
+	}
+	self->acquiesce_source = fu_context_add_timeout(self->ctx,
+							self->acquiesce_delay,
+							fu_engine_acquiesce_timeout_cb,
+							self);
 }
 
 static void
@@ -651,7 +658,10 @@ fu_engine_wait_for_acquiesce(FuEngine *self, guint acquiesce_delay)
 	if (acquiesce_delay == 0)
 		return;
 	self->acquiesce_delay = acquiesce_delay;
-	self->acquiesce_id = g_timeout_add(acquiesce_delay, fu_engine_acquiesce_timeout_cb, self);
+	self->acquiesce_source = fu_context_add_timeout(self->ctx,
+							acquiesce_delay,
+							fu_engine_acquiesce_timeout_cb,
+							self);
 	g_main_loop_run(self->acquiesce_loop);
 }
 
@@ -9571,6 +9581,7 @@ fu_engine_constructed(GObject *obj)
 	self->history = fu_history_new(self->ctx);
 	self->device_list = fu_device_list_new(self->ctx);
 	self->emulation = fu_engine_emulator_new(self);
+	self->acquiesce_loop = g_main_loop_new(fu_context_get_main_context(self->ctx), FALSE);
 
 	self->remote_list = fu_remote_list_new(self->ctx);
 	g_signal_connect(FU_REMOTE_LIST(self->remote_list),
@@ -9643,7 +9654,6 @@ fu_engine_init(FuEngine *self)
 	self->host_security_attrs = fu_security_attrs_new();
 	self->local_monitors = g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
 	self->search_queries = g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
-	self->acquiesce_loop = g_main_loop_new(NULL, FALSE);
 	self->device_changed_allowlist =
 	    g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
 #ifdef HAVE_PASSIM
@@ -9680,17 +9690,22 @@ fu_engine_finalize(GObject *obj)
 		g_object_unref(self->query_tag_by_guid_version);
 	if (self->approved_firmware != NULL)
 		g_hash_table_unref(self->approved_firmware);
-	if (self->acquiesce_id != 0)
-		g_source_remove(self->acquiesce_id);
-	if (self->update_motd_id != 0)
-		g_source_remove(self->update_motd_id);
+	if (self->acquiesce_source != NULL) {
+		g_source_destroy(self->acquiesce_source);
+		g_source_unref(self->acquiesce_source);
+	}
+	if (self->update_motd_source != NULL) {
+		g_source_destroy(self->update_motd_source);
+		g_source_unref(self->update_motd_source);
+	}
 	if (self->emulation != NULL)
 		g_object_unref(self->emulation);
 #ifdef HAVE_PASSIM
 	if (self->passim_client != NULL)
 		g_object_unref(self->passim_client);
 #endif
-	g_main_loop_unref(self->acquiesce_loop);
+	if (self->acquiesce_loop != NULL)
+		g_main_loop_unref(self->acquiesce_loop);
 
 	g_free(self->host_machine_id);
 	g_object_unref(self->host_security_attrs);

--- a/src/fu-udev-backend.c
+++ b/src/fu-udev-backend.c
@@ -26,7 +26,7 @@ struct _FuUdevBackend {
 	GHashTable *map_paths;	    /* of str:None */
 	GHashTable *coldplug_cache; /* of str:FuUdevBackendColdplugCacheItem */
 	GPtrArray *dpaux_devices;   /* of FuDpauxDevice */
-	guint dpaux_devices_rescan_id;
+	GSource *dpaux_devices_rescan_source;
 	gboolean done_coldplug;
 };
 
@@ -117,19 +117,23 @@ fu_udev_backend_rescan_dpaux_devices_cb(gpointer user_data)
 		FuDevice *dpaux_device = g_ptr_array_index(self->dpaux_devices, i);
 		fu_udev_backend_rescan_dpaux_device(self, dpaux_device);
 	}
-	self->dpaux_devices_rescan_id = 0;
+	g_clear_pointer(&self->dpaux_devices_rescan_source, g_source_unref);
 	return G_SOURCE_REMOVE;
 }
 
 static void
 fu_udev_backend_rescan_dpaux_devices(FuUdevBackend *self)
 {
-	if (self->dpaux_devices_rescan_id != 0)
-		g_source_remove(self->dpaux_devices_rescan_id);
-	self->dpaux_devices_rescan_id =
-	    g_timeout_add_seconds(FU_UDEV_BACKEND_DPAUX_RESCAN_DELAY,
-				  fu_udev_backend_rescan_dpaux_devices_cb,
-				  self);
+	FuContext *ctx = fu_backend_get_context(FU_BACKEND(self));
+	if (self->dpaux_devices_rescan_source != NULL) {
+		g_source_destroy(self->dpaux_devices_rescan_source);
+		g_source_unref(self->dpaux_devices_rescan_source);
+	}
+	self->dpaux_devices_rescan_source =
+	    fu_context_add_timeout_seconds(ctx,
+					   FU_UDEV_BACKEND_DPAUX_RESCAN_DELAY,
+					   fu_udev_backend_rescan_dpaux_devices_cb,
+					   self);
 }
 
 static FuUdevDevice *
@@ -911,8 +915,10 @@ static void
 fu_udev_backend_finalize(GObject *object)
 {
 	FuUdevBackend *self = FU_UDEV_BACKEND(object);
-	if (self->dpaux_devices_rescan_id != 0)
-		g_source_remove(self->dpaux_devices_rescan_id);
+	if (self->dpaux_devices_rescan_source != NULL) {
+		g_source_destroy(self->dpaux_devices_rescan_source);
+		g_source_unref(self->dpaux_devices_rescan_source);
+	}
 	if (self->netlink_fd > 0)
 		g_close(self->netlink_fd, NULL);
 	g_hash_table_unref(self->map_paths);

--- a/src/fu-usb-backend.c
+++ b/src/fu-usb-backend.c
@@ -29,7 +29,7 @@ struct _FuUsbBackend {
 	GPtrArray *idle_events;
 	GMutex idle_events_mutex;
 	guint idle_events_id;
-	guint hotplug_poll_id;
+	GSource *hotplug_poll_source;
 	guint hotplug_poll_interval;
 #endif
 };
@@ -194,10 +194,16 @@ fu_usb_backend_rescan_cb(gpointer user_data)
 static void
 fu_usb_backend_ensure_rescan_timeout(FuUsbBackend *self)
 {
-	g_clear_handle_id(&self->hotplug_poll_id, g_source_remove);
+	FuContext *ctx = fu_backend_get_context(FU_BACKEND(self));
+	if (self->hotplug_poll_source != NULL) {
+		g_source_destroy(self->hotplug_poll_source);
+		g_clear_pointer(&self->hotplug_poll_source, g_source_unref);
+	}
 	if (self->hotplug_poll_interval > 0) {
-		self->hotplug_poll_id =
-		    g_timeout_add(self->hotplug_poll_interval, fu_usb_backend_rescan_cb, self);
+		self->hotplug_poll_source = fu_context_add_timeout(ctx,
+								   self->hotplug_poll_interval,
+								   fu_usb_backend_rescan_cb,
+								   self);
 	}
 }
 
@@ -211,7 +217,7 @@ fu_usb_backend_set_hotplug_poll_interval(FuUsbBackend *self, guint hotplug_poll_
 	self->hotplug_poll_interval = hotplug_poll_interval;
 
 	/* if already running then change the existing timeout */
-	if (self->hotplug_poll_id > 0)
+	if (self->hotplug_poll_source != NULL)
 		fu_usb_backend_ensure_rescan_timeout(self);
 }
 
@@ -480,8 +486,10 @@ fu_usb_backend_finalize(GObject *object)
 	}
 	if (self->idle_events_id > 0)
 		g_source_remove(self->idle_events_id);
-	if (self->hotplug_poll_id > 0)
-		g_source_remove(self->hotplug_poll_id);
+	if (self->hotplug_poll_source != NULL) {
+		g_source_destroy(self->hotplug_poll_source);
+		g_source_unref(self->hotplug_poll_source);
+	}
 	if (self->ctx != NULL)
 		libusb_exit(self->ctx);
 	g_clear_pointer(&self->idle_events, g_ptr_array_unref);


### PR DESCRIPTION
At the moment we're using the default context in lots of places and although that works now, it's only by accident.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
