### PR TITLE
trivial: Hide vfuncs when compiling with C++

### DIFF
--- a/libfwupdplugin/fu-efivars.h
+++ b/libfwupdplugin/fu-efivars.h
@@ -17,6 +17,7 @@ G_DECLARE_DERIVABLE_TYPE(FuEfivars, fu_efivars, FU, EFIVARS, GObject)
 
 struct _FuEfivarsClass {
 	GObjectClass parent_class;
+#ifndef __cplusplus
 	gboolean (*supported)(FuEfivars *self, GError **error) G_GNUC_NON_NULL(1);
 	guint64 (*space_used)(FuEfivars *self, GError **error) G_GNUC_NON_NULL(1);
 	guint64 (*space_free)(FuEfivars *self, GError **error) G_GNUC_NON_NULL(1);
@@ -49,6 +50,7 @@ struct _FuEfivarsClass {
 	GPtrArray *(*get_names)(FuEfivars *self,
 				const gchar *guid,
 				GError **error)G_GNUC_NON_NULL(1, 2);
+#endif
 };
 
 #define FU_EFIVARS_GUID_EFI_GLOBAL	   "8be4df61-93ca-11d2-aa0d-00e098032b8c"

--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -24,6 +24,7 @@ G_DECLARE_DERIVABLE_TYPE(FuFirmware, fu_firmware, FU, FIRMWARE, GObject)
 
 struct _FuFirmwareClass {
 	GObjectClass parent_class;
+#ifndef __cplusplus
 	gboolean (*parse)(FuFirmware *self,
 			  FuInputStream *stream,
 			  FuFirmwareParseFlags flags,
@@ -50,6 +51,7 @@ struct _FuFirmwareClass {
 				     GError **error);
 	gchar *(*convert_version)(FuFirmware *self, guint64 version_raw);
 	void (*add_magic)(FuFirmware *self);
+#endif
 };
 
 /**


### PR DESCRIPTION
Both 'delete' and 'export' are keywords there...

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
