### PR TITLE
Drop fu_memory_input_stream_new() from the API

### DIFF
--- a/libfwupdplugin/fu-memory-input-stream.c
+++ b/libfwupdplugin/fu-memory-input-stream.c
@@ -136,23 +136,6 @@ fu_memory_input_stream_init(FuMemoryInputStream *self)
 }
 
 /**
- * fu_memory_input_stream_new:
- *
- * Creates a new empty memory-backed input stream.
- *
- * Returns: (transfer full): a #FuInputStream
- *
- * Since: 2.1.7
- **/
-FuInputStream *
-fu_memory_input_stream_new(void)
-{
-	FuMemoryInputStream *self = g_object_new(FU_TYPE_MEMORY_INPUT_STREAM, NULL);
-
-	return FU_INPUT_STREAM(self);
-}
-
-/**
  * fu_memory_input_stream_new_from_bytes:
  * @bytes: a #GBytes
  *

--- a/libfwupdplugin/fu-memory-input-stream.h
+++ b/libfwupdplugin/fu-memory-input-stream.h
@@ -16,8 +16,6 @@ G_DECLARE_FINAL_TYPE(FuMemoryInputStream,
 		     FuInputStream)
 
 FuInputStream *
-fu_memory_input_stream_new(void) G_GNUC_WARN_UNUSED_RESULT;
-FuInputStream *
 fu_memory_input_stream_new_from_bytes(GBytes *bytes) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1);
 FuInputStream *
 fu_memory_input_stream_new_from_data(const void *data,

--- a/src/fu-engine-gtypes-test.c
+++ b/src/fu-engine-gtypes-test.c
@@ -31,7 +31,8 @@ fu_engine_plugin_device_gtype(FuContext *ctx, GType gtype, gboolean is_fake)
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GHashTable) metadata_post = NULL;
 	g_autoptr(GHashTable) metadata_pre = NULL;
-	g_autoptr(FuInputStream) stream = fu_memory_input_stream_new();
+	g_autoptr(GBytes) data = g_bytes_new(NULL, 0);
+	g_autoptr(FuInputStream) stream = fu_memory_input_stream_new_from_bytes(data);
 
 	g_debug("loading %s", g_type_name(gtype));
 	device = g_object_new(gtype, "context", ctx, "physical-id", "/sys", NULL);


### PR DESCRIPTION
This API was unused by any caller and it's quite pointless, it would merely create an empty stream that cannot be appended to. The only in-tree caller we had was a test case that can easily be switched to GBytes.

It was only introduced with the streams rework for 2.1.7 so we don't have anyone relying on it yet but it makes life harder for the rust input stream conversion. So let's drop it.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
