### PR TITLE
rust: Add a glib crate for FFI calls down to glib

### DIFF
--- a/rust/fwupd-ffi/src/glib/gerror.rs
+++ b/rust/fwupd-ffi/src/glib/gerror.rs
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+//! Minimal GError FFI helpers for setting errors from Rust.
+
+use std::ffi::CString;
+use std::os::raw::{c_char, c_int};
+
+/// GError -- must match the GLib GError struct layout
+#[repr(C)]
+pub struct GError {
+    pub domain: u32,
+    pub code: i32,
+    pub message: *mut c_char,
+}
+
+impl GError {
+    /// Generic setter for a GError from an error code and a message.
+    #[allow(dead_code)]
+    pub(crate) unsafe fn set(error: *mut *mut GError, error_code: u32, msg: &str) {
+        if error.is_null() {
+            return;
+        }
+
+        let c_msg =
+            CString::new(msg).unwrap_or_else(|_| CString::new("(invalid error message)").unwrap());
+        unsafe {
+            g_set_error_literal(
+                error,
+                fwupd_error_quark(),
+                error_code as c_int,
+                c_msg.as_ptr(),
+            );
+        }
+    }
+}
+
+/// Opaque GQuark (a guint32 in GLib).
+type GQuark = u32;
+
+#[allow(dead_code)]
+extern "C" {
+    /// `GQuark fwupd_error_quark(void)` -- defined in libfwupd.
+    fn fwupd_error_quark() -> GQuark;
+
+    /// `void g_set_error_literal(GError **err, GQuark domain, gint code, const gchar *message)`
+    fn g_set_error_literal(
+        err: *mut *mut GError,
+        domain: GQuark,
+        code: c_int,
+        message: *const c_char,
+    );
+}

--- a/rust/fwupd-ffi/src/glib/gstring.rs
+++ b/rust/fwupd-ffi/src/glib/gstring.rs
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+//! Minimal GString FFI helpers for returning GLib strings from Rust.
+
+use std::ffi::CString;
+use std::os::raw::c_char;
+
+/// Opaque GString -- matches the GLib `GString` struct layout.
+#[repr(C)]
+pub struct GString {
+    pub str_: *mut c_char,
+    pub len: usize,
+    pub allocated_len: usize,
+}
+
+#[allow(dead_code)]
+extern "C" {
+    fn g_string_new(init: *const c_char) -> *mut GString;
+    fn g_string_append_len(string: *mut GString, val: *const c_char, len: isize) -> *mut GString;
+}
+
+impl GString {
+    /// Create a new `GString *` from a Rust string.
+    ///
+    /// The returned `GString` is owned by the caller and must be freed accordingly.
+    pub fn from_rust_string(s: &str) -> *mut GString {
+        let cs = CString::new(s).expect("Unexpected null byte in string");
+        unsafe {
+            let gstr = g_string_new(cs.as_ptr());
+            if gstr.is_null() {
+                panic!("g_string_new() returned NULL");
+            }
+            gstr
+        }
+    }
+}

--- a/rust/fwupd-ffi/src/glib/mod.rs
+++ b/rust/fwupd-ffi/src/glib/mod.rs
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 Red Hat
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+//! GLib FFI helpers
+
+mod gerror;
+mod gstring;
+
+pub use gerror::*;
+pub use gstring::*;
+
+/// GLib gboolean TRUE
+pub const GTRUE: i32 = 1;
+/// GLib gboolean FALSE
+pub const GFALSE: i32 = 0;
+
+pub const G_SEEK_CUR: i32 = 0;
+pub const G_SEEK_SET: i32 = 1;
+pub const G_SEEK_END: i32 = 2;

--- a/rust/fwupd-ffi/src/lib.rs
+++ b/rust/fwupd-ffi/src/lib.rs
@@ -14,3 +14,5 @@
 //! This crate provides `#[no_mangle] extern "C"` wrappers around the pure-Rust
 //! `fwupd` crate, producing a static library that can be linked into other
 //! components of fwupd.
+
+pub mod glib;


### PR DESCRIPTION
Currently provides GError and GString and a few helper function we already know we'll use shortly.

This is basically a (working but not-yet-used) sneak preview of what we'll have to do if we need to wrap glib functions without using [`glib-sys`](https://docs.rs/glib-sys/) as dependency (which would pull in a few other deps). 

The hook ones currently implemented are the ones we need very soon. `GError` and `GString` are public structs in glib so we can keep them abi-compatible and give us some rustier APIs than just calling into the various `g_foo_bar` functions for everything (which we couldn't do if we were to use `glib-sys`).

The main drawback is that we're responsible for ABI compatibility, the compiler won't pick changes up.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
