### PR TITLE
rust: Link our rust FFI lib into libfwupdplugin and libfwupd

### DIFF
--- a/libfwupd/meson.build
+++ b/libfwupd/meson.build
@@ -108,7 +108,7 @@ install_headers(
   subdir: join_paths(base_dir, 'libfwupd'),
 )
 
-libfwupd_deps = [gio, giounix, glib, libcurl]
+libfwupd_deps = [gio, giounix, glib, libcurl, fwupd_rust_ffi_dep ]
 
 libfwupd_src = [
   'fwupd-client.c',

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -430,6 +430,7 @@ library_deps = [
   libdrm,
   gnutls,
   platform_deps,
+  fwupd_rust_ffi_dep,
 ]
 
 fwupdplugin = library(

--- a/rust/meson.build
+++ b/rust/meson.build
@@ -24,6 +24,10 @@ fwupd_ffi_lib = fwupd_ffi_pkg.library(
 )
 
 fwupd_rust_ffi_incdir = include_directories('fwupd-ffi')
+fwupd_rust_ffi_dep = declare_dependency(
+  link_with: fwupd_ffi_lib,
+  include_directories: [fwupd_rust_ffi_incdir],
+)
 
 if get_option('tests')
   rustmod.test(


### PR DESCRIPTION
We don't have code in either that requires it but let's set this up now so we know it passes the CI and we don't have to keep the same commit in various branches.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
