### PR TITLE
Use rust_ld in cross file rather than passing -C linker= to rustc

### DIFF
--- a/contrib/android/android_x86_64-cross-file.ini
+++ b/contrib/android/android_x86_64-cross-file.ini
@@ -22,7 +22,8 @@ c =     toolchain_bin / target_triple + '-clang'
 cpp =   toolchain_bin / target_triple + '-clang++'
 ar =    toolchain_bin / 'llvm-ar'
 strip = toolchain_bin / 'llvm-strip'
-rust =  ['rustc', '--target', rust_target_triple, '-C', 'linker=' + toolchain_bin / target_triple + '-clang']
+rust =  ['rustc', '--target', rust_target_triple]
+rust_ld = toolchain_bin / target_triple + '-clang'
 
 [built-in options]
 c_std = 'gnu11'

--- a/contrib/ci/Dockerfile-ubuntu.in
+++ b/contrib/ci/Dockerfile-ubuntu.in
@@ -14,4 +14,5 @@ RUN set -euxo pipefail; \
     sudo \
 %%%DEPENDENCIES%%%; \
     apt-get clean
+%%%RUSTUP%%%
 WORKDIR /github/workspace

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -942,6 +942,11 @@
       <package variant="aarch64" />
     </distro>
   </dependency>
+  <dependency id="rustup">
+    <distro id="ubuntu">
+      <package variant="android" />
+    </distro>
+  </dependency>
   <dependency id="libstd-rust-dev">
     <distro id="debian">
       <multi-arch />

--- a/contrib/ci/generate_docker.py
+++ b/contrib/ci/generate_docker.py
@@ -84,6 +84,11 @@ deps = [f"    {i}" for i in deps]
 deps = " \\\n".join(deps)
 content = content.replace("%%%DEPENDENCIES%%%", deps)
 
+# install android rust target
+rustup: str = ""
+if VARIANT == "android":
+    rustup = "RUN rustup default stable && rustup target add x86_64-linux-android"
+content = content.replace("%%%RUSTUP%%%", rustup)
 
 with open("Dockerfile", "w") as file:
     file.write(content)

--- a/contrib/ci/ubuntu-android.sh
+++ b/contrib/ci/ubuntu-android.sh
@@ -37,6 +37,9 @@ fi
 
 export PATH="${PATH}:${ANDROID_SDK_ROOT}/cmdline-tools/bin:${ANDROID_SDK_ROOT}/build-tools/35.0.0"
 
+rustup default stable
+rustup target add x86_64-linux-android
+
 root=$(pwd)
 export BUILD="${root}/build"
 rm -rf "${BUILD}"


### PR DESCRIPTION
Meson >= 1.11 requires the linker to be specified via rust_ld in the cross file [binaries] section rather than as a -C linker= argument.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
