### PR TITLE
redfish: add NVIDIA DGX Station GB300 OOB firmware update support

### DIFF
--- a/contrib/codespell.cfg
+++ b/contrib/codespell.cfg
@@ -1,4 +1,4 @@
 [codespell]
 builtin = clear,informal,en-GB_to_en-US,usage
 skip = *.po,*.csv,*.css,*.svg,*.p7c,*.proto,subprojects,.git,pcrs,build*,.ossfuzz,*/tests/*,contrib/codespell.cfg
-ignore-words-list = conexant,Conexant,gir,GIR,hsi,HSI,cancelled,Cancelled,te,mitre,distroname,wel,FPT,$FPT,inout,som,SoM,sme,abl,outin,master,buildd,slaves,Aluminium
+ignore-words-list = conexant,Conexant,gir,GIR,hsi,HSI,cancelled,Cancelled,cancelling,Cancelling,te,mitre,distroname,wel,FPT,$FPT,inout,som,SoM,sme,abl,outin,master,buildd,slaves,Aluminium

--- a/plugins/redfish/README.md
+++ b/plugins/redfish/README.md
@@ -38,6 +38,13 @@ Additionally, this Instance ID is added for quirk and parent matching:
 
 * `REDFISH\VENDOR_${RedfishManufacturer}&ID_${RedfishId}`
 
+On the NVIDIA DGX Station GB300 two further Instance IDs are added, as the BMC
+reports `Name=Software Inventory` for every FirmwareInventory entry:
+
+* `NVIDIA_OOB\URI_${odata.id}` -- always added, and unique per inventory entry
+* `NVIDIA_OOB\SWID_${RedfishSoftwareId}` -- added when a `SoftwareId` is present,
+  so that a unified-image archive can target several components at once
+
 ## Update Behavior
 
 The firmware will be deployed as appropriate. The Redfish API does not specify
@@ -89,6 +96,64 @@ Use unsigned development builds.
 ### `Flags=manager-reset`
 
 Reset the manager (typically the BMC) after updating this device.
+
+## Session Token Authentication
+
+Instead of storing a password in `/etc/fwupd/redfish.conf` the plugin can reuse a
+Redfish `X-Auth-Token` created out of band. Set `FWUPD_SESSION_TOKEN_FILE` to the
+path of a file containing the token, for example with a systemd drop-in:
+
+```ini
+[Service]
+Environment=FWUPD_SESSION_TOKEN_FILE=/run/example-bmc-auth/session
+```
+
+The file should live on tmpfs and be readable only by root so that no secret is
+written to persistent storage. When the variable is unset, or the file does not
+exist, the plugin falls back to the configured username and password.
+
+The file is re-read before each request rather than cached at startup, as the
+session it names expires independently of the daemon. Replacing the file is
+therefore enough to re-authenticate, with no need to restart `fwupd`.
+
+## NVIDIA DGX Station GB300
+
+The BMC is detected by probing `/redfish/v1/Chassis/Chassis_0` for
+`Manufacturer=NVIDIA` and a `Model` containing both `GB300` and `Station`. A
+matching BMC gets GB300-specific update semantics, which diverge from DMTF
+DSP0266 in several places:
+
+* `Targets` must be an empty array, as the BMC resolves the components to update
+  from the PLDM bundle manifest; naming a component returns HTTP 400.
+* `ForceUpdate` must be `true`, as the BMC otherwise rejects same-version installs.
+* `@Redfish.OperationApplyTime` must be `Immediate`, as `OnReset` is not in the
+  BMC's list of acceptable values.
+* `PercentComplete` is only updated on `/redfish/v1/TaskService/Tasks/<id>`, so
+  polling `/Tasks/<id>/Monitor` always reports 0%.
+* Once a task completes the BMC returns HTTP 200 with an empty body for the task
+  monitor rather than the HTTP 404 that normally signals it has been reaped.
+
+This device requires a session token, so see **Session Token Authentication**
+above before installing firmware:
+
+```shell
+fwupdmgr get-devices        # lists FW_BMC_0, FW_GPU_0, FW_CPU_0, ...
+fwupdmgr install firmware.cab --allow-reinstall
+```
+
+A full PLDM bundle flash takes about 20 minutes. The firmware is staged rather
+than applied, and the device is marked as needing activation: it becomes active
+only after an aux-rail power cycle.
+
+```shell
+fwupdmgr activate
+```
+
+This POSTs `{"ResetType":"AuxPowerCycleForce"}` to the OEM
+`NvidiaChassis.AuxPowerReset` action advertised by `/redfish/v1/Chassis/BMC_0`,
+which is not the chassis used to detect the GB300. The `Force` variant does not
+wait for the host to shut down, so the system loses power as soon as the BMC
+accepts the request -- save your work before activating.
 
 ## Setting Service IP Manually
 

--- a/plugins/redfish/README.md
+++ b/plugins/redfish/README.md
@@ -119,8 +119,12 @@ therefore enough to re-authenticate, with no need to restart `fwupd`.
 ## NVIDIA DGX Station GB300
 
 The BMC is detected by probing `/redfish/v1/Chassis/Chassis_0` for
-`Manufacturer=NVIDIA` and a `Model` containing both `GB300` and `Station`. A
-matching BMC gets GB300-specific update semantics, which diverge from DMTF
+`Manufacturer=NVIDIA` and a `Model` containing both `GB300` and `Station`. Each
+entry in the BMC's `FirmwareInventory` -- for example
+`/redfish/v1/UpdateService/FirmwareInventory/FW_BMC_0` -- is then exposed as its
+own device.
+
+A matching BMC gets GB300-specific update semantics, which diverge from DMTF
 DSP0266 in several places:
 
 * `Targets` must be an empty array, as the BMC resolves the components to update
@@ -132,6 +136,8 @@ DSP0266 in several places:
   polling `/Tasks/<id>/Monitor` always reports 0%.
 * Once a task completes the BMC returns HTTP 200 with an empty body for the task
   monitor rather than the HTTP 404 that normally signals it has been reaped.
+* When both the task monitor and `/Tasks/<id>` have been reaped, the
+  resource-gone condition is treated as a completed update.
 
 This device requires a session token, so see **Session Token Authentication**
 above before installing firmware:

--- a/plugins/redfish/README.md
+++ b/plugins/redfish/README.md
@@ -99,22 +99,22 @@ Reset the manager (typically the BMC) after updating this device.
 
 ## Session Token Authentication
 
-Instead of storing a password in `/etc/fwupd/redfish.conf` the plugin can reuse a
-Redfish `X-Auth-Token` created out of band. Set `FWUPD_SESSION_TOKEN_FILE` to the
-path of a file containing the token, for example with a systemd drop-in:
+Instead of storing a password, the plugin can reuse a Redfish `X-Auth-Token`
+created out of band by setting `SessionKeyFile` in `/etc/fwupd/redfish.conf` to
+the path of a file containing the token:
 
 ```ini
-[Service]
-Environment=FWUPD_SESSION_TOKEN_FILE=/run/example-bmc-auth/session
+[redfish]
+SessionKeyFile=/run/example-bmc-auth/session
 ```
 
 The file should live on tmpfs and be readable only by root so that no secret is
-written to persistent storage. When the variable is unset, or the file does not
+written to persistent storage. When the key is unset, or the file does not
 exist, the plugin falls back to the configured username and password.
 
-The file is re-read before each request rather than cached at startup, as the
-session it names expires independently of the daemon. Replacing the file is
-therefore enough to re-authenticate, with no need to restart `fwupd`.
+The file is read on each use rather than cached at startup, as the session it
+names expires independently of the daemon. Replacing the file is therefore
+enough to re-authenticate, with no need to restart `fwupd`.
 
 ## NVIDIA DGX Station GB300
 

--- a/plugins/redfish/fu-redfish-backend.c
+++ b/plugins/redfish/fu-redfish-backend.c
@@ -26,8 +26,8 @@ struct _FuRedfishBackend {
 	gchar *bearer_token;
 	gchar *session_key_file;
 	gchar *session_key;
+	gchar *session_key_file;
 	gchar *session_uri;
-	struct curl_slist *session_xauth_header; /* X-Auth-Token: <session_key> slist */
 	guint port;
 	gchar *vendor;
 	gchar *version;
@@ -47,9 +47,6 @@ struct _FuRedfishBackend {
 
 G_DEFINE_TYPE(FuRedfishBackend, fu_redfish_backend, FU_TYPE_BACKEND)
 
-typedef struct curl_slist _curl_slist;
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(_curl_slist, curl_slist_free_all)
-
 const gchar *
 fu_redfish_backend_get_vendor(FuRedfishBackend *self)
 {
@@ -68,6 +65,47 @@ fu_redfish_backend_get_uuid(FuRedfishBackend *self)
 	return self->uuid;
 }
 
+/*
+ * Re-read the session key from the file it was provisioned in.
+ *
+ * The X-Auth-Token names a BMC session created out of band, and that session
+ * expires independently of this daemon, so the value read when the plugin
+ * started may already be dead. Nothing re-runs ->startup(), and no vfunc runs
+ * before ->activate(), which can be minutes or hours after ->write_firmware().
+ */
+static void
+fu_redfish_backend_reload_session_key(FuRedfishBackend *self)
+{
+	g_autofree gchar *session_key = NULL;
+	g_autoptr(GError) error_local = NULL;
+
+	if (self->session_key_file == NULL)
+		return;
+	if (!g_file_get_contents(self->session_key_file, &session_key, NULL, &error_local)) {
+		/* keep the existing key, as the provisioner removes the file while it
+		 * re-authenticates */
+		g_debug("failed to read %s: %s", self->session_key_file, error_local->message);
+		return;
+	}
+	/* strip before testing for content, so that a partially written file does not
+	 * set an empty session key and suppress the password fallback */
+	g_strstrip(session_key);
+	if (session_key[0] == '\0' || g_strcmp0(session_key, self->session_key) == 0)
+		return;
+	g_debug("session key changed, using the newly provisioned one");
+	fu_redfish_backend_set_session_key(self, session_key);
+	g_hash_table_remove_all(self->request_cache);
+}
+
+void
+fu_redfish_backend_set_session_key_file(FuRedfishBackend *self, const gchar *session_key_file)
+{
+	g_return_if_fail(FU_IS_REDFISH_BACKEND(self));
+	g_free(self->session_key_file);
+	self->session_key_file = g_strdup(session_key_file);
+	fu_redfish_backend_reload_session_key(self);
+}
+
 FuRedfishRequest *
 fu_redfish_backend_request_new(FuRedfishBackend *self)
 {
@@ -80,6 +118,9 @@ fu_redfish_backend_request_new(FuRedfishBackend *self)
 #endif
 	g_autofree gchar *user_agent = NULL;
 	g_autofree gchar *port = g_strdup_printf("%u", self->port);
+
+	/* the provisioned session may have been replaced since the last request */
+	fu_redfish_backend_reload_session_key(self);
 
 	/* set the cache location */
 	fu_redfish_request_set_cache(request, self->request_cache);
@@ -102,18 +143,13 @@ fu_redfish_backend_request_new(FuRedfishBackend *self)
 #endif
 	(void)curl_easy_setopt(curl, CURLOPT_TIMEOUT, (glong)180);
 
-	if (self->session_xauth_header != NULL) {
-		/* X-Auth-Token session authentication per Redfish DSP0266 §12.3.
-		 * Used when a session was pre-created externally (e.g. nvidia-oob-auth)
-		 * so no password needs to be stored on disk.  The slist is owned by
-		 * the backend and outlives this request.
-		 *
-		 * Set on the curl handle for plain GET requests (fu_redfish_request_perform).
-		 * Also stored on the request so fu_redfish_request_perform_full() can merge
-		 * it with Content-Type headers instead of replacing them (which would cause
-		 * authenticated POST/PATCH to return HTTP 401). */
-		(void)curl_easy_setopt(curl, CURLOPT_HTTPHEADER, self->session_xauth_header);
-		fu_redfish_request_set_auth_headers(request, self->session_xauth_header);
+	if (self->session_key != NULL) {
+		/* X-Auth-Token session authentication per Redfish DSP0266 §12.3, used
+		 * when a session was created out of band so that no password needs to
+		 * be stored on disk */
+		g_autofree gchar *auth_header =
+		    g_strdup_printf("X-Auth-Token: %s", self->session_key);
+		fu_redfish_request_add_header(request, auth_header);
 	} else if (self->bearer_token != NULL) {
 		/* Some custom implementations require OAuth2 bearer token auth. */
 		(void)curl_easy_setopt(curl, CURLOPT_HTTPAUTH, (glong)CURLAUTH_BEARER);
@@ -269,15 +305,6 @@ void
 fu_redfish_backend_set_session_key(FuRedfishBackend *self, const gchar *session_key)
 {
 	g_set_str(&self->session_key, session_key);
-
-	/* Rebuild the pre-built X-Auth-Token header slist so request_new() can
-	 * stamp it on every request without a per-request allocation. */
-	curl_slist_free_all(self->session_xauth_header);
-	self->session_xauth_header = NULL;
-	if (session_key != NULL) {
-		g_autofree gchar *hdr = g_strdup_printf("X-Auth-Token: %s", session_key);
-		self->session_xauth_header = curl_slist_append(NULL, hdr);
-	}
 }
 
 /**
@@ -371,10 +398,7 @@ fu_redfish_backend_create_session(FuRedfishBackend *self, GError **error)
 gboolean
 fu_redfish_backend_delete_session(FuRedfishBackend *self, GError **error)
 {
-	g_autofree gchar *auth_header = NULL;
 	g_autoptr(FuRedfishRequest) request = NULL;
-	g_autoptr(_curl_slist) hs = NULL;
-	CURL *curl;
 
 	g_return_val_if_fail(FU_IS_REDFISH_BACKEND(self), FALSE);
 
@@ -391,12 +415,11 @@ fu_redfish_backend_delete_session(FuRedfishBackend *self, GError **error)
 		return FALSE;
 	}
 
+	/* request_new() already stamps the X-Auth-Token header for the session */
 	request = fu_redfish_backend_request_new(self);
-	curl = fu_redfish_request_get_curl(request);
-	(void)curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE");
-	auth_header = g_strconcat("X-Auth-Token: ", self->session_key, NULL);
-	hs = curl_slist_append(hs, auth_header);
-	(void)curl_easy_setopt(curl, CURLOPT_HTTPHEADER, hs);
+	(void)curl_easy_setopt(fu_redfish_request_get_curl(request),
+			       CURLOPT_CUSTOMREQUEST,
+			       "DELETE");
 	if (!fu_redfish_request_perform(request, self->session_uri, 0, error)) {
 		g_prefix_error_literal(error, "failed to delete session: ");
 		return FALSE;
@@ -435,6 +458,7 @@ fu_redfish_backend_is_nvidia_bmc(FuRedfishBackend *self)
 {
 	const gchar *manufacturer;
 	const gchar *model;
+	g_autofree gchar *model_lower = NULL;
 	g_autoptr(FuRedfishRequest) req = NULL;
 	g_autoptr(FwupdJsonObject) json_chassis = NULL;
 	g_autoptr(GError) error_local = NULL;
@@ -447,18 +471,18 @@ fu_redfish_backend_is_nvidia_bmc(FuRedfishBackend *self)
 		g_debug("Chassis_0 probe failed: %s", error_local->message);
 		return FALSE;
 	}
+	/* a BMC without this chassis may answer with no JSON body at all */
 	json_chassis = fu_redfish_request_get_json_object(req);
+	if (json_chassis == NULL)
+		return FALSE;
 	manufacturer = fwupd_json_object_get_string(json_chassis, "Manufacturer", NULL);
 	model = fwupd_json_object_get_string(json_chassis, "Model", NULL);
 	if (g_strcmp0(manufacturer, "NVIDIA") != 0 || model == NULL)
 		return FALSE;
-	/* Match "GB300" and "Station" anywhere in the model string, in any order
-	 * and case — covers "GB300 Station", "DGX Station GB300", etc. */
-	{
-		g_autofree gchar *model_lower = g_ascii_strdown(model, -1);
-		return strstr(model_lower, "gb300") != NULL &&
-		       strstr(model_lower, "station") != NULL;
-	}
+	/* match "GB300" and "Station" anywhere in the model string, in any order and
+	 * case, covering "GB300 Station", "DGX Station GB300" and similar */
+	model_lower = g_ascii_strdown(model, -1);
+	return strstr(model_lower, "gb300") != NULL && strstr(model_lower, "station") != NULL;
 }
 
 static gboolean
@@ -857,7 +881,6 @@ fu_redfish_backend_finalize(GObject *object)
 {
 	FuRedfishBackend *self = FU_REDFISH_BACKEND(object);
 	g_hash_table_unref(self->request_cache);
-	curl_slist_free_all(self->session_xauth_header);
 	curl_share_cleanup(self->curlsh);
 	g_free(self->update_uri_path);
 	g_free(self->push_uri_path);
@@ -868,6 +891,7 @@ fu_redfish_backend_finalize(GObject *object)
 	g_free(self->bearer_token);
 	g_free(self->session_key_file);
 	g_free(self->session_key);
+	g_free(self->session_key_file);
 	g_free(self->session_uri);
 	g_free(self->vendor);
 	g_free(self->version);

--- a/plugins/redfish/fu-redfish-backend.c
+++ b/plugins/redfish/fu-redfish-backend.c
@@ -26,7 +26,6 @@ struct _FuRedfishBackend {
 	gchar *bearer_token;
 	gchar *session_key_file;
 	gchar *session_key;
-	gchar *session_key_file;
 	gchar *session_uri;
 	guint port;
 	gchar *vendor;
@@ -65,47 +64,6 @@ fu_redfish_backend_get_uuid(FuRedfishBackend *self)
 	return self->uuid;
 }
 
-/*
- * Re-read the session key from the file it was provisioned in.
- *
- * The X-Auth-Token names a BMC session created out of band, and that session
- * expires independently of this daemon, so the value read when the plugin
- * started may already be dead. Nothing re-runs ->startup(), and no vfunc runs
- * before ->activate(), which can be minutes or hours after ->write_firmware().
- */
-static void
-fu_redfish_backend_reload_session_key(FuRedfishBackend *self)
-{
-	g_autofree gchar *session_key = NULL;
-	g_autoptr(GError) error_local = NULL;
-
-	if (self->session_key_file == NULL)
-		return;
-	if (!g_file_get_contents(self->session_key_file, &session_key, NULL, &error_local)) {
-		/* keep the existing key, as the provisioner removes the file while it
-		 * re-authenticates */
-		g_debug("failed to read %s: %s", self->session_key_file, error_local->message);
-		return;
-	}
-	/* strip before testing for content, so that a partially written file does not
-	 * set an empty session key and suppress the password fallback */
-	g_strstrip(session_key);
-	if (session_key[0] == '\0' || g_strcmp0(session_key, self->session_key) == 0)
-		return;
-	g_debug("session key changed, using the newly provisioned one");
-	fu_redfish_backend_set_session_key(self, session_key);
-	g_hash_table_remove_all(self->request_cache);
-}
-
-void
-fu_redfish_backend_set_session_key_file(FuRedfishBackend *self, const gchar *session_key_file)
-{
-	g_return_if_fail(FU_IS_REDFISH_BACKEND(self));
-	g_free(self->session_key_file);
-	self->session_key_file = g_strdup(session_key_file);
-	fu_redfish_backend_reload_session_key(self);
-}
-
 FuRedfishRequest *
 fu_redfish_backend_request_new(FuRedfishBackend *self)
 {
@@ -118,9 +76,7 @@ fu_redfish_backend_request_new(FuRedfishBackend *self)
 #endif
 	g_autofree gchar *user_agent = NULL;
 	g_autofree gchar *port = g_strdup_printf("%u", self->port);
-
-	/* the provisioned session may have been replaced since the last request */
-	fu_redfish_backend_reload_session_key(self);
+	g_autofree gchar *session_key = fu_redfish_backend_get_session_key(self, NULL);
 
 	/* set the cache location */
 	fu_redfish_request_set_cache(request, self->request_cache);
@@ -143,12 +99,13 @@ fu_redfish_backend_request_new(FuRedfishBackend *self)
 #endif
 	(void)curl_easy_setopt(curl, CURLOPT_TIMEOUT, (glong)180);
 
-	if (self->session_key != NULL) {
+	if (session_key != NULL) {
 		/* X-Auth-Token session authentication per Redfish DSP0266 §12.3, used
 		 * when a session was created out of band so that no password needs to
-		 * be stored on disk */
-		g_autofree gchar *auth_header =
-		    g_strdup_printf("X-Auth-Token: %s", self->session_key);
+		 * be stored on disk.  fu_redfish_backend_get_session_key() re-reads the
+		 * key file on each call, so a session replaced out of band is picked up
+		 * without restarting the daemon. */
+		g_autofree gchar *auth_header = g_strdup_printf("X-Auth-Token: %s", session_key);
 		fu_redfish_request_add_header(request, auth_header);
 	} else if (self->bearer_token != NULL) {
 		/* Some custom implementations require OAuth2 bearer token auth. */
@@ -301,7 +258,7 @@ fu_redfish_backend_check_wildcard_targets(FuRedfishBackend *self)
 	}
 }
 
-void
+static void
 fu_redfish_backend_set_session_key(FuRedfishBackend *self, const gchar *session_key)
 {
 	g_set_str(&self->session_key, session_key);

--- a/plugins/redfish/fu-redfish-backend.c
+++ b/plugins/redfish/fu-redfish-backend.c
@@ -13,6 +13,7 @@
 #include "fu-redfish-hpe-device.h"
 #include "fu-redfish-legacy-device.h"
 #include "fu-redfish-multipart-device.h"
+#include "fu-redfish-nvidia-device.h"
 #include "fu-redfish-request.h"
 #include "fu-redfish-smbios.h"
 #include "fu-redfish-smc-device.h"
@@ -26,6 +27,7 @@ struct _FuRedfishBackend {
 	gchar *session_key_file;
 	gchar *session_key;
 	gchar *session_uri;
+	struct curl_slist *session_xauth_header; /* X-Auth-Token: <session_key> slist */
 	guint port;
 	gchar *vendor;
 	gchar *version;
@@ -100,15 +102,24 @@ fu_redfish_backend_request_new(FuRedfishBackend *self)
 #endif
 	(void)curl_easy_setopt(curl, CURLOPT_TIMEOUT, (glong)180);
 
-	if (self->bearer_token != NULL) {
-		/* Some custom implementation require special authentication through bearer token.
-		 * Let's use that if configured to do so. */
+	if (self->session_xauth_header != NULL) {
+		/* X-Auth-Token session authentication per Redfish DSP0266 §12.3.
+		 * Used when a session was pre-created externally (e.g. nvidia-oob-auth)
+		 * so no password needs to be stored on disk.  The slist is owned by
+		 * the backend and outlives this request.
+		 *
+		 * Set on the curl handle for plain GET requests (fu_redfish_request_perform).
+		 * Also stored on the request so fu_redfish_request_perform_full() can merge
+		 * it with Content-Type headers instead of replacing them (which would cause
+		 * authenticated POST/PATCH to return HTTP 401). */
+		(void)curl_easy_setopt(curl, CURLOPT_HTTPHEADER, self->session_xauth_header);
+		fu_redfish_request_set_auth_headers(request, self->session_xauth_header);
+	} else if (self->bearer_token != NULL) {
+		/* Some custom implementations require OAuth2 bearer token auth. */
 		(void)curl_easy_setopt(curl, CURLOPT_HTTPAUTH, (glong)CURLAUTH_BEARER);
 		(void)curl_easy_setopt(curl, CURLOPT_XOAUTH2_BEARER, self->bearer_token);
 	} else {
-		/* Here is the common auth scenario, when no specific bearer token is configured.
-		 * since DSP0266 makes Basic Authorization a requirement,
-		 * it is safe to use Basic Auth for all implementations */
+		/* Common scenario: Basic Auth per DSP0266 §12.1. */
 		(void)curl_easy_setopt(curl, CURLOPT_HTTPAUTH, (glong)CURLAUTH_BASIC);
 		(void)curl_easy_setopt(curl, CURLOPT_USERNAME, self->username);
 		(void)curl_easy_setopt(curl, CURLOPT_PASSWORD, self->password);
@@ -254,10 +265,19 @@ fu_redfish_backend_check_wildcard_targets(FuRedfishBackend *self)
 	}
 }
 
-static void
+void
 fu_redfish_backend_set_session_key(FuRedfishBackend *self, const gchar *session_key)
 {
 	g_set_str(&self->session_key, session_key);
+
+	/* Rebuild the pre-built X-Auth-Token header slist so request_new() can
+	 * stamp it on every request without a per-request allocation. */
+	curl_slist_free_all(self->session_xauth_header);
+	self->session_xauth_header = NULL;
+	if (session_key != NULL) {
+		g_autofree gchar *hdr = g_strdup_printf("X-Auth-Token: %s", session_key);
+		self->session_xauth_header = curl_slist_append(NULL, hdr);
+	}
 }
 
 /**
@@ -402,6 +422,45 @@ fu_redfish_backend_set_path_prefix(FuRedfishBackend *self, const gchar *path_pre
 	g_set_str(&self->path_prefix, path_prefix);
 }
 
+/*
+ * Detect an NVIDIA DGX Station GB300 BMC by probing Chassis_0.
+ *
+ * Vendor="NVIDIA" at the Redfish root is necessary but not sufficient —
+ * other NVIDIA Redfish implementations (non-GB300 systems) must not receive
+ * GB300-specific update semantics (empty Targets, ForceUpdate, GB300 task
+ * lifecycle).  Always verify the chassis model.
+ */
+static gboolean
+fu_redfish_backend_is_nvidia_bmc(FuRedfishBackend *self)
+{
+	const gchar *manufacturer;
+	const gchar *model;
+	g_autoptr(FuRedfishRequest) req = NULL;
+	g_autoptr(FwupdJsonObject) json_chassis = NULL;
+	g_autoptr(GError) error_local = NULL;
+
+	req = fu_redfish_backend_request_new(self);
+	if (!fu_redfish_request_perform(req,
+					"/redfish/v1/Chassis/Chassis_0",
+					FU_REDFISH_REQUEST_PERFORM_FLAG_LOAD_JSON,
+					&error_local)) {
+		g_debug("Chassis_0 probe failed: %s", error_local->message);
+		return FALSE;
+	}
+	json_chassis = fu_redfish_request_get_json_object(req);
+	manufacturer = fwupd_json_object_get_string(json_chassis, "Manufacturer", NULL);
+	model = fwupd_json_object_get_string(json_chassis, "Model", NULL);
+	if (g_strcmp0(manufacturer, "NVIDIA") != 0 || model == NULL)
+		return FALSE;
+	/* Match "GB300" and "Station" anywhere in the model string, in any order
+	 * and case — covers "GB300 Station", "DGX Station GB300", etc. */
+	{
+		g_autofree gchar *model_lower = g_ascii_strdown(model, -1);
+		return strstr(model_lower, "gb300") != NULL &&
+		       strstr(model_lower, "station") != NULL;
+	}
+}
+
 static gboolean
 fu_redfish_backend_has_smc_update_path(FwupdJsonObject *json_obj)
 {
@@ -464,8 +523,10 @@ fu_redfish_backend_coldplug(FuBackend *backend, FuProgress *progress, GError **e
 		const gchar *tmp =
 		    fwupd_json_object_get_string(json_obj, "MultipartHttpPushUri", NULL);
 		if (tmp != NULL) {
-			if (g_strcmp0(self->vendor, "SMCI") == 0 &&
-			    fu_redfish_backend_has_smc_update_path(json_obj)) {
+			if (fu_redfish_backend_is_nvidia_bmc(self)) {
+				self->device_gtype = FU_TYPE_REDFISH_NVIDIA_DEVICE;
+			} else if (g_strcmp0(self->vendor, "SMCI") == 0 &&
+				   fu_redfish_backend_has_smc_update_path(json_obj)) {
 				self->device_gtype = FU_TYPE_REDFISH_SMC_DEVICE;
 			} else {
 				self->device_gtype = FU_TYPE_REDFISH_MULTIPART_DEVICE;
@@ -775,6 +836,7 @@ fu_redfish_backend_to_string(FuBackend *backend, guint idt, GString *str)
 	fwupd_codec_string_append(str, idt, "Username", self->username);
 	fwupd_codec_string_append_bool(str, idt, "Password", self->password != NULL);
 	fwupd_codec_string_append_bool(str, idt, "BearerToken", self->bearer_token != NULL);
+	/* only ever the path: the key itself is a bearer-equivalent token */
 	fwupd_codec_string_append(str, idt, "SessionKeyFile", self->session_key_file);
 	fwupd_codec_string_append_bool(str, idt, "SessionKey", self->session_key != NULL);
 	fwupd_codec_string_append_int(str, idt, "Port", self->port);
@@ -795,6 +857,7 @@ fu_redfish_backend_finalize(GObject *object)
 {
 	FuRedfishBackend *self = FU_REDFISH_BACKEND(object);
 	g_hash_table_unref(self->request_cache);
+	curl_slist_free_all(self->session_xauth_header);
 	curl_share_cleanup(self->curlsh);
 	g_free(self->update_uri_path);
 	g_free(self->push_uri_path);

--- a/plugins/redfish/fu-redfish-device.c
+++ b/plugins/redfish/fu-redfish-device.c
@@ -949,6 +949,23 @@ fu_redfish_device_get_reset_post_delay(FuRedfishDevice *self)
 	return priv->reset_post_delay;
 }
 
+/**
+ * fu_redfish_device_get_json_obj_member:
+ * @self: a #FuRedfishDevice
+ *
+ * Returns the raw FirmwareInventory JSON member object passed to this device
+ * at construction time.  Subclasses may call this in their probe() override to
+ * read vendor-specific fields that the base probe() does not expose.
+ *
+ * Returns: (transfer none) (nullable): a #FwupdJsonObject, or %NULL.
+ */
+FwupdJsonObject *
+fu_redfish_device_get_json_obj_member(FuRedfishDevice *self)
+{
+	FuRedfishDevicePrivate *priv = GET_PRIVATE(self);
+	return priv->json_obj_member;
+}
+
 static gboolean
 fu_redfish_device_set_quirk_kv(FuDevice *device,
 			       const gchar *key,

--- a/plugins/redfish/fu-redfish-device.h
+++ b/plugins/redfish/fu-redfish-device.h
@@ -47,3 +47,5 @@ guint
 fu_redfish_device_get_reset_pre_delay(FuRedfishDevice *self);
 guint
 fu_redfish_device_get_reset_post_delay(FuRedfishDevice *self);
+FwupdJsonObject *
+fu_redfish_device_get_json_obj_member(FuRedfishDevice *self);

--- a/plugins/redfish/fu-redfish-nvidia-device.c
+++ b/plugins/redfish/fu-redfish-nvidia-device.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2026 NVIDIA Corporation
+ * Author: Vishnu Raghav <vraghav@nvidia.com>
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
@@ -8,8 +9,8 @@
  * FuRedfishNvidiaDevice — NVIDIA DGX Station GB300 OOB firmware update via Redfish.
  *
  * Represents a single component in the BMC's FirmwareInventory (e.g.
- * /redfish/v1/UpdateService/FirmwareInventory/FW_BMC_0) and implements
- * the GB300-specific upload + task-monitoring flow:
+ * /redfish/v1/UpdateService/FirmwareInventory/FW_BMC_0) and implements the
+ * GB300-specific upload and task-monitoring flow:
  *
  *   1. Multipart POST to UpdateService/MultipartHttpPushUri:
  *        UpdateParameters: { "Targets":[], "ForceUpdate":true,
@@ -19,105 +20,66 @@
  *   2. Poll /redfish/v1/TaskService/Tasks/<id> (the persistent task resource,
  *      not the /Monitor sub-resource) for PercentComplete and TaskState.
  *      GB300-specific divergences from DMTF DSP0266:
- *        - Targets must be an empty array (BMC resolves components from the
- *          PLDM bundle manifest); passing the logical_id causes a 400 error.
+ *        - Targets must be an empty array, as the BMC resolves components from
+ *          the PLDM bundle manifest; passing the logical_id causes a 400 error.
  *        - ForceUpdate=true is required; the BMC rejects same-version installs.
  *        - OperationApplyTime "OnReset" is not in the BMC's acceptable-values
  *          list; "Immediate" must be used.
  *        - PercentComplete is only updated on /Tasks/<id>, not on
  *          /Tasks/<id>/Monitor; polling the Monitor always returns 0%.
- *        - After task completion the BMC returns HTTP 200 + empty body for the
- *          TaskMonitor instead of the canonical 404 that signals reap; both
- *          are handled here. When both the Monitor and /Tasks/<id> are gone
- *          the resource-gone condition is treated as Completed.
+ *        - After task completion the BMC returns HTTP 200 and an empty body for
+ *          the TaskMonitor instead of the canonical 404 that signals reap; both
+ *          are handled here. When both the Monitor and /Tasks/<id> are gone the
+ *          resource-gone condition is treated as Completed.
  *
- *   3. attach() sets NEEDS_ACTIVATION; the firmware is staged and only becomes
- *      active after an aux-rail (AC) power cycle. The BMC's AuxPowerReset OEM
- *      action is gated on chassis-off so automation from the host is impossible.
+ *   3. A completed write sets NEEDS_ACTIVATION, as the firmware is staged and
+ *      only becomes active after an aux-rail power cycle. activate() drives
+ *      that cycle by POSTing ResetType=AuxPowerCycleForce to the OEM
+ *      NvidiaChassis.AuxPowerReset action advertised by Chassis/BMC_0. The
+ *      Force variant does not wait for the host to shut down, so it drops the
+ *      rail powering fwupd itself.
  *
- * Instance IDs registered per device (in addition to those from the base class):
+ * Instance IDs registered per device, in addition to those from the base class:
  *   NVIDIA_OOB\URI_<@odata.id>   — always; unique per FirmwareInventory entry
- *   NVIDIA_OOB\SWID_<SoftwareId> — when present; enables unified-image CABs to
- *                                   target multiple components by SoftwareId
+ *   NVIDIA_OOB\SWID_<SoftwareId> — when present; lets a unified-image CAB target
+ *                                  multiple components by SoftwareId
  *
  * Backend detection: fu_redfish_backend_coldplug() sets device_gtype to
- * FU_TYPE_REDFISH_NVIDIA_DEVICE when the Redfish root Vendor equals "NVIDIA"
- * or when /redfish/v1/Chassis/Chassis_0 reports Manufacturer="NVIDIA" and
- * Model contains "GB300" and "Station".
+ * FU_TYPE_REDFISH_NVIDIA_DEVICE when /redfish/v1/Chassis/Chassis_0 reports
+ * Manufacturer="NVIDIA" and a Model containing both "GB300" and "Station".
  *
- * ── Prerequisites ─────────────────────────────────────────────────────────────
- *
- * This plugin consumes a Redfish X-Auth-Token written by the separate
- * nvidia-host-bmc-interface-setup platform package. That package must be
- * installed and commissioned before this plugin can enumerate devices.
- *
- * The token is read from:
- *   /run/nvidia-host-bmc-interface/session   (tmpfs, mode 600, root-only)
- *
- * If the file is absent fwupd falls back to Basic Auth (username/password
- * from /etc/fwupd/redfish.conf), which requires a plaintext password on disk.
- *
- * ── Build ─────────────────────────────────────────────────────────────────────
- *
- *   # Install build dependencies (Ubuntu/Debian)
- *   sudo apt install -y meson ninja-build pkg-config gettext \
- *       libusb-1.0-0-dev libglib2.0-dev libcurl4-openssl-dev \
- *       libjson-glib-dev libxmlb-dev libsqlite3-dev \
- *       libgnutls28-dev libgirepository1.0-dev netplan.io
- *
- *   # Upgrade meson if system version < 0.63.0
- *   pip3 install --user --break-system-packages "meson>=1.3.0"
- *   export PATH="$HOME/.local/bin:$PATH"
- *
- *   cd ~/fwupd
- *   meson setup build \
- *       -Dauto_features=disabled -Ddocs=disabled \
- *       -Dtests=false -Dman=false
- *   ninja -C build
- *
- * ── Install ───────────────────────────────────────────────────────────────────
- *
- *   sudo env PATH="/home/nvidia/.local/bin:$PATH" \
- *       PYTHONPATH="/home/nvidia/.local/lib/python3.12/site-packages" \
- *       meson install -C build
- *
- *   meson install places a systemd drop-in at
- *   /etc/systemd/system/fwupd.service.d/nvidia.conf that redirects
- *   fwupd.service to the newly installed binary and sets --verbose +
- *   G_MESSAGES_DEBUG=all so plugin log messages appear in journalctl.
- *
- *   After install, reload systemd and restart fwupd to pick up the new binary:
- *
- *   sudo systemctl daemon-reload
- *   sudo systemctl restart fwupd.service
- *   sleep 2
- *   systemctl status fwupd.service
- *
- * ── Verify ────────────────────────────────────────────────────────────────────
- *
- *   systemctl status fwupd.service      # confirm our binary is running
- *   fwupdmgr get-devices               # should list FW_BMC_0, FW_GPU_0, …
- *   sudo journalctl -u fwupd -f        # live plugin logs during install
- *
- * ── Firmware install ──────────────────────────────────────────────────────────
- *
- *   sudo fwupdmgr install firmware.cab --allow-reinstall
- *
- *   Progress is logged every 60 s:
- *     NvidiaOob: task poll #31 — 20% complete (~62 s elapsed)
- *   Typical install time for a full PLDM bundle: ~20 minutes.
- *   Firmware activates on the next AC (aux-rail) power cycle.
+ * This device requires a Redfish X-Auth-Token provisioned out of band; see
+ * README.md for how to set FWUPD_SESSION_TOKEN_FILE. Without a token the
+ * plugin falls back to Basic Auth.
  */
 
 #include "config.h"
 
 #include <curl/curl.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "fu-redfish-backend.h"
 #include "fu-redfish-device.h"
 #include "fu-redfish-nvidia-device.h"
 #include "fu-redfish-request.h"
+
+/* 1800 polls at 2s covers the worst-case GB300 bundle flash of ~60 minutes */
+#define FU_REDFISH_NVIDIA_TASK_POLL_DELAY 2000u /* ms */
+#define FU_REDFISH_NVIDIA_TASK_POLL_CNT	  1800u
+
+/* a newly accepted upload needs a few seconds before /Tasks/<id> appears */
+#define FU_REDFISH_NVIDIA_TASK_CREATION_GRACE 5 /* polls */
+
+/* consecutive transient failures tolerated before the update is abandoned */
+#define FU_REDFISH_NVIDIA_TASK_ERRORS_MAX 5
+
+/* only used when the BMC UpdateService does not report MaxImageSizeBytes */
+#define FU_REDFISH_NVIDIA_FIRMWARE_SIZE_MAX (256 * FU_MB)
+
+/* the chassis carrying the OEM aux-rail reset, which is not the one used to
+ * detect the GB300 */
+#define FU_REDFISH_NVIDIA_CHASSIS_URI "/redfish/v1/Chassis/BMC_0"
 
 struct _FuRedfishNvidiaDevice {
 	FuRedfishDevice parent_instance;
@@ -127,15 +89,22 @@ G_DEFINE_TYPE(FuRedfishNvidiaDevice, fu_redfish_nvidia_device, FU_TYPE_REDFISH_D
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(curl_mime, curl_mime_free)
 
-/* ------------------------------------------------------------------ */
-/* Location header capture (same pattern as FuRedfishMultipartDevice) */
-/* ------------------------------------------------------------------ */
+typedef struct {
+	FuRedfishBackend *backend;
+	FuProgress *progress;
+	const gchar *task_uri;
+	const gchar *monitor_uri;
+	guint attempt;
+	guint consecutive_errors;
+	/* set once the persistent /Tasks/<id> URI has returned a valid TaskState, to
+	 * tell "task reaped after completing" apart from "task never existed"; the
+	 * monitor URI returning a live response does not set this */
+	gboolean saw_persistent_task;
+} FuRedfishNvidiaTaskHelper;
 
+/* same pattern as FuRedfishMultipartDevice */
 static size_t
-fu_redfish_nvidia_device_location_header_cb(char *ptr,
-					    size_t size,
-					    size_t nmemb,
-					    void *userdata)
+fu_redfish_nvidia_device_location_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
 {
 	char **location = (char **)userdata;
 	if ((size * nmemb) > 16 && g_ascii_strncasecmp(ptr, "Location:", 9) == 0)
@@ -143,15 +112,8 @@ fu_redfish_nvidia_device_location_header_cb(char *ptr,
 	return size * nmemb;
 }
 
-/* ------------------------------------------------------------------ */
-/* Task polling — GB300-specific                                       */
-/* ------------------------------------------------------------------ */
-
-/*
- * Derive the persistent /Tasks/<id> URI from a /Tasks/<id>/Monitor URI by
- * stripping the trailing /Monitor segment.  Returns NULL if uri does not end
- * in /Monitor (caller must check).
- */
+/* derive the persistent /Tasks/<id> URI from a /Tasks/<id>/Monitor URI, returning
+ * NULL when @monitor_uri does not end in /Monitor */
 static gchar *
 fu_redfish_nvidia_device_derive_task_uri(const gchar *monitor_uri)
 {
@@ -167,25 +129,25 @@ fu_redfish_nvidia_device_classify_task_response(glong status_code,
 						gboolean has_json,
 						gboolean allow_empty_200)
 {
-	/* A reap status wins over any body the BMC happens to return. */
+	/* a reap status wins over any body the BMC happens to return */
 	if (status_code == 404)
 		return FU_REDFISH_NVIDIA_TASK_RESPONSE_REAPED;
 
-	/* These statuses can clear while an update remains active. */
+	/* these statuses can clear while an update remains active */
 	if (status_code == 0 || status_code == 408 || status_code == 425 || status_code == 429 ||
 	    status_code >= 500)
 		return FU_REDFISH_NVIDIA_TASK_RESPONSE_TRANSIENT;
 
-	/* Never let task-shaped JSON turn an HTTP error into success. */
+	/* never let task-shaped JSON turn an HTTP error into success */
 	if (status_code < 200 || status_code >= 300)
 		return FU_REDFISH_NVIDIA_TASK_RESPONSE_FATAL;
 
-	/* A 2xx response that failed transport or JSON validation is not a task. */
+	/* a 2xx response that failed transport or JSON validation is not a task */
 	if (!request_succeeded)
 		return FU_REDFISH_NVIDIA_TASK_RESPONSE_FATAL;
 
 	if (!has_json) {
-		/* This is a documented GB300 quirk of TaskMonitor only. */
+		/* a documented GB300 quirk of the TaskMonitor only */
 		if (status_code == 200 && allow_empty_200)
 			return FU_REDFISH_NVIDIA_TASK_RESPONSE_REAPED;
 		return FU_REDFISH_NVIDIA_TASK_RESPONSE_TRANSIENT;
@@ -197,30 +159,29 @@ fu_redfish_nvidia_device_classify_task_response(glong status_code,
 static gboolean
 fu_redfish_nvidia_device_task_state_is_running(const gchar *state)
 {
-	return g_strcmp0(state, "New") == 0 ||
-	       g_strcmp0(state, "Starting") == 0 ||
-	       g_strcmp0(state, "Running") == 0 ||
-	       g_strcmp0(state, "Suspended") == 0 ||
-	       g_strcmp0(state, "Pending") == 0 ||
-	       g_strcmp0(state, "Stopping") == 0 ||
-	       g_strcmp0(state, "Service") == 0 ||
-	       g_strcmp0(state, "Cancelling") == 0 ||
+	return g_strcmp0(state, "New") == 0 || g_strcmp0(state, "Starting") == 0 ||
+	       g_strcmp0(state, "Running") == 0 || g_strcmp0(state, "Suspended") == 0 ||
+	       g_strcmp0(state, "Pending") == 0 || g_strcmp0(state, "Stopping") == 0 ||
+	       g_strcmp0(state, "Service") == 0 || g_strcmp0(state, "Cancelling") == 0 ||
 	       g_strcmp0(state, "Continue") == 0;
 }
 
-/*
- * Parse TaskState and PercentComplete from a task JSON object.
- * Updates *out_percent (0–100).  On FAILED, also sets @error.
- */
-FuRedfishNvidiaTaskState
+/* parse TaskState and PercentComplete from a task JSON object, returning %FALSE
+ * with @error set when the task has failed or cannot be understood */
+gboolean
 fu_redfish_nvidia_device_parse_task(const gchar *task_uri,
 				    FwupdJsonObject *json_task,
-				    guint *out_percent,
+				    FuRedfishNvidiaTaskState *task_state,
+				    guint *percentage,
 				    GError **error)
 {
 	const gchar *state;
 	const gchar *status;
 	gint64 percent = 0;
+
+	g_return_val_if_fail(task_uri != NULL, FALSE);
+	g_return_val_if_fail(json_task != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	state = fwupd_json_object_get_string(json_task, "TaskState", NULL);
 	status = fwupd_json_object_get_string(json_task, "TaskStatus", NULL);
@@ -229,8 +190,8 @@ fu_redfish_nvidia_device_parse_task(const gchar *task_uri,
 							 &percent,
 							 0,
 							 NULL);
-	if (out_percent != NULL)
-		*out_percent = (guint)CLAMP(percent, 0, 100);
+	if (percentage != NULL)
+		*percentage = (guint)CLAMP(percent, 0, 100);
 
 	if (state == NULL) {
 		g_set_error(error,
@@ -238,40 +199,40 @@ fu_redfish_nvidia_device_parse_task(const gchar *task_uri,
 			    FWUPD_ERROR_INVALID_FILE,
 			    "BMC task %s has no TaskState",
 			    task_uri);
-		return FU_REDFISH_NVIDIA_TASK_FAILED;
+		return FALSE;
 	}
 
-	/* TaskStatus=Critical is a fatal condition at any stage — per DMTF DSP0266
-	 * the BMC sets this when the operation has failed, even if TaskState still
-	 * shows Running.  Reject immediately so we do not wait for a state transition
-	 * that will never arrive. */
+	/* per DMTF DSP0266 the BMC sets TaskStatus=Critical once the operation has
+	 * failed, even while TaskState still shows Running, so reject it here rather
+	 * than wait for a state transition that will never arrive */
 	if (g_strcmp0(status, "Critical") == 0) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_WRITE,
 			    "BMC task %s has TaskStatus=Critical (TaskState=%s)",
 			    task_uri,
-			    state != NULL ? state : "?");
-		return FU_REDFISH_NVIDIA_TASK_FAILED;
+			    state);
+		return FALSE;
 	}
 
-	/* Terminal failure states — task will not make further progress. */
-	if (g_strcmp0(state, "Exception") == 0 ||
-	    g_strcmp0(state, "Killed") == 0 ||
-	    g_strcmp0(state, "Cancelled") == 0 ||
-	    g_strcmp0(state, "UserIntervention") == 0 ||
+	/* terminal failure states, where the task will make no further progress */
+	if (g_strcmp0(state, "Exception") == 0 || g_strcmp0(state, "Killed") == 0 ||
+	    g_strcmp0(state, "Cancelled") == 0 || g_strcmp0(state, "UserIntervention") == 0 ||
 	    g_strcmp0(state, "Interrupted") == 0) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_WRITE,
 			    "BMC task %s failed (TaskState=%s)",
 			    task_uri,
-			    state != NULL ? state : "?");
-		return FU_REDFISH_NVIDIA_TASK_FAILED;
+			    state);
+		return FALSE;
 	}
 
-	if (g_strcmp0(state, "Completed") == 0)
-		return FU_REDFISH_NVIDIA_TASK_COMPLETED;
+	if (g_strcmp0(state, "Completed") == 0) {
+		if (task_state != NULL)
+			*task_state = FU_REDFISH_NVIDIA_TASK_COMPLETED;
+		return TRUE;
+	}
 
 	if (!fu_redfish_nvidia_device_task_state_is_running(state)) {
 		g_set_error(error,
@@ -280,281 +241,331 @@ fu_redfish_nvidia_device_parse_task(const gchar *task_uri,
 			    "BMC task %s has unknown TaskState=%s",
 			    task_uri,
 			    state);
-		return FU_REDFISH_NVIDIA_TASK_FAILED;
+		return FALSE;
 	}
 
-	/* Some GB300 BMC versions report 100% before changing a known running state. */
-	if (percent == 100)
-		return FU_REDFISH_NVIDIA_TASK_COMPLETED;
-
-	return FU_REDFISH_NVIDIA_TASK_RUNNING;
+	/* some GB300 BMC versions report 100% before leaving a known running state */
+	if (task_state != NULL) {
+		*task_state = percent == 100 ? FU_REDFISH_NVIDIA_TASK_COMPLETED
+					     : FU_REDFISH_NVIDIA_TASK_RUNNING;
+	}
+	return TRUE;
 }
 
-static FuRedfishNvidiaTaskResponse
+/*
+ * Poll @uri once and classify the result.
+ *
+ * Returns %TRUE when @response is TASK or REAPED, and %FALSE with @error set
+ * otherwise. FWUPD_ERROR_BUSY marks the conditions the caller may retry; every
+ * other error code aborts the poll.
+ */
+static gboolean
 fu_redfish_nvidia_device_poll_request(FuRedfishBackend *backend,
 				      const gchar *uri,
 				      gboolean allow_empty_200,
-				      FwupdJsonObject **out_json,
+				      FuRedfishNvidiaTaskResponse *response,
+				      FwupdJsonObject **json_task,
 				      GError **error)
 {
-	g_autoptr(FuRedfishRequest) request = fu_redfish_backend_request_new(backend);
-	g_autoptr(FwupdJsonObject) json_task = NULL;
-	g_autoptr(GError) error_local = NULL;
-	FuRedfishNvidiaTaskResponse response;
 	gboolean request_succeeded;
 	glong status_code;
+	g_autoptr(FuRedfishRequest) request = fu_redfish_backend_request_new(backend);
+	g_autoptr(FwupdJsonObject) json_tmp = NULL;
+	g_autoptr(GError) error_local = NULL;
 
-	g_return_val_if_fail(out_json != NULL, FU_REDFISH_NVIDIA_TASK_RESPONSE_FATAL);
-	g_return_val_if_fail(*out_json == NULL, FU_REDFISH_NVIDIA_TASK_RESPONSE_FATAL);
+	g_return_val_if_fail(response != NULL, FALSE);
+	g_return_val_if_fail(json_task != NULL, FALSE);
+	g_return_val_if_fail(*json_task == NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	request_succeeded =
-	    fu_redfish_request_perform(request,
-				       uri,
-				       FU_REDFISH_REQUEST_PERFORM_FLAG_LOAD_JSON,
-				       &error_local);
+	request_succeeded = fu_redfish_request_perform(request,
+						       uri,
+						       FU_REDFISH_REQUEST_PERFORM_FLAG_LOAD_JSON,
+						       &error_local);
 	status_code = fu_redfish_request_get_status_code(request);
-	json_task = fu_redfish_request_get_json_object(request);
-	response = fu_redfish_nvidia_device_classify_task_response(status_code,
-							    request_succeeded,
-							    json_task != NULL,
-							    allow_empty_200);
+	json_tmp = fu_redfish_request_get_json_object(request);
+	*response = fu_redfish_nvidia_device_classify_task_response(status_code,
+								    request_succeeded,
+								    json_tmp != NULL,
+								    allow_empty_200);
 
-	if (response == FU_REDFISH_NVIDIA_TASK_RESPONSE_TASK) {
-		*out_json = g_steal_pointer(&json_task);
-		return response;
+	if (*response == FU_REDFISH_NVIDIA_TASK_RESPONSE_TASK) {
+		*json_task = g_steal_pointer(&json_tmp);
+		return TRUE;
 	}
-	if (response == FU_REDFISH_NVIDIA_TASK_RESPONSE_REAPED)
-		return response;
-
-	if (response == FU_REDFISH_NVIDIA_TASK_RESPONSE_FATAL &&
-	    (status_code == 401 || status_code == 403)) {
-		g_clear_error(&error_local);
+	if (*response == FU_REDFISH_NVIDIA_TASK_RESPONSE_REAPED)
+		return TRUE;
+	if (*response == FU_REDFISH_NVIDIA_TASK_RESPONSE_TRANSIENT) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_BUSY,
+			    "transient HTTP %li polling task %s: %s",
+			    status_code,
+			    uri,
+			    error_local != NULL ? error_local->message : "no error detail");
+		return FALSE;
+	}
+	if (status_code == 401 || status_code == 403) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_AUTH_FAILED,
 			    "authentication failed with HTTP %li polling task %s",
 			    status_code,
 			    uri);
-		return response;
+		return FALSE;
 	}
 	if (error_local != NULL) {
 		g_propagate_error(error, g_steal_pointer(&error_local));
-		return response;
+		return FALSE;
 	}
-	if (response == FU_REDFISH_NVIDIA_TASK_RESPONSE_TRANSIENT) {
-		g_set_error(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_WRITE,
-			    "transient HTTP %li polling task %s",
-			    status_code,
-			    uri);
-		return response;
-	}
-
 	g_set_error(error,
 		    FWUPD_ERROR,
 		    FWUPD_ERROR_WRITE,
 		    "unexpected HTTP %li polling task %s",
 		    status_code,
 		    uri);
-	return response;
-}
-
-/*
- * Poll a Redfish TaskMonitor URI until the task completes, fails, or times out.
- *
- * Handles GB300-specific task lifecycle:
- *   - HTTP 200 + empty body signals TaskMonitor reaped (not a canonical 404);
- *     both are treated as "Monitor URI gone, try /Tasks/<id>".
- *   - If the persistent /Tasks/<id> is also gone after at least one successful
- *     poll, the BMC has completed the full PLDM activation lifecycle and reaped
- *     all task resources — treat as Completed.
- */
-static gboolean
-fu_redfish_nvidia_device_poll_task(FuRedfishNvidiaDevice *self,
-				   FuRedfishBackend *backend,
-				   const gchar *initial_location,
-				   FuProgress *progress,
-				   GError **error)
-{
-	/* On the GB300 BMC, PercentComplete is only updated on the persistent
-	 * /Tasks/<id> resource, not on the /Tasks/<id>/Monitor sub-resource.
-	 * Prefer the persistent URI for polling, but keep the monitor URI so
-	 * we can detect its reap separately and use it as a fallback if the
-	 * persistent URI was not yet created.  A newly accepted upload may
-	 * need a few seconds before /Tasks/<id> appears. */
-	g_autofree gchar *monitor_uri = g_strdup(initial_location);
-	g_autofree gchar *persistent_uri =
-	    fu_redfish_nvidia_device_derive_task_uri(initial_location);
-	g_autofree gchar *task_uri =
-	    persistent_uri ? g_steal_pointer(&persistent_uri)
-			   : g_strdup(initial_location);
-	/* Grace-period counter: allow N attempts before giving up on a task
-	 * that has not appeared yet (persistent URI returns 404 immediately). */
-	const guint task_creation_grace = 5;
-	const guint poll_interval_ms = 2000;
-	/* 1800 attempts × 2 s = 60 min, covering worst-case GB300 bundle flash. */
-	const guint max_attempts = 1800;
-	/* True only after the persistent /Tasks/<id> URI has returned at least
-	 * one valid JSON body with a recognised TaskState.  Used to distinguish
-	 * "task reaped after completing" from "task never existed".  The monitor
-	 * URI returning a live response does NOT set this flag — only the
-	 * persistent resource does. */
-	gboolean saw_persistent_task = FALSE;
-	/* Reset to 0 after each successful poll; abort only after this many
-	 * consecutive failures to tolerate short network blips mid-update. */
-	guint consecutive_errors = 0;
-
-	g_message("NvidiaOob: polling task %s (up to %u s)",
-		  task_uri, max_attempts * poll_interval_ms / 1000);
-
-	for (guint attempt = 0; attempt < max_attempts; attempt++) {
-		guint percent = 0;
-		FuRedfishNvidiaTaskState ts;
-		FuRedfishNvidiaTaskResponse response;
-		g_autoptr(FwupdJsonObject) json_task = NULL;
-		g_autoptr(GError) err_local = NULL;
-
-		fu_device_sleep(FU_DEVICE(self), poll_interval_ms);
-
-		response = fu_redfish_nvidia_device_poll_request(backend,
-							 task_uri,
-							 g_str_has_suffix(task_uri, "/Monitor"),
-							 &json_task,
-							 &err_local);
-		if (response == FU_REDFISH_NVIDIA_TASK_RESPONSE_TASK) {
-			ts = fu_redfish_nvidia_device_parse_task(
-			    task_uri, json_task, &percent, &err_local);
-			fu_progress_set_percentage(progress, percent);
-			if (ts == FU_REDFISH_NVIDIA_TASK_FAILED) {
-				g_message("NvidiaOob: task failed at %s", task_uri);
-				g_propagate_error(error, g_steal_pointer(&err_local));
-				return FALSE;
-			}
-			if (!g_str_has_suffix(task_uri, "/Monitor"))
-				saw_persistent_task = TRUE;
-			consecutive_errors = 0;
-			/* Log progress every 60 s. */
-			if (attempt % 30 == 0)
-				g_message("NvidiaOob: task poll #%u — %u%% complete "
-					  "(~%u s elapsed)",
-					  attempt + 1,
-					  percent,
-					  (attempt + 1) * poll_interval_ms / 1000);
-			if (ts == FU_REDFISH_NVIDIA_TASK_COMPLETED) {
-				g_message("NvidiaOob: task completed at %u%%", percent);
-				fu_progress_set_percentage(progress, 100);
-				return TRUE;
-			}
-			continue;
-		}
-
-		if (response == FU_REDFISH_NVIDIA_TASK_RESPONSE_FATAL) {
-			g_propagate_error(error, g_steal_pointer(&err_local));
-			return FALSE;
-		}
-
-		/* If the persistent task is gone, validate the monitor before declaring
-		 * success.  A live monitor can still report a terminal failure. */
-		if (response == FU_REDFISH_NVIDIA_TASK_RESPONSE_REAPED) {
-			if (monitor_uri != NULL && !g_str_equal(task_uri, monitor_uri)) {
-				g_autoptr(FwupdJsonObject) monitor_json = NULL;
-				g_autoptr(GError) monitor_error = NULL;
-				FuRedfishNvidiaTaskResponse monitor_response =
-				    fu_redfish_nvidia_device_poll_request(backend,
-								  monitor_uri,
-								  TRUE,
-								  &monitor_json,
-								  &monitor_error);
-
-				if (monitor_response == FU_REDFISH_NVIDIA_TASK_RESPONSE_TASK) {
-					guint monitor_percent = 0;
-					FuRedfishNvidiaTaskState monitor_state =
-					    fu_redfish_nvidia_device_parse_task(monitor_uri,
-									monitor_json,
-									&monitor_percent,
-									&monitor_error);
-					fu_progress_set_percentage(progress, monitor_percent);
-					if (monitor_state == FU_REDFISH_NVIDIA_TASK_FAILED) {
-						g_propagate_error(error,
-								  g_steal_pointer(&monitor_error));
-						return FALSE;
-					}
-					if (monitor_state == FU_REDFISH_NVIDIA_TASK_COMPLETED) {
-						fu_progress_set_percentage(progress, 100);
-						return TRUE;
-					}
-					consecutive_errors = 0;
-					g_debug("NvidiaOob: monitor active, waiting for persistent task");
-					continue;
-				}
-				if (monitor_response == FU_REDFISH_NVIDIA_TASK_RESPONSE_FATAL) {
-					g_propagate_error(error, g_steal_pointer(&monitor_error));
-					return FALSE;
-				}
-				if (monitor_response == FU_REDFISH_NVIDIA_TASK_RESPONSE_TRANSIENT) {
-					g_clear_error(&err_local);
-					err_local = g_steal_pointer(&monitor_error);
-					response = monitor_response;
-				} else if (saw_persistent_task) {
-					g_message("NvidiaOob: task and monitor reaped after a valid poll — "
-						  "treating as Completed");
-					fu_progress_set_percentage(progress, 100);
-					return TRUE;
-				}
-			} else if (saw_persistent_task) {
-				g_message("NvidiaOob: task reaped after a valid poll — treating as Completed");
-				fu_progress_set_percentage(progress, 100);
-				return TRUE;
-			}
-
-			if (response == FU_REDFISH_NVIDIA_TASK_RESPONSE_REAPED) {
-				if (attempt < task_creation_grace) {
-					g_debug("NvidiaOob: task not yet visible (attempt %u/%u), retrying",
-						attempt + 1,
-						task_creation_grace);
-					continue;
-				}
-				g_set_error_literal(error,
-						    FWUPD_ERROR,
-						    FWUPD_ERROR_NOT_FOUND,
-						    "task not found after grace period; upload may not "
-						    "have started or task was stale");
-				return FALSE;
-			}
-		}
-
-		/* Transient network blips: allow up to 5 consecutive failures so
-		 * brief connectivity interruptions during a ~20 min update do not
-		 * abort a still-running BMC flash.  The counter resets to 0 after
-		 * each successful poll so intermittent errors are tolerated. */
-		if (++consecutive_errors <= 5) {
-			g_debug("transient poll error (consecutive %u): %s",
-				consecutive_errors,
-				err_local != NULL ? err_local->message : "unknown");
-			continue;
-		}
-
-		if (err_local != NULL)
-			g_propagate_error(error, g_steal_pointer(&err_local));
-		else
-			g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_WRITE,
-					    "poll failed with no error detail");
-		return FALSE;
-	}
-
-	g_set_error(error,
-		    FWUPD_ERROR,
-		    FWUPD_ERROR_TIMED_OUT,
-		    "timed out waiting for BMC task %s after %u seconds",
-		    task_uri,
-		    max_attempts * poll_interval_ms / 1000);
 	return FALSE;
 }
 
-/* ------------------------------------------------------------------ */
-/* FuDevice vfuncs                                                     */
-/* ------------------------------------------------------------------ */
+/*
+ * Account for a failed poll, always returning %FALSE with @error set.
+ *
+ * Transient failures are tolerated so that brief connectivity blips during a
+ * flash lasting tens of minutes do not abandon a still-running update. The
+ * counter is reset by every poll that returns a valid task body, so only
+ * consecutive failures abort.
+ */
+static gboolean
+fu_redfish_nvidia_device_poll_error(FuRedfishNvidiaTaskHelper *helper,
+				    GError *error_local,
+				    GError **error)
+{
+	g_autoptr(GError) error_taken = error_local;
+
+	if (!g_error_matches(error_taken, FWUPD_ERROR, FWUPD_ERROR_BUSY)) {
+		g_propagate_error(error, g_steal_pointer(&error_taken));
+		return FALSE;
+	}
+	if (++helper->consecutive_errors > FU_REDFISH_NVIDIA_TASK_ERRORS_MAX) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_WRITE,
+			    "gave up after %u consecutive poll errors: %s",
+			    helper->consecutive_errors,
+			    error_taken->message);
+		return FALSE;
+	}
+	g_propagate_error(error, g_steal_pointer(&error_taken));
+	return FALSE;
+}
+
+/* the persistent task is gone, so validate the monitor before declaring success
+ * as a live monitor can still report a terminal failure */
+static gboolean
+fu_redfish_nvidia_device_poll_task_reaped(FuRedfishNvidiaTaskHelper *helper, GError **error)
+{
+	FuRedfishNvidiaTaskResponse response;
+	FuRedfishNvidiaTaskState task_state;
+	guint percentage = 0;
+	g_autoptr(FwupdJsonObject) json_task = NULL;
+	g_autoptr(GError) error_local = NULL;
+
+	if (helper->monitor_uri != NULL && !g_str_equal(helper->task_uri, helper->monitor_uri)) {
+		if (!fu_redfish_nvidia_device_poll_request(helper->backend,
+							   helper->monitor_uri,
+							   TRUE,
+							   &response,
+							   &json_task,
+							   &error_local)) {
+			return fu_redfish_nvidia_device_poll_error(helper,
+								   g_steal_pointer(&error_local),
+								   error);
+		}
+		if (response == FU_REDFISH_NVIDIA_TASK_RESPONSE_TASK) {
+			if (!fu_redfish_nvidia_device_parse_task(helper->monitor_uri,
+								 json_task,
+								 &task_state,
+								 &percentage,
+								 error))
+				return FALSE;
+			fu_progress_set_percentage(helper->progress, percentage);
+			if (task_state == FU_REDFISH_NVIDIA_TASK_COMPLETED) {
+				fu_progress_set_percentage(helper->progress, 100);
+				return TRUE;
+			}
+			helper->consecutive_errors = 0;
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_BUSY,
+					    "monitor is active, waiting for the persistent task");
+			return FALSE;
+		}
+	}
+
+	/* both resources are gone after at least one valid poll of the persistent
+	 * task, so the BMC has completed the PLDM activation lifecycle and reaped them */
+	if (helper->saw_persistent_task) {
+		g_debug("task and monitor reaped after a valid poll, treating as completed");
+		fu_progress_set_percentage(helper->progress, 100);
+		return TRUE;
+	}
+
+	if (helper->attempt <= FU_REDFISH_NVIDIA_TASK_CREATION_GRACE) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_BUSY,
+			    "task is not yet visible on poll %u",
+			    helper->attempt);
+		return FALSE;
+	}
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
+			    "task not found after the grace period; the upload may not have "
+			    "started, or the task was stale");
+	return FALSE;
+}
+
+static gboolean
+fu_redfish_nvidia_device_poll_task_once(FuRedfishNvidiaTaskHelper *helper, GError **error)
+{
+	FuRedfishNvidiaTaskResponse response;
+	FuRedfishNvidiaTaskState task_state;
+	gboolean is_monitor = g_str_has_suffix(helper->task_uri, "/Monitor");
+	guint percentage = 0;
+	g_autoptr(FwupdJsonObject) json_task = NULL;
+	g_autoptr(GError) error_local = NULL;
+
+	if (!fu_redfish_nvidia_device_poll_request(helper->backend,
+						   helper->task_uri,
+						   is_monitor,
+						   &response,
+						   &json_task,
+						   &error_local)) {
+		return fu_redfish_nvidia_device_poll_error(helper,
+							   g_steal_pointer(&error_local),
+							   error);
+	}
+	if (response == FU_REDFISH_NVIDIA_TASK_RESPONSE_REAPED)
+		return fu_redfish_nvidia_device_poll_task_reaped(helper, error);
+
+	if (!fu_redfish_nvidia_device_parse_task(helper->task_uri,
+						 json_task,
+						 &task_state,
+						 &percentage,
+						 error))
+		return FALSE;
+	fu_progress_set_percentage(helper->progress, percentage);
+	if (!is_monitor)
+		helper->saw_persistent_task = TRUE;
+	helper->consecutive_errors = 0;
+
+	/* log progress every 60 seconds */
+	if (helper->attempt % 30 == 1) {
+		g_debug("task poll #%u, %u%% complete (~%u s elapsed)",
+			helper->attempt,
+			percentage,
+			helper->attempt * FU_REDFISH_NVIDIA_TASK_POLL_DELAY / 1000);
+	}
+
+	if (task_state == FU_REDFISH_NVIDIA_TASK_COMPLETED) {
+		g_debug("task completed at %u%%", percentage);
+		fu_progress_set_percentage(helper->progress, 100);
+		return TRUE;
+	}
+	g_set_error(error,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_BUSY,
+		    "task %s is %u%% complete",
+		    helper->task_uri,
+		    percentage);
+	return FALSE;
+}
+
+static gboolean
+fu_redfish_nvidia_device_poll_task_cb(FuDevice *device, gpointer user_data, GError **error)
+{
+	FuRedfishNvidiaTaskHelper *helper = (FuRedfishNvidiaTaskHelper *)user_data;
+	g_autoptr(GError) error_local = NULL;
+
+	helper->attempt++;
+	if (fu_redfish_nvidia_device_poll_task_once(helper, &error_local))
+		return TRUE;
+
+	/* fu_device_retry_full() retries any error that has no recovery registered in
+	 * _init(), so normalize everything the poll does not want retried into
+	 * FWUPD_ERROR_WRITE, keeping the original message */
+	if (error_local != NULL && !g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_BUSY) &&
+	    !g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_AUTH_FAILED)) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_WRITE, error_local->message);
+		return FALSE;
+	}
+	g_propagate_error(error, g_steal_pointer(&error_local));
+	return FALSE;
+}
+
+static gboolean
+fu_redfish_nvidia_device_poll_task(FuRedfishNvidiaDevice *self,
+				   FuRedfishBackend *backend,
+				   const gchar *location,
+				   FuProgress *progress,
+				   GError **error)
+{
+	FuRedfishNvidiaTaskHelper helper = {
+	    .backend = backend,
+	    .progress = progress,
+	    .monitor_uri = location,
+	};
+	/* the GB300 BMC only updates PercentComplete on the persistent /Tasks/<id>
+	 * resource, so prefer it for polling but keep the monitor URI to detect its
+	 * reap separately and to fall back to while /Tasks/<id> is being created */
+	g_autofree gchar *persistent_uri = fu_redfish_nvidia_device_derive_task_uri(location);
+
+	helper.task_uri = persistent_uri != NULL ? persistent_uri : location;
+	g_debug("polling task %s for up to %u s",
+		helper.task_uri,
+		FU_REDFISH_NVIDIA_TASK_POLL_CNT * FU_REDFISH_NVIDIA_TASK_POLL_DELAY / 1000);
+	if (!fu_device_retry_full(FU_DEVICE(self),
+				  fu_redfish_nvidia_device_poll_task_cb,
+				  FU_REDFISH_NVIDIA_TASK_POLL_CNT,
+				  FU_REDFISH_NVIDIA_TASK_POLL_DELAY,
+				  &helper,
+				  error)) {
+		g_prefix_error(error, "failed to poll BMC task %s: ", helper.task_uri);
+		return FALSE;
+	}
+	return TRUE;
+}
+
+/*
+ * Has the BMC staged an image for this component that is waiting on the
+ * aux-rail power cycle?
+ *
+ * The OEM slot data is the authoritative answer, and asking the BMC each time
+ * the device is probed means a pending activation survives a daemon restart,
+ * a host reboot, and a same-version reinstall -- none of which the engine's
+ * own history can express.
+ */
+static gboolean
+fu_redfish_nvidia_device_slot_is_pending(FwupdJsonObject *json_member)
+{
+	const gchar *state;
+	g_autoptr(FwupdJsonObject) json_nvidia = NULL;
+	g_autoptr(FwupdJsonObject) json_oem = NULL;
+	g_autoptr(FwupdJsonObject) json_slot = NULL;
+
+	json_oem = fwupd_json_object_get_object(json_member, "Oem", NULL);
+	if (json_oem == NULL)
+		return FALSE;
+	json_nvidia = fwupd_json_object_get_object(json_oem, "Nvidia", NULL);
+	if (json_nvidia == NULL)
+		return FALSE;
+	json_slot = fwupd_json_object_get_object(json_nvidia, "ActiveFirmwareSlot", NULL);
+	if (json_slot == NULL)
+		return FALSE;
+	state = fwupd_json_object_get_string(json_slot, "FirmwareState", NULL);
+	return g_strcmp0(state, "PendingActivation") == 0;
+}
 
 static gboolean
 fu_redfish_nvidia_device_probe(FuDevice *device, GError **error)
@@ -563,13 +574,14 @@ fu_redfish_nvidia_device_probe(FuDevice *device, GError **error)
 	FwupdJsonObject *member;
 	const gchar *inventory_uri;
 	const gchar *software_id;
+	g_autofree gchar *basename = NULL;
 
-	/* Base probe: sets logical_id = @odata.id, vendor, version, name,
-	 * SoftwareId instance IDs (REDFISH\VENDOR\SOFTWAREID), etc. */
+	/* the base probe sets logical_id, vendor, version, name and the
+	 * REDFISH\VENDOR\SOFTWAREID instance IDs */
 	if (!FU_DEVICE_CLASS(fu_redfish_nvidia_device_parent_class)->probe(device, error))
 		return FALSE;
 
-	/* After base probe, logical_id holds the @odata.id inventory URI. */
+	/* after the base probe, logical_id holds the @odata.id inventory URI */
 	inventory_uri = fu_device_get_logical_id(device);
 	if (inventory_uri == NULL) {
 		g_set_error_literal(error,
@@ -579,108 +591,70 @@ fu_redfish_nvidia_device_probe(FuDevice *device, GError **error)
 		return FALSE;
 	}
 
-	/*
-	 * Override the device name with the inventory URI basename (e.g.
-	 * FW_BMC_0, FW_GPU_0, FW_CPU_0).  The BMC's JSON "Name" field returns
-	 * "Software Inventory" for every entry — identical for all 12+ OOB
-	 * components — making each device indistinguishable by name.  The
-	 * basename is unique, operator-meaningful, and matches LVFS CAB labels.
-	 */
-	{
-		g_autofree gchar *basename = g_path_get_basename(inventory_uri);
-		if (basename != NULL && basename[0] != '\0' &&
-		    g_strcmp0(basename, ".") != 0 && g_strcmp0(basename, "/") != 0)
-			fu_device_set_name(device, basename);
-	}
+	/* the BMC returns Name="Software Inventory" for every entry, which makes all
+	 * 12+ OOB components indistinguishable; the inventory URI basename is unique
+	 * and operator-meaningful, and fu_device_set_name() renders the underscores
+	 * as spaces */
+	basename = g_path_get_basename(inventory_uri);
+	if (basename != NULL && basename[0] != '\0' && g_strcmp0(basename, ".") != 0 &&
+	    g_strcmp0(basename, "/") != 0)
+		fu_device_set_name(device, basename);
 
-	/*
-	 * URI-derived instance ID — globally unique per FirmwareInventory entry.
-	 * Primary match key for per-device LVFS CABs targeting a specific
-	 * component.  The explicit add_guid() call registers the UUID-v5 hash
-	 * immediately so the engine sees a GUID right after coldplug; the
-	 * add_instance_id() call produces the display mapping in get-devices.
-	 */
-	{
-		g_autofree gchar *iid =
-		    g_strdup_printf("NVIDIA_OOB\\URI_%s", inventory_uri);
-		fu_device_add_instance_id(device, iid);
-	}
+	/* globally unique per FirmwareInventory entry, and the primary match key for
+	 * a per-device LVFS CAB targeting one component */
+	fu_device_add_instance_str(device, "URI", inventory_uri);
+	if (!fu_device_build_instance_id(device, error, "NVIDIA_OOB", "URI", NULL))
+		return FALSE;
 
-	/*
-	 * SoftwareId-derived instance ID — allows a unified-image CAB to target
-	 * multiple components that share a SoftwareId (e.g. FW_ERoT_CPU_0 and
-	 * FW_ERoT_FPGA_0 both carry SoftwareId=0xFF00 in NVIDIA's PLDM bundle).
-	 */
+	/* lets a unified-image CAB target multiple components sharing a SoftwareId,
+	 * e.g. FW_ERoT_CPU_0 and FW_ERoT_FPGA_0 both carry SoftwareId=0xFF00 */
 	member = fu_redfish_device_get_json_obj_member(rdev);
 	if (member != NULL) {
 		software_id = fwupd_json_object_get_string(member, "SoftwareId", NULL);
 		if (software_id != NULL && software_id[0] != '\0') {
-			g_autofree gchar *iid =
-			    g_strdup_printf("NVIDIA_OOB\\SWID_%s", software_id);
-			fu_device_add_instance_id(device, iid);
+			fu_device_add_instance_str(device, "SWID", software_id);
+			if (!fu_device_build_instance_id(device, error, "NVIDIA_OOB", "SWID", NULL))
+				return FALSE;
 		}
+		if (fu_redfish_nvidia_device_slot_is_pending(member))
+			fu_device_add_flag(device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
 	}
 
-	/*
-	 * Vendor IDs for LVFS CAB signature validation.  DMI:NVIDIA pairs with
-	 * the GB300 system's SMBIOS identity; OEM:NVIDIA is the non-bus fallback
-	 * since OOB-managed components have no PCI/USB/NVMe identity on the host.
-	 */
+	/* DMI:NVIDIA pairs with the GB300 SMBIOS identity, and OEM:NVIDIA is the
+	 * non-bus fallback as OOB-managed components have no host bus identity */
 	fu_device_add_vendor_id(device, "DMI:NVIDIA");
 	fu_device_add_vendor_id(device, "OEM:NVIDIA");
 
-	/*
-	 * 15-minute install duration covers the worst-case scenario: full PLDM
-	 * bundle flash across all components (BMC, SBIOS, GPU, CX, ERoT, MCU).
-	 * An overestimate is far less confusing than an underestimate given that
-	 * the BMC's PLDM verification + per-component fan-out runs ~10 minutes.
-	 */
-	/* GB300 PLDM bundle flash covers all components and takes ~20 minutes
-	 * in practice; 45 minutes gives headroom for slower runs. */
+	/* the backend replaces this with MaxImageSizeBytes when the BMC reports one */
+	fu_device_set_firmware_size_max(device, FU_REDFISH_NVIDIA_FIRMWARE_SIZE_MAX);
+
+	/* a full PLDM bundle flash across all components takes ~20 minutes in
+	 * practice, and 45 minutes leaves headroom for slower runs */
 	fu_device_set_install_duration(device, 2700);
 	fu_device_set_summary(device, "OOB-managed firmware (activates on AC cycle)");
 
 	return TRUE;
 }
 
+/*
+ * The PLDM bundle is an opaque blob of about 117MB, which is larger than the
+ * FuFirmware base-class parse ceiling of FU_FIRMWARE_SIZE_MAX_DEFAULT, so read
+ * it straight into a FuFirmware rather than parsing it. The real limit is the
+ * device firmware size max set in probe(), which fu_device_prepare_firmware()
+ * applies to the result.
+ */
 static FuFirmware *
 fu_redfish_nvidia_device_prepare_firmware(FuDevice *device,
-					  GInputStream *stream,
+					  FuInputStream *stream,
 					  FuProgress *progress,
 					  FuFirmwareParseFlags flags,
 					  GError **error)
 {
 	g_autoptr(GBytes) blob = NULL;
-	gsize max_sz;
-	gsize read_sz;
 
-	/* Use the BMC-reported FirmwareSizeMax when available (the base class
-	 * probe reads it from the UpdateService resource); otherwise use a finite
-	 * 256 MiB ceiling to prevent runaway allocations on corrupt input. Read one
-	 * byte beyond the limit so oversized payloads are rejected, never silently
-	 * truncated to an apparently valid image. */
-	max_sz = fu_device_get_firmware_size_max(device);
-	if (max_sz == 0)
-		max_sz = 256u * 1024u * 1024u;
-	read_sz = max_sz < G_MAXSIZE ? max_sz + 1 : max_sz;
-	blob = fu_input_stream_read_bytes(stream, 0, read_sz, progress, error);
+	blob = fu_input_stream_read_bytes(stream, 0, G_MAXSIZE, progress, error);
 	if (blob == NULL)
 		return NULL;
-	if (g_bytes_get_size(blob) > max_sz) {
-		g_set_error(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_INVALID_FILE,
-			    "firmware payload exceeds maximum size of %" G_GSIZE_FORMAT " bytes",
-			    max_sz);
-		return NULL;
-	}
-	if (g_bytes_get_size(blob) == 0) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_INVALID_FILE,
-				    "firmware payload is empty");
-		return NULL;
-	}
 	return fu_firmware_new_from_bytes(blob);
 }
 
@@ -696,18 +670,16 @@ fu_redfish_nvidia_device_write_firmware(FuDevice *device,
 	curl_mimepart *part;
 	g_autofree gchar *location = NULL;
 	g_autoptr(FuRedfishRequest) request = NULL;
+	g_autoptr(FwupdJsonArray) json_targets = fwupd_json_array_new();
+	g_autoptr(FwupdJsonObject) json_params = fwupd_json_object_new();
+	g_autoptr(FwupdRequest) request_activate = fwupd_request_new();
 	g_autoptr(GBytes) fw = NULL;
 	g_autoptr(GString) params = NULL;
 	g_autoptr(curl_mime) mime = NULL;
 
-	/*
-	 * Two sub-steps inside the "write" phase:
-	 *   upload (5%)  — multipart POST; fast (~30 s for a ~117 MB bundle)
-	 *   bmc-apply (95%) — PLDM verify + per-component fan-out (~10 min)
-	 * Weighting 5/95 keeps fwupdmgr's rate-based ETA accurate: an ETA
-	 * extrapolated at end-of-upload works out to ~10 min for the remaining
-	 * 95%, matching install_duration.
-	 */
+	/* the upload is fast (~30s for a ~117MB bundle) and the BMC-side PLDM verify
+	 * and per-component fan-out takes ~10 minutes, so weighting the two steps
+	 * 5/95 keeps the rate-based ETA from fwupdmgr close to install_duration */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 5, "upload");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 95, "bmc-apply");
@@ -716,26 +688,15 @@ fu_redfish_nvidia_device_write_firmware(FuDevice *device,
 	if (fw == NULL)
 		return FALSE;
 
-	/*
-	 * UpdateParameters JSON:
-	 *   Targets: []          — empty; BMC resolves components from the PLDM
-	 *                          bundle manifest.  Passing logical_id causes 400.
-	 *   ForceUpdate: true    — required to bypass the BMC's same-version check.
-	 *   OperationApplyTime:  — "Immediate" is the only accepted value; the BMC
-	 *     "Immediate"          rejects "OnReset" with 400 InvalidValue.
-	 */
-	{
-		g_autoptr(FwupdJsonObject) json_params = fwupd_json_object_new();
-		g_autoptr(FwupdJsonArray) json_targets = fwupd_json_array_new();
-		fwupd_json_object_add_array(json_params, "Targets", json_targets);
-		fwupd_json_object_add_boolean(json_params, "ForceUpdate", TRUE);
-		fwupd_json_object_add_string(json_params,
-					     "@Redfish.OperationApplyTime",
-					     "Immediate");
-		params = fwupd_json_object_to_string(json_params, FWUPD_JSON_EXPORT_FLAG_INDENT);
-	}
+	/* Targets is empty as the BMC resolves components from the PLDM bundle
+	 * manifest, ForceUpdate bypasses the same-version check, and Immediate is
+	 * the only OperationApplyTime the BMC accepts */
+	fwupd_json_object_add_array(json_params, "Targets", json_targets);
+	fwupd_json_object_add_boolean(json_params, "ForceUpdate", TRUE);
+	fwupd_json_object_add_string(json_params, "@Redfish.OperationApplyTime", "Immediate");
+	params = fwupd_json_object_to_string(json_params, FWUPD_JSON_EXPORT_FLAG_INDENT);
 
-	/* Build the multipart POST. */
+	/* build the multipart POST */
 	backend = fu_redfish_device_get_backend(FU_REDFISH_DEVICE(device), error);
 	if (backend == NULL)
 		return FALSE;
@@ -760,12 +721,12 @@ fu_redfish_nvidia_device_write_firmware(FuDevice *device,
 			       CURLOPT_HEADERFUNCTION,
 			       fu_redfish_nvidia_device_location_header_cb);
 	(void)curl_easy_setopt(curl, CURLOPT_HEADERDATA, &location);
-	/* 600 s upload timeout: ~117 MB over USB-OOB at ~1–2 MB/s. */
+	/* ~117MB over USB-OOB at ~1-2MB/s */
 	(void)curl_easy_setopt(curl, CURLOPT_TIMEOUT, (glong)600);
 
-	g_message("NvidiaOob: uploading firmware (%.1f MB) to %s",
-	       (double)g_bytes_get_size(fw) / (1000.0 * 1000.0),
-	       fu_redfish_backend_get_push_uri_path(backend));
+	g_debug("uploading firmware (%.1f MB) to %s",
+		(double)g_bytes_get_size(fw) / (1000.0 * 1000.0),
+		fu_redfish_backend_get_push_uri_path(backend));
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
 	if (!fu_redfish_request_perform(request,
 					fu_redfish_backend_get_push_uri_path(backend),
@@ -780,12 +741,17 @@ fu_redfish_nvidia_device_write_firmware(FuDevice *device,
 			    fu_redfish_request_get_status_code(request));
 		return FALSE;
 	}
-	g_message("NvidiaOob: upload accepted (HTTP 202) — waiting for TaskMonitor");
 
-	/* Prefer Location: header; fall back to @odata.id in the response body. */
+	/* prefer the Location header, falling back to @odata.id in the response body */
 	if (location == NULL || location[0] == '\0') {
-		FwupdJsonObject *json_resp = fu_redfish_request_get_json_object(request);
-		if (!fwupd_json_object_has_node(json_resp, "@odata.id")) {
+		g_autoptr(FwupdJsonObject) json_resp = fu_redfish_request_get_json_object(request);
+		const gchar *odata_id = NULL;
+
+		/* check the parsed value rather than has_node(), as the node may be
+		 * present but not a string, which would leave location NULL */
+		if (json_resp != NULL)
+			odata_id = fwupd_json_object_get_string(json_resp, "@odata.id", NULL);
+		if (odata_id == NULL || odata_id[0] == '\0') {
 			g_set_error(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_NOT_SUPPORTED,
@@ -794,11 +760,10 @@ fu_redfish_nvidia_device_write_firmware(FuDevice *device,
 			return FALSE;
 		}
 		g_free(location);
-		location =
-		    g_strdup(fwupd_json_object_get_string(json_resp, "@odata.id", NULL));
+		location = g_strdup(odata_id);
 	}
-	g_message("NvidiaOob: TaskMonitor location: %s", location);
-	fu_progress_step_done(progress); /* upload */
+	g_debug("TaskMonitor location: %s", location);
+	fu_progress_step_done(progress);
 
 	if (!fu_redfish_nvidia_device_poll_task(FU_REDFISH_NVIDIA_DEVICE(device),
 						backend,
@@ -806,78 +771,165 @@ fu_redfish_nvidia_device_write_firmware(FuDevice *device,
 						fu_progress_get_child(progress),
 						error))
 		return FALSE;
-	fu_progress_step_done(progress); /* bmc-apply */
-	return TRUE;
+	fu_progress_step_done(progress);
+
+	/* the upload only stages the firmware; it becomes active when the BMC cycles
+	 * the aux rail, which activate() asks it to do.
+	 *
+	 * This is deliberately here rather than in attach(), which the engine also
+	 * runs after a failed write to return the device to runtime -- marking a
+	 * failed update as pending activation would ask the user to power-cycle the
+	 * machine for firmware that was never staged.
+	 *
+	 * Deliberately not NEEDS_SHUTDOWN either: that makes the client offer a soft
+	 * poweroff, which leaves the aux rail energised and so activates nothing,
+	 * while steering the user away from the activation that does work. */
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
+	fwupd_request_set_kind(request_activate, FWUPD_REQUEST_KIND_POST);
+	fwupd_request_set_id(request_activate, FWUPD_REQUEST_ID_REPLUG_POWER);
+	fwupd_request_add_flag(request_activate, FWUPD_REQUEST_FLAG_NON_GENERIC_MESSAGE);
+	fwupd_request_set_message(request_activate,
+				  "The staged firmware becomes active after an aux-rail power "
+				  "cycle. Run `fwupdmgr activate` to ask the BMC to cycle the "
+				  "rail, which powers the system off immediately -- save your "
+				  "work first.");
+	return fu_device_emit_request(device, request_activate, progress, error);
 }
 
-static gboolean
-fu_redfish_nvidia_device_attach(FuDevice *device, FuProgress *progress, GError **error)
+/* return the target of the OEM AuxPowerReset action advertised by @json_chassis */
+static gchar *
+fu_redfish_nvidia_device_chassis_reset_uri(FwupdJsonObject *json_chassis)
 {
-	/*
-	 * GB300 OOB firmware is staged by the upload but only becomes active
-	 * after an aux-rail (AC) power cycle.  Use fwupd's canonical activation
-	 * flow: set NEEDS_ACTIVATION so `fwupdmgr activate` can be called, and
-	 * document the manual procedure in update_message.
-	 *
-	 * We do NOT attempt to drive the cycle automatically:
-	 *   - The BMC's NvidiaChassis.AuxPowerReset OEM action requires the
-	 *     chassis to already be powered off.
-	 *   - Issuing a chassis PowerOff kills this process before any follow-up
-	 *     POST can fire.
-	 * The activate() vfunc below surfaces this as NEEDS_USER_ACTION.
-	 */
-	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
-	fu_device_set_update_message(
-	    device,
-	    "An AC (aux-rail) power cycle is required to activate the staged firmware:\n"
-	    "  1. sudo poweroff\n"
-	    "  2. After the host is fully off, physically unplug AC for at least 30 s\n"
-	    "  3. Reconnect AC and power on — staged firmware will be active on next boot");
-	return TRUE;
+	const gchar *target;
+	g_autoptr(FwupdJsonObject) json_actions = NULL;
+	g_autoptr(FwupdJsonObject) json_oem = NULL;
+	g_autoptr(FwupdJsonObject) json_reset = NULL;
+
+	json_actions = fwupd_json_object_get_object(json_chassis, "Actions", NULL);
+	if (json_actions == NULL)
+		return NULL;
+	json_oem = fwupd_json_object_get_object(json_actions, "Oem", NULL);
+	if (json_oem == NULL)
+		return NULL;
+	json_reset = fwupd_json_object_get_object(json_oem, "#NvidiaChassis.AuxPowerReset", NULL);
+	if (json_reset == NULL)
+		return NULL;
+	target = fwupd_json_object_get_string(json_reset, "target", NULL);
+	if (target == NULL || target[0] == '\0')
+		return NULL;
+	return g_strdup(target);
+}
+
+/* read the action target from the BMC chassis rather than building the URI here,
+ * so that a BMC which moves the action still works */
+static gchar *
+fu_redfish_nvidia_device_find_reset_uri(FuRedfishBackend *backend, GError **error)
+{
+	g_autofree gchar *reset_uri = NULL;
+	g_autoptr(FuRedfishRequest) request = fu_redfish_backend_request_new(backend);
+	g_autoptr(FwupdJsonObject) json_chassis = NULL;
+
+	if (!fu_redfish_request_perform(request,
+					FU_REDFISH_NVIDIA_CHASSIS_URI,
+					FU_REDFISH_REQUEST_PERFORM_FLAG_LOAD_JSON,
+					error))
+		return NULL;
+	json_chassis = fu_redfish_request_get_json_object(request);
+	if (json_chassis != NULL)
+		reset_uri = fu_redfish_nvidia_device_chassis_reset_uri(json_chassis);
+	if (reset_uri == NULL) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "%s does not advertise NvidiaChassis.AuxPowerReset",
+			    FU_REDFISH_NVIDIA_CHASSIS_URI);
+		return NULL;
+	}
+	return g_steal_pointer(&reset_uri);
 }
 
 static gboolean
 fu_redfish_nvidia_device_activate(FuDevice *device, FuProgress *progress, GError **error)
 {
-	/*
-	 * `fwupdmgr activate` dispatches here.  We cannot drive the AC cycle
-	 * from the host (see attach() comment) so we return NEEDS_USER_ACTION
-	 * with the full manual procedure.  fwupdmgr surfaces this as an error
-	 * message; the user acts out of band.
-	 */
-	g_set_error_literal(
-	    error,
-	    FWUPD_ERROR,
-	    FWUPD_ERROR_NEEDS_USER_ACTION,
-	    "Activation cannot be performed automatically on this hardware.\n"
-	    "An AC (aux-rail) power cycle is required and must be done out of band:\n"
-	    "  1. sudo poweroff\n"
-	    "  2. After the host is fully off, physically unplug AC for at least 30 s\n"
-	    "  3. Reconnect AC and power on — staged firmware will be active on next boot.\n"
-	    "Reason: the BMC's NvidiaChassis.AuxPowerReset OEM action is gated on "
-	    "chassis-off, and the chassis-off step kills this process before a "
-	    "follow-up POST can fire.");
-	return FALSE;
+	FuRedfishBackend *backend;
+	glong status_code;
+	g_autofree gchar *reset_uri = NULL;
+	g_autoptr(FuRedfishRequest) request = NULL;
+	g_autoptr(FwupdJsonObject) json_obj = fwupd_json_object_new();
+	g_autoptr(GError) error_local = NULL;
+
+	backend = fu_redfish_device_get_backend(FU_REDFISH_DEVICE(device), error);
+	if (backend == NULL)
+		return FALSE;
+	reset_uri = fu_redfish_nvidia_device_find_reset_uri(backend, error);
+	if (reset_uri == NULL)
+		return FALSE;
+
+	/* AuxPowerCycleForce does not wait for the host to shut down and drops the
+	 * rail powering this process, so flush the filesystems while we still can */
+	sync();
+
+	fwupd_json_object_add_string(json_obj, "ResetType", "AuxPowerCycleForce");
+	request = fu_redfish_backend_request_new(backend);
+	g_debug("requesting aux power cycle via %s", reset_uri);
+	if (!fu_redfish_request_perform_full(request,
+					     reset_uri,
+					     "POST",
+					     json_obj,
+					     FU_REDFISH_REQUEST_PERFORM_FLAG_NONE,
+					     &error_local)) {
+		/* the BMC drops the rail as it acts on the request, so losing the
+		 * connection before any status arrives is the expected outcome */
+		if (fu_redfish_request_get_status_code(request) == 0) {
+			g_debug("connection lost as the aux rail dropped: %s",
+				error_local->message);
+			return TRUE;
+		}
+		g_propagate_error(error, g_steal_pointer(&error_local));
+		g_prefix_error_literal(error, "failed to request aux power cycle: ");
+		return FALSE;
+	}
+
+	/* fu_redfish_request_perform() only rejects HTTP 401, so check the status here
+	 * rather than report a rejected action as a successful activation */
+	status_code = fu_redfish_request_get_status_code(request);
+	if (status_code != 200 && status_code != 202 && status_code != 204) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "failed to request aux power cycle: HTTP %li",
+			    status_code);
+		return FALSE;
+	}
+	return TRUE;
 }
 
 static void
 fu_redfish_nvidia_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING,  0, "prepare-fw");
+	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0, "detach");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 100, "write");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0, "attach");
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY,   0, "reload");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 0, "reload");
 }
-
-/* ------------------------------------------------------------------ */
-/* GObject boilerplate                                                 */
-/* ------------------------------------------------------------------ */
 
 static void
 fu_redfish_nvidia_device_init(FuRedfishNvidiaDevice *self)
 {
+	/* a recovery registered without a function makes fu_device_retry_full() abort
+	 * as soon as that error is returned; the task poll normalizes every failure it
+	 * does not want retried into one of these two codes */
+	fu_device_retry_add_recovery(FU_DEVICE(self), FWUPD_ERROR, FWUPD_ERROR_WRITE, NULL);
+	fu_device_retry_add_recovery(FU_DEVICE(self), FWUPD_ERROR, FWUPD_ERROR_AUTH_FAILED, NULL);
+
+	/* write_firmware() explains the aux-rail power cycle in its own words */
+	fu_device_add_request_flag(FU_DEVICE(self), FWUPD_REQUEST_FLAG_NON_GENERIC_MESSAGE);
+
+	/* NEEDS_ACTIVATION is runtime-only, so without this any daemon restart
+	 * between staging and activating would strand the staged firmware */
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_INHERIT_ACTIVATION);
 }
 
 static void
@@ -887,7 +939,6 @@ fu_redfish_nvidia_device_class_init(FuRedfishNvidiaDeviceClass *klass)
 	device_class->probe = fu_redfish_nvidia_device_probe;
 	device_class->prepare_firmware = fu_redfish_nvidia_device_prepare_firmware;
 	device_class->write_firmware = fu_redfish_nvidia_device_write_firmware;
-	device_class->attach = fu_redfish_nvidia_device_attach;
 	device_class->activate = fu_redfish_nvidia_device_activate;
 	device_class->set_progress = fu_redfish_nvidia_device_set_progress;
 }

--- a/plugins/redfish/fu-redfish-nvidia-device.c
+++ b/plugins/redfish/fu-redfish-nvidia-device.c
@@ -1,0 +1,893 @@
+/*
+ * Copyright 2026 NVIDIA Corporation
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+/*
+ * FuRedfishNvidiaDevice — NVIDIA DGX Station GB300 OOB firmware update via Redfish.
+ *
+ * Represents a single component in the BMC's FirmwareInventory (e.g.
+ * /redfish/v1/UpdateService/FirmwareInventory/FW_BMC_0) and implements
+ * the GB300-specific upload + task-monitoring flow:
+ *
+ *   1. Multipart POST to UpdateService/MultipartHttpPushUri:
+ *        UpdateParameters: { "Targets":[], "ForceUpdate":true,
+ *                            "@Redfish.OperationApplyTime":"Immediate" }
+ *        UpdateFile: raw firmware blob
+ *
+ *   2. Poll /redfish/v1/TaskService/Tasks/<id> (the persistent task resource,
+ *      not the /Monitor sub-resource) for PercentComplete and TaskState.
+ *      GB300-specific divergences from DMTF DSP0266:
+ *        - Targets must be an empty array (BMC resolves components from the
+ *          PLDM bundle manifest); passing the logical_id causes a 400 error.
+ *        - ForceUpdate=true is required; the BMC rejects same-version installs.
+ *        - OperationApplyTime "OnReset" is not in the BMC's acceptable-values
+ *          list; "Immediate" must be used.
+ *        - PercentComplete is only updated on /Tasks/<id>, not on
+ *          /Tasks/<id>/Monitor; polling the Monitor always returns 0%.
+ *        - After task completion the BMC returns HTTP 200 + empty body for the
+ *          TaskMonitor instead of the canonical 404 that signals reap; both
+ *          are handled here. When both the Monitor and /Tasks/<id> are gone
+ *          the resource-gone condition is treated as Completed.
+ *
+ *   3. attach() sets NEEDS_ACTIVATION; the firmware is staged and only becomes
+ *      active after an aux-rail (AC) power cycle. The BMC's AuxPowerReset OEM
+ *      action is gated on chassis-off so automation from the host is impossible.
+ *
+ * Instance IDs registered per device (in addition to those from the base class):
+ *   NVIDIA_OOB\URI_<@odata.id>   — always; unique per FirmwareInventory entry
+ *   NVIDIA_OOB\SWID_<SoftwareId> — when present; enables unified-image CABs to
+ *                                   target multiple components by SoftwareId
+ *
+ * Backend detection: fu_redfish_backend_coldplug() sets device_gtype to
+ * FU_TYPE_REDFISH_NVIDIA_DEVICE when the Redfish root Vendor equals "NVIDIA"
+ * or when /redfish/v1/Chassis/Chassis_0 reports Manufacturer="NVIDIA" and
+ * Model contains "GB300" and "Station".
+ *
+ * ── Prerequisites ─────────────────────────────────────────────────────────────
+ *
+ * This plugin consumes a Redfish X-Auth-Token written by the separate
+ * nvidia-host-bmc-interface-setup platform package. That package must be
+ * installed and commissioned before this plugin can enumerate devices.
+ *
+ * The token is read from:
+ *   /run/nvidia-host-bmc-interface/session   (tmpfs, mode 600, root-only)
+ *
+ * If the file is absent fwupd falls back to Basic Auth (username/password
+ * from /etc/fwupd/redfish.conf), which requires a plaintext password on disk.
+ *
+ * ── Build ─────────────────────────────────────────────────────────────────────
+ *
+ *   # Install build dependencies (Ubuntu/Debian)
+ *   sudo apt install -y meson ninja-build pkg-config gettext \
+ *       libusb-1.0-0-dev libglib2.0-dev libcurl4-openssl-dev \
+ *       libjson-glib-dev libxmlb-dev libsqlite3-dev \
+ *       libgnutls28-dev libgirepository1.0-dev netplan.io
+ *
+ *   # Upgrade meson if system version < 0.63.0
+ *   pip3 install --user --break-system-packages "meson>=1.3.0"
+ *   export PATH="$HOME/.local/bin:$PATH"
+ *
+ *   cd ~/fwupd
+ *   meson setup build \
+ *       -Dauto_features=disabled -Ddocs=disabled \
+ *       -Dtests=false -Dman=false
+ *   ninja -C build
+ *
+ * ── Install ───────────────────────────────────────────────────────────────────
+ *
+ *   sudo env PATH="/home/nvidia/.local/bin:$PATH" \
+ *       PYTHONPATH="/home/nvidia/.local/lib/python3.12/site-packages" \
+ *       meson install -C build
+ *
+ *   meson install places a systemd drop-in at
+ *   /etc/systemd/system/fwupd.service.d/nvidia.conf that redirects
+ *   fwupd.service to the newly installed binary and sets --verbose +
+ *   G_MESSAGES_DEBUG=all so plugin log messages appear in journalctl.
+ *
+ *   After install, reload systemd and restart fwupd to pick up the new binary:
+ *
+ *   sudo systemctl daemon-reload
+ *   sudo systemctl restart fwupd.service
+ *   sleep 2
+ *   systemctl status fwupd.service
+ *
+ * ── Verify ────────────────────────────────────────────────────────────────────
+ *
+ *   systemctl status fwupd.service      # confirm our binary is running
+ *   fwupdmgr get-devices               # should list FW_BMC_0, FW_GPU_0, …
+ *   sudo journalctl -u fwupd -f        # live plugin logs during install
+ *
+ * ── Firmware install ──────────────────────────────────────────────────────────
+ *
+ *   sudo fwupdmgr install firmware.cab --allow-reinstall
+ *
+ *   Progress is logged every 60 s:
+ *     NvidiaOob: task poll #31 — 20% complete (~62 s elapsed)
+ *   Typical install time for a full PLDM bundle: ~20 minutes.
+ *   Firmware activates on the next AC (aux-rail) power cycle.
+ */
+
+#include "config.h"
+
+#include <curl/curl.h>
+#include <string.h>
+
+#include "fu-redfish-backend.h"
+#include "fu-redfish-device.h"
+#include "fu-redfish-nvidia-device.h"
+#include "fu-redfish-request.h"
+
+struct _FuRedfishNvidiaDevice {
+	FuRedfishDevice parent_instance;
+};
+
+G_DEFINE_TYPE(FuRedfishNvidiaDevice, fu_redfish_nvidia_device, FU_TYPE_REDFISH_DEVICE)
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(curl_mime, curl_mime_free)
+
+/* ------------------------------------------------------------------ */
+/* Location header capture (same pattern as FuRedfishMultipartDevice) */
+/* ------------------------------------------------------------------ */
+
+static size_t
+fu_redfish_nvidia_device_location_header_cb(char *ptr,
+					    size_t size,
+					    size_t nmemb,
+					    void *userdata)
+{
+	char **location = (char **)userdata;
+	if ((size * nmemb) > 16 && g_ascii_strncasecmp(ptr, "Location:", 9) == 0)
+		*location = g_strndup(ptr + 10, (size * nmemb) - 12);
+	return size * nmemb;
+}
+
+/* ------------------------------------------------------------------ */
+/* Task polling — GB300-specific                                       */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Derive the persistent /Tasks/<id> URI from a /Tasks/<id>/Monitor URI by
+ * stripping the trailing /Monitor segment.  Returns NULL if uri does not end
+ * in /Monitor (caller must check).
+ */
+static gchar *
+fu_redfish_nvidia_device_derive_task_uri(const gchar *monitor_uri)
+{
+	const gchar *suffix = "/Monitor";
+	if (!g_str_has_suffix(monitor_uri, suffix))
+		return NULL;
+	return g_strndup(monitor_uri, strlen(monitor_uri) - strlen(suffix));
+}
+
+FuRedfishNvidiaTaskResponse
+fu_redfish_nvidia_device_classify_task_response(glong status_code,
+						gboolean request_succeeded,
+						gboolean has_json,
+						gboolean allow_empty_200)
+{
+	/* A reap status wins over any body the BMC happens to return. */
+	if (status_code == 404)
+		return FU_REDFISH_NVIDIA_TASK_RESPONSE_REAPED;
+
+	/* These statuses can clear while an update remains active. */
+	if (status_code == 0 || status_code == 408 || status_code == 425 || status_code == 429 ||
+	    status_code >= 500)
+		return FU_REDFISH_NVIDIA_TASK_RESPONSE_TRANSIENT;
+
+	/* Never let task-shaped JSON turn an HTTP error into success. */
+	if (status_code < 200 || status_code >= 300)
+		return FU_REDFISH_NVIDIA_TASK_RESPONSE_FATAL;
+
+	/* A 2xx response that failed transport or JSON validation is not a task. */
+	if (!request_succeeded)
+		return FU_REDFISH_NVIDIA_TASK_RESPONSE_FATAL;
+
+	if (!has_json) {
+		/* This is a documented GB300 quirk of TaskMonitor only. */
+		if (status_code == 200 && allow_empty_200)
+			return FU_REDFISH_NVIDIA_TASK_RESPONSE_REAPED;
+		return FU_REDFISH_NVIDIA_TASK_RESPONSE_TRANSIENT;
+	}
+
+	return FU_REDFISH_NVIDIA_TASK_RESPONSE_TASK;
+}
+
+static gboolean
+fu_redfish_nvidia_device_task_state_is_running(const gchar *state)
+{
+	return g_strcmp0(state, "New") == 0 ||
+	       g_strcmp0(state, "Starting") == 0 ||
+	       g_strcmp0(state, "Running") == 0 ||
+	       g_strcmp0(state, "Suspended") == 0 ||
+	       g_strcmp0(state, "Pending") == 0 ||
+	       g_strcmp0(state, "Stopping") == 0 ||
+	       g_strcmp0(state, "Service") == 0 ||
+	       g_strcmp0(state, "Cancelling") == 0 ||
+	       g_strcmp0(state, "Continue") == 0;
+}
+
+/*
+ * Parse TaskState and PercentComplete from a task JSON object.
+ * Updates *out_percent (0–100).  On FAILED, also sets @error.
+ */
+FuRedfishNvidiaTaskState
+fu_redfish_nvidia_device_parse_task(const gchar *task_uri,
+				    FwupdJsonObject *json_task,
+				    guint *out_percent,
+				    GError **error)
+{
+	const gchar *state;
+	const gchar *status;
+	gint64 percent = 0;
+
+	state = fwupd_json_object_get_string(json_task, "TaskState", NULL);
+	status = fwupd_json_object_get_string(json_task, "TaskStatus", NULL);
+	(void)fwupd_json_object_get_integer_with_default(json_task,
+							 "PercentComplete",
+							 &percent,
+							 0,
+							 NULL);
+	if (out_percent != NULL)
+		*out_percent = (guint)CLAMP(percent, 0, 100);
+
+	if (state == NULL) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_FILE,
+			    "BMC task %s has no TaskState",
+			    task_uri);
+		return FU_REDFISH_NVIDIA_TASK_FAILED;
+	}
+
+	/* TaskStatus=Critical is a fatal condition at any stage — per DMTF DSP0266
+	 * the BMC sets this when the operation has failed, even if TaskState still
+	 * shows Running.  Reject immediately so we do not wait for a state transition
+	 * that will never arrive. */
+	if (g_strcmp0(status, "Critical") == 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_WRITE,
+			    "BMC task %s has TaskStatus=Critical (TaskState=%s)",
+			    task_uri,
+			    state != NULL ? state : "?");
+		return FU_REDFISH_NVIDIA_TASK_FAILED;
+	}
+
+	/* Terminal failure states — task will not make further progress. */
+	if (g_strcmp0(state, "Exception") == 0 ||
+	    g_strcmp0(state, "Killed") == 0 ||
+	    g_strcmp0(state, "Cancelled") == 0 ||
+	    g_strcmp0(state, "UserIntervention") == 0 ||
+	    g_strcmp0(state, "Interrupted") == 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_WRITE,
+			    "BMC task %s failed (TaskState=%s)",
+			    task_uri,
+			    state != NULL ? state : "?");
+		return FU_REDFISH_NVIDIA_TASK_FAILED;
+	}
+
+	if (g_strcmp0(state, "Completed") == 0)
+		return FU_REDFISH_NVIDIA_TASK_COMPLETED;
+
+	if (!fu_redfish_nvidia_device_task_state_is_running(state)) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_FILE,
+			    "BMC task %s has unknown TaskState=%s",
+			    task_uri,
+			    state);
+		return FU_REDFISH_NVIDIA_TASK_FAILED;
+	}
+
+	/* Some GB300 BMC versions report 100% before changing a known running state. */
+	if (percent == 100)
+		return FU_REDFISH_NVIDIA_TASK_COMPLETED;
+
+	return FU_REDFISH_NVIDIA_TASK_RUNNING;
+}
+
+static FuRedfishNvidiaTaskResponse
+fu_redfish_nvidia_device_poll_request(FuRedfishBackend *backend,
+				      const gchar *uri,
+				      gboolean allow_empty_200,
+				      FwupdJsonObject **out_json,
+				      GError **error)
+{
+	g_autoptr(FuRedfishRequest) request = fu_redfish_backend_request_new(backend);
+	g_autoptr(FwupdJsonObject) json_task = NULL;
+	g_autoptr(GError) error_local = NULL;
+	FuRedfishNvidiaTaskResponse response;
+	gboolean request_succeeded;
+	glong status_code;
+
+	g_return_val_if_fail(out_json != NULL, FU_REDFISH_NVIDIA_TASK_RESPONSE_FATAL);
+	g_return_val_if_fail(*out_json == NULL, FU_REDFISH_NVIDIA_TASK_RESPONSE_FATAL);
+
+	request_succeeded =
+	    fu_redfish_request_perform(request,
+				       uri,
+				       FU_REDFISH_REQUEST_PERFORM_FLAG_LOAD_JSON,
+				       &error_local);
+	status_code = fu_redfish_request_get_status_code(request);
+	json_task = fu_redfish_request_get_json_object(request);
+	response = fu_redfish_nvidia_device_classify_task_response(status_code,
+							    request_succeeded,
+							    json_task != NULL,
+							    allow_empty_200);
+
+	if (response == FU_REDFISH_NVIDIA_TASK_RESPONSE_TASK) {
+		*out_json = g_steal_pointer(&json_task);
+		return response;
+	}
+	if (response == FU_REDFISH_NVIDIA_TASK_RESPONSE_REAPED)
+		return response;
+
+	if (response == FU_REDFISH_NVIDIA_TASK_RESPONSE_FATAL &&
+	    (status_code == 401 || status_code == 403)) {
+		g_clear_error(&error_local);
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_AUTH_FAILED,
+			    "authentication failed with HTTP %li polling task %s",
+			    status_code,
+			    uri);
+		return response;
+	}
+	if (error_local != NULL) {
+		g_propagate_error(error, g_steal_pointer(&error_local));
+		return response;
+	}
+	if (response == FU_REDFISH_NVIDIA_TASK_RESPONSE_TRANSIENT) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_WRITE,
+			    "transient HTTP %li polling task %s",
+			    status_code,
+			    uri);
+		return response;
+	}
+
+	g_set_error(error,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_WRITE,
+		    "unexpected HTTP %li polling task %s",
+		    status_code,
+		    uri);
+	return response;
+}
+
+/*
+ * Poll a Redfish TaskMonitor URI until the task completes, fails, or times out.
+ *
+ * Handles GB300-specific task lifecycle:
+ *   - HTTP 200 + empty body signals TaskMonitor reaped (not a canonical 404);
+ *     both are treated as "Monitor URI gone, try /Tasks/<id>".
+ *   - If the persistent /Tasks/<id> is also gone after at least one successful
+ *     poll, the BMC has completed the full PLDM activation lifecycle and reaped
+ *     all task resources — treat as Completed.
+ */
+static gboolean
+fu_redfish_nvidia_device_poll_task(FuRedfishNvidiaDevice *self,
+				   FuRedfishBackend *backend,
+				   const gchar *initial_location,
+				   FuProgress *progress,
+				   GError **error)
+{
+	/* On the GB300 BMC, PercentComplete is only updated on the persistent
+	 * /Tasks/<id> resource, not on the /Tasks/<id>/Monitor sub-resource.
+	 * Prefer the persistent URI for polling, but keep the monitor URI so
+	 * we can detect its reap separately and use it as a fallback if the
+	 * persistent URI was not yet created.  A newly accepted upload may
+	 * need a few seconds before /Tasks/<id> appears. */
+	g_autofree gchar *monitor_uri = g_strdup(initial_location);
+	g_autofree gchar *persistent_uri =
+	    fu_redfish_nvidia_device_derive_task_uri(initial_location);
+	g_autofree gchar *task_uri =
+	    persistent_uri ? g_steal_pointer(&persistent_uri)
+			   : g_strdup(initial_location);
+	/* Grace-period counter: allow N attempts before giving up on a task
+	 * that has not appeared yet (persistent URI returns 404 immediately). */
+	const guint task_creation_grace = 5;
+	const guint poll_interval_ms = 2000;
+	/* 1800 attempts × 2 s = 60 min, covering worst-case GB300 bundle flash. */
+	const guint max_attempts = 1800;
+	/* True only after the persistent /Tasks/<id> URI has returned at least
+	 * one valid JSON body with a recognised TaskState.  Used to distinguish
+	 * "task reaped after completing" from "task never existed".  The monitor
+	 * URI returning a live response does NOT set this flag — only the
+	 * persistent resource does. */
+	gboolean saw_persistent_task = FALSE;
+	/* Reset to 0 after each successful poll; abort only after this many
+	 * consecutive failures to tolerate short network blips mid-update. */
+	guint consecutive_errors = 0;
+
+	g_message("NvidiaOob: polling task %s (up to %u s)",
+		  task_uri, max_attempts * poll_interval_ms / 1000);
+
+	for (guint attempt = 0; attempt < max_attempts; attempt++) {
+		guint percent = 0;
+		FuRedfishNvidiaTaskState ts;
+		FuRedfishNvidiaTaskResponse response;
+		g_autoptr(FwupdJsonObject) json_task = NULL;
+		g_autoptr(GError) err_local = NULL;
+
+		fu_device_sleep(FU_DEVICE(self), poll_interval_ms);
+
+		response = fu_redfish_nvidia_device_poll_request(backend,
+							 task_uri,
+							 g_str_has_suffix(task_uri, "/Monitor"),
+							 &json_task,
+							 &err_local);
+		if (response == FU_REDFISH_NVIDIA_TASK_RESPONSE_TASK) {
+			ts = fu_redfish_nvidia_device_parse_task(
+			    task_uri, json_task, &percent, &err_local);
+			fu_progress_set_percentage(progress, percent);
+			if (ts == FU_REDFISH_NVIDIA_TASK_FAILED) {
+				g_message("NvidiaOob: task failed at %s", task_uri);
+				g_propagate_error(error, g_steal_pointer(&err_local));
+				return FALSE;
+			}
+			if (!g_str_has_suffix(task_uri, "/Monitor"))
+				saw_persistent_task = TRUE;
+			consecutive_errors = 0;
+			/* Log progress every 60 s. */
+			if (attempt % 30 == 0)
+				g_message("NvidiaOob: task poll #%u — %u%% complete "
+					  "(~%u s elapsed)",
+					  attempt + 1,
+					  percent,
+					  (attempt + 1) * poll_interval_ms / 1000);
+			if (ts == FU_REDFISH_NVIDIA_TASK_COMPLETED) {
+				g_message("NvidiaOob: task completed at %u%%", percent);
+				fu_progress_set_percentage(progress, 100);
+				return TRUE;
+			}
+			continue;
+		}
+
+		if (response == FU_REDFISH_NVIDIA_TASK_RESPONSE_FATAL) {
+			g_propagate_error(error, g_steal_pointer(&err_local));
+			return FALSE;
+		}
+
+		/* If the persistent task is gone, validate the monitor before declaring
+		 * success.  A live monitor can still report a terminal failure. */
+		if (response == FU_REDFISH_NVIDIA_TASK_RESPONSE_REAPED) {
+			if (monitor_uri != NULL && !g_str_equal(task_uri, monitor_uri)) {
+				g_autoptr(FwupdJsonObject) monitor_json = NULL;
+				g_autoptr(GError) monitor_error = NULL;
+				FuRedfishNvidiaTaskResponse monitor_response =
+				    fu_redfish_nvidia_device_poll_request(backend,
+								  monitor_uri,
+								  TRUE,
+								  &monitor_json,
+								  &monitor_error);
+
+				if (monitor_response == FU_REDFISH_NVIDIA_TASK_RESPONSE_TASK) {
+					guint monitor_percent = 0;
+					FuRedfishNvidiaTaskState monitor_state =
+					    fu_redfish_nvidia_device_parse_task(monitor_uri,
+									monitor_json,
+									&monitor_percent,
+									&monitor_error);
+					fu_progress_set_percentage(progress, monitor_percent);
+					if (monitor_state == FU_REDFISH_NVIDIA_TASK_FAILED) {
+						g_propagate_error(error,
+								  g_steal_pointer(&monitor_error));
+						return FALSE;
+					}
+					if (monitor_state == FU_REDFISH_NVIDIA_TASK_COMPLETED) {
+						fu_progress_set_percentage(progress, 100);
+						return TRUE;
+					}
+					consecutive_errors = 0;
+					g_debug("NvidiaOob: monitor active, waiting for persistent task");
+					continue;
+				}
+				if (monitor_response == FU_REDFISH_NVIDIA_TASK_RESPONSE_FATAL) {
+					g_propagate_error(error, g_steal_pointer(&monitor_error));
+					return FALSE;
+				}
+				if (monitor_response == FU_REDFISH_NVIDIA_TASK_RESPONSE_TRANSIENT) {
+					g_clear_error(&err_local);
+					err_local = g_steal_pointer(&monitor_error);
+					response = monitor_response;
+				} else if (saw_persistent_task) {
+					g_message("NvidiaOob: task and monitor reaped after a valid poll — "
+						  "treating as Completed");
+					fu_progress_set_percentage(progress, 100);
+					return TRUE;
+				}
+			} else if (saw_persistent_task) {
+				g_message("NvidiaOob: task reaped after a valid poll — treating as Completed");
+				fu_progress_set_percentage(progress, 100);
+				return TRUE;
+			}
+
+			if (response == FU_REDFISH_NVIDIA_TASK_RESPONSE_REAPED) {
+				if (attempt < task_creation_grace) {
+					g_debug("NvidiaOob: task not yet visible (attempt %u/%u), retrying",
+						attempt + 1,
+						task_creation_grace);
+					continue;
+				}
+				g_set_error_literal(error,
+						    FWUPD_ERROR,
+						    FWUPD_ERROR_NOT_FOUND,
+						    "task not found after grace period; upload may not "
+						    "have started or task was stale");
+				return FALSE;
+			}
+		}
+
+		/* Transient network blips: allow up to 5 consecutive failures so
+		 * brief connectivity interruptions during a ~20 min update do not
+		 * abort a still-running BMC flash.  The counter resets to 0 after
+		 * each successful poll so intermittent errors are tolerated. */
+		if (++consecutive_errors <= 5) {
+			g_debug("transient poll error (consecutive %u): %s",
+				consecutive_errors,
+				err_local != NULL ? err_local->message : "unknown");
+			continue;
+		}
+
+		if (err_local != NULL)
+			g_propagate_error(error, g_steal_pointer(&err_local));
+		else
+			g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_WRITE,
+					    "poll failed with no error detail");
+		return FALSE;
+	}
+
+	g_set_error(error,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_TIMED_OUT,
+		    "timed out waiting for BMC task %s after %u seconds",
+		    task_uri,
+		    max_attempts * poll_interval_ms / 1000);
+	return FALSE;
+}
+
+/* ------------------------------------------------------------------ */
+/* FuDevice vfuncs                                                     */
+/* ------------------------------------------------------------------ */
+
+static gboolean
+fu_redfish_nvidia_device_probe(FuDevice *device, GError **error)
+{
+	FuRedfishDevice *rdev = FU_REDFISH_DEVICE(device);
+	FwupdJsonObject *member;
+	const gchar *inventory_uri;
+	const gchar *software_id;
+
+	/* Base probe: sets logical_id = @odata.id, vendor, version, name,
+	 * SoftwareId instance IDs (REDFISH\VENDOR\SOFTWAREID), etc. */
+	if (!FU_DEVICE_CLASS(fu_redfish_nvidia_device_parent_class)->probe(device, error))
+		return FALSE;
+
+	/* After base probe, logical_id holds the @odata.id inventory URI. */
+	inventory_uri = fu_device_get_logical_id(device);
+	if (inventory_uri == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "FirmwareInventory member has no @odata.id");
+		return FALSE;
+	}
+
+	/*
+	 * Override the device name with the inventory URI basename (e.g.
+	 * FW_BMC_0, FW_GPU_0, FW_CPU_0).  The BMC's JSON "Name" field returns
+	 * "Software Inventory" for every entry — identical for all 12+ OOB
+	 * components — making each device indistinguishable by name.  The
+	 * basename is unique, operator-meaningful, and matches LVFS CAB labels.
+	 */
+	{
+		g_autofree gchar *basename = g_path_get_basename(inventory_uri);
+		if (basename != NULL && basename[0] != '\0' &&
+		    g_strcmp0(basename, ".") != 0 && g_strcmp0(basename, "/") != 0)
+			fu_device_set_name(device, basename);
+	}
+
+	/*
+	 * URI-derived instance ID — globally unique per FirmwareInventory entry.
+	 * Primary match key for per-device LVFS CABs targeting a specific
+	 * component.  The explicit add_guid() call registers the UUID-v5 hash
+	 * immediately so the engine sees a GUID right after coldplug; the
+	 * add_instance_id() call produces the display mapping in get-devices.
+	 */
+	{
+		g_autofree gchar *iid =
+		    g_strdup_printf("NVIDIA_OOB\\URI_%s", inventory_uri);
+		fu_device_add_instance_id(device, iid);
+	}
+
+	/*
+	 * SoftwareId-derived instance ID — allows a unified-image CAB to target
+	 * multiple components that share a SoftwareId (e.g. FW_ERoT_CPU_0 and
+	 * FW_ERoT_FPGA_0 both carry SoftwareId=0xFF00 in NVIDIA's PLDM bundle).
+	 */
+	member = fu_redfish_device_get_json_obj_member(rdev);
+	if (member != NULL) {
+		software_id = fwupd_json_object_get_string(member, "SoftwareId", NULL);
+		if (software_id != NULL && software_id[0] != '\0') {
+			g_autofree gchar *iid =
+			    g_strdup_printf("NVIDIA_OOB\\SWID_%s", software_id);
+			fu_device_add_instance_id(device, iid);
+		}
+	}
+
+	/*
+	 * Vendor IDs for LVFS CAB signature validation.  DMI:NVIDIA pairs with
+	 * the GB300 system's SMBIOS identity; OEM:NVIDIA is the non-bus fallback
+	 * since OOB-managed components have no PCI/USB/NVMe identity on the host.
+	 */
+	fu_device_add_vendor_id(device, "DMI:NVIDIA");
+	fu_device_add_vendor_id(device, "OEM:NVIDIA");
+
+	/*
+	 * 15-minute install duration covers the worst-case scenario: full PLDM
+	 * bundle flash across all components (BMC, SBIOS, GPU, CX, ERoT, MCU).
+	 * An overestimate is far less confusing than an underestimate given that
+	 * the BMC's PLDM verification + per-component fan-out runs ~10 minutes.
+	 */
+	/* GB300 PLDM bundle flash covers all components and takes ~20 minutes
+	 * in practice; 45 minutes gives headroom for slower runs. */
+	fu_device_set_install_duration(device, 2700);
+	fu_device_set_summary(device, "OOB-managed firmware (activates on AC cycle)");
+
+	return TRUE;
+}
+
+static FuFirmware *
+fu_redfish_nvidia_device_prepare_firmware(FuDevice *device,
+					  GInputStream *stream,
+					  FuProgress *progress,
+					  FuFirmwareParseFlags flags,
+					  GError **error)
+{
+	g_autoptr(GBytes) blob = NULL;
+	gsize max_sz;
+	gsize read_sz;
+
+	/* Use the BMC-reported FirmwareSizeMax when available (the base class
+	 * probe reads it from the UpdateService resource); otherwise use a finite
+	 * 256 MiB ceiling to prevent runaway allocations on corrupt input. Read one
+	 * byte beyond the limit so oversized payloads are rejected, never silently
+	 * truncated to an apparently valid image. */
+	max_sz = fu_device_get_firmware_size_max(device);
+	if (max_sz == 0)
+		max_sz = 256u * 1024u * 1024u;
+	read_sz = max_sz < G_MAXSIZE ? max_sz + 1 : max_sz;
+	blob = fu_input_stream_read_bytes(stream, 0, read_sz, progress, error);
+	if (blob == NULL)
+		return NULL;
+	if (g_bytes_get_size(blob) > max_sz) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_FILE,
+			    "firmware payload exceeds maximum size of %" G_GSIZE_FORMAT " bytes",
+			    max_sz);
+		return NULL;
+	}
+	if (g_bytes_get_size(blob) == 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_FILE,
+				    "firmware payload is empty");
+		return NULL;
+	}
+	return fu_firmware_new_from_bytes(blob);
+}
+
+static gboolean
+fu_redfish_nvidia_device_write_firmware(FuDevice *device,
+					FuFirmware *firmware,
+					FuProgress *progress,
+					FwupdInstallFlags flags,
+					GError **error)
+{
+	FuRedfishBackend *backend;
+	CURL *curl;
+	curl_mimepart *part;
+	g_autofree gchar *location = NULL;
+	g_autoptr(FuRedfishRequest) request = NULL;
+	g_autoptr(GBytes) fw = NULL;
+	g_autoptr(GString) params = NULL;
+	g_autoptr(curl_mime) mime = NULL;
+
+	/*
+	 * Two sub-steps inside the "write" phase:
+	 *   upload (5%)  — multipart POST; fast (~30 s for a ~117 MB bundle)
+	 *   bmc-apply (95%) — PLDM verify + per-component fan-out (~10 min)
+	 * Weighting 5/95 keeps fwupdmgr's rate-based ETA accurate: an ETA
+	 * extrapolated at end-of-upload works out to ~10 min for the remaining
+	 * 95%, matching install_duration.
+	 */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 5, "upload");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 95, "bmc-apply");
+
+	fw = fu_firmware_get_bytes(firmware, error);
+	if (fw == NULL)
+		return FALSE;
+
+	/*
+	 * UpdateParameters JSON:
+	 *   Targets: []          — empty; BMC resolves components from the PLDM
+	 *                          bundle manifest.  Passing logical_id causes 400.
+	 *   ForceUpdate: true    — required to bypass the BMC's same-version check.
+	 *   OperationApplyTime:  — "Immediate" is the only accepted value; the BMC
+	 *     "Immediate"          rejects "OnReset" with 400 InvalidValue.
+	 */
+	{
+		g_autoptr(FwupdJsonObject) json_params = fwupd_json_object_new();
+		g_autoptr(FwupdJsonArray) json_targets = fwupd_json_array_new();
+		fwupd_json_object_add_array(json_params, "Targets", json_targets);
+		fwupd_json_object_add_boolean(json_params, "ForceUpdate", TRUE);
+		fwupd_json_object_add_string(json_params,
+					     "@Redfish.OperationApplyTime",
+					     "Immediate");
+		params = fwupd_json_object_to_string(json_params, FWUPD_JSON_EXPORT_FLAG_INDENT);
+	}
+
+	/* Build the multipart POST. */
+	backend = fu_redfish_device_get_backend(FU_REDFISH_DEVICE(device), error);
+	if (backend == NULL)
+		return FALSE;
+	request = fu_redfish_backend_request_new(backend);
+	curl = fu_redfish_request_get_curl(request);
+	mime = curl_mime_init(curl);
+
+	part = curl_mime_addpart(mime);
+	curl_mime_name(part, "UpdateParameters");
+	(void)curl_mime_type(part, "application/json");
+	(void)curl_mime_data(part, params->str, CURL_ZERO_TERMINATED);
+	g_debug("UpdateParameters: %s", params->str);
+
+	part = curl_mime_addpart(mime);
+	curl_mime_name(part, "UpdateFile");
+	(void)curl_mime_type(part, "application/octet-stream");
+	(void)curl_mime_filename(part, "firmware.bin");
+	(void)curl_mime_data(part, g_bytes_get_data(fw, NULL), g_bytes_get_size(fw));
+
+	(void)curl_easy_setopt(curl, CURLOPT_MIMEPOST, mime);
+	(void)curl_easy_setopt(curl,
+			       CURLOPT_HEADERFUNCTION,
+			       fu_redfish_nvidia_device_location_header_cb);
+	(void)curl_easy_setopt(curl, CURLOPT_HEADERDATA, &location);
+	/* 600 s upload timeout: ~117 MB over USB-OOB at ~1–2 MB/s. */
+	(void)curl_easy_setopt(curl, CURLOPT_TIMEOUT, (glong)600);
+
+	g_message("NvidiaOob: uploading firmware (%.1f MB) to %s",
+	       (double)g_bytes_get_size(fw) / (1000.0 * 1000.0),
+	       fu_redfish_backend_get_push_uri_path(backend));
+	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
+	if (!fu_redfish_request_perform(request,
+					fu_redfish_backend_get_push_uri_path(backend),
+					FU_REDFISH_REQUEST_PERFORM_FLAG_LOAD_JSON,
+					error))
+		return FALSE;
+	if (fu_redfish_request_get_status_code(request) != 202) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_FILE,
+			    "failed to upload firmware: HTTP %li",
+			    fu_redfish_request_get_status_code(request));
+		return FALSE;
+	}
+	g_message("NvidiaOob: upload accepted (HTTP 202) — waiting for TaskMonitor");
+
+	/* Prefer Location: header; fall back to @odata.id in the response body. */
+	if (location == NULL || location[0] == '\0') {
+		FwupdJsonObject *json_resp = fu_redfish_request_get_json_object(request);
+		if (!fwupd_json_object_has_node(json_resp, "@odata.id")) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no TaskMonitor location in upload response from %s",
+				    fu_redfish_backend_get_push_uri_path(backend));
+			return FALSE;
+		}
+		g_free(location);
+		location =
+		    g_strdup(fwupd_json_object_get_string(json_resp, "@odata.id", NULL));
+	}
+	g_message("NvidiaOob: TaskMonitor location: %s", location);
+	fu_progress_step_done(progress); /* upload */
+
+	if (!fu_redfish_nvidia_device_poll_task(FU_REDFISH_NVIDIA_DEVICE(device),
+						backend,
+						location,
+						fu_progress_get_child(progress),
+						error))
+		return FALSE;
+	fu_progress_step_done(progress); /* bmc-apply */
+	return TRUE;
+}
+
+static gboolean
+fu_redfish_nvidia_device_attach(FuDevice *device, FuProgress *progress, GError **error)
+{
+	/*
+	 * GB300 OOB firmware is staged by the upload but only becomes active
+	 * after an aux-rail (AC) power cycle.  Use fwupd's canonical activation
+	 * flow: set NEEDS_ACTIVATION so `fwupdmgr activate` can be called, and
+	 * document the manual procedure in update_message.
+	 *
+	 * We do NOT attempt to drive the cycle automatically:
+	 *   - The BMC's NvidiaChassis.AuxPowerReset OEM action requires the
+	 *     chassis to already be powered off.
+	 *   - Issuing a chassis PowerOff kills this process before any follow-up
+	 *     POST can fire.
+	 * The activate() vfunc below surfaces this as NEEDS_USER_ACTION.
+	 */
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
+	fu_device_set_update_message(
+	    device,
+	    "An AC (aux-rail) power cycle is required to activate the staged firmware:\n"
+	    "  1. sudo poweroff\n"
+	    "  2. After the host is fully off, physically unplug AC for at least 30 s\n"
+	    "  3. Reconnect AC and power on — staged firmware will be active on next boot");
+	return TRUE;
+}
+
+static gboolean
+fu_redfish_nvidia_device_activate(FuDevice *device, FuProgress *progress, GError **error)
+{
+	/*
+	 * `fwupdmgr activate` dispatches here.  We cannot drive the AC cycle
+	 * from the host (see attach() comment) so we return NEEDS_USER_ACTION
+	 * with the full manual procedure.  fwupdmgr surfaces this as an error
+	 * message; the user acts out of band.
+	 */
+	g_set_error_literal(
+	    error,
+	    FWUPD_ERROR,
+	    FWUPD_ERROR_NEEDS_USER_ACTION,
+	    "Activation cannot be performed automatically on this hardware.\n"
+	    "An AC (aux-rail) power cycle is required and must be done out of band:\n"
+	    "  1. sudo poweroff\n"
+	    "  2. After the host is fully off, physically unplug AC for at least 30 s\n"
+	    "  3. Reconnect AC and power on — staged firmware will be active on next boot.\n"
+	    "Reason: the BMC's NvidiaChassis.AuxPowerReset OEM action is gated on "
+	    "chassis-off, and the chassis-off step kills this process before a "
+	    "follow-up POST can fire.");
+	return FALSE;
+}
+
+static void
+fu_redfish_nvidia_device_set_progress(FuDevice *device, FuProgress *progress)
+{
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING,  0, "prepare-fw");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0, "detach");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 100, "write");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0, "attach");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY,   0, "reload");
+}
+
+/* ------------------------------------------------------------------ */
+/* GObject boilerplate                                                 */
+/* ------------------------------------------------------------------ */
+
+static void
+fu_redfish_nvidia_device_init(FuRedfishNvidiaDevice *self)
+{
+}
+
+static void
+fu_redfish_nvidia_device_class_init(FuRedfishNvidiaDeviceClass *klass)
+{
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->probe = fu_redfish_nvidia_device_probe;
+	device_class->prepare_firmware = fu_redfish_nvidia_device_prepare_firmware;
+	device_class->write_firmware = fu_redfish_nvidia_device_write_firmware;
+	device_class->attach = fu_redfish_nvidia_device_attach;
+	device_class->activate = fu_redfish_nvidia_device_activate;
+	device_class->set_progress = fu_redfish_nvidia_device_set_progress;
+}

--- a/plugins/redfish/fu-redfish-nvidia-device.c
+++ b/plugins/redfish/fu-redfish-nvidia-device.c
@@ -5,54 +5,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
-/*
- * FuRedfishNvidiaDevice — NVIDIA DGX Station GB300 OOB firmware update via Redfish.
- *
- * Represents a single component in the BMC's FirmwareInventory (e.g.
- * /redfish/v1/UpdateService/FirmwareInventory/FW_BMC_0) and implements the
- * GB300-specific upload and task-monitoring flow:
- *
- *   1. Multipart POST to UpdateService/MultipartHttpPushUri:
- *        UpdateParameters: { "Targets":[], "ForceUpdate":true,
- *                            "@Redfish.OperationApplyTime":"Immediate" }
- *        UpdateFile: raw firmware blob
- *
- *   2. Poll /redfish/v1/TaskService/Tasks/<id> (the persistent task resource,
- *      not the /Monitor sub-resource) for PercentComplete and TaskState.
- *      GB300-specific divergences from DMTF DSP0266:
- *        - Targets must be an empty array, as the BMC resolves components from
- *          the PLDM bundle manifest; passing the logical_id causes a 400 error.
- *        - ForceUpdate=true is required; the BMC rejects same-version installs.
- *        - OperationApplyTime "OnReset" is not in the BMC's acceptable-values
- *          list; "Immediate" must be used.
- *        - PercentComplete is only updated on /Tasks/<id>, not on
- *          /Tasks/<id>/Monitor; polling the Monitor always returns 0%.
- *        - After task completion the BMC returns HTTP 200 and an empty body for
- *          the TaskMonitor instead of the canonical 404 that signals reap; both
- *          are handled here. When both the Monitor and /Tasks/<id> are gone the
- *          resource-gone condition is treated as Completed.
- *
- *   3. A completed write sets NEEDS_ACTIVATION, as the firmware is staged and
- *      only becomes active after an aux-rail power cycle. activate() drives
- *      that cycle by POSTing ResetType=AuxPowerCycleForce to the OEM
- *      NvidiaChassis.AuxPowerReset action advertised by Chassis/BMC_0. The
- *      Force variant does not wait for the host to shut down, so it drops the
- *      rail powering fwupd itself.
- *
- * Instance IDs registered per device, in addition to those from the base class:
- *   NVIDIA_OOB\URI_<@odata.id>   — always; unique per FirmwareInventory entry
- *   NVIDIA_OOB\SWID_<SoftwareId> — when present; lets a unified-image CAB target
- *                                  multiple components by SoftwareId
- *
- * Backend detection: fu_redfish_backend_coldplug() sets device_gtype to
- * FU_TYPE_REDFISH_NVIDIA_DEVICE when /redfish/v1/Chassis/Chassis_0 reports
- * Manufacturer="NVIDIA" and a Model containing both "GB300" and "Station".
- *
- * This device requires a Redfish X-Auth-Token provisioned out of band; see
- * README.md for how to set FWUPD_SESSION_TOKEN_FILE. Without a token the
- * plugin falls back to Basic Auth.
- */
-
 #include "config.h"
 
 #include <curl/curl.h>
@@ -545,11 +497,17 @@ fu_redfish_nvidia_device_poll_task(FuRedfishNvidiaDevice *self,
  * the device is probed means a pending activation survives a daemon restart,
  * a host reboot, and a same-version reinstall -- none of which the engine's
  * own history can express.
+ *
+ * FirmwareState alone is not enough: the BMC also reports PendingActivation for
+ * a slot that holds no image at all, which happens when an update erased the
+ * slot and then failed to authenticate the replacement. Acting on that would
+ * mark the device as needing an aux-rail power cycle to activate nothing.
  */
 static gboolean
 fu_redfish_nvidia_device_slot_is_pending(FwupdJsonObject *json_member)
 {
 	const gchar *state;
+	const gchar *version;
 	g_autoptr(FwupdJsonObject) json_nvidia = NULL;
 	g_autoptr(FwupdJsonObject) json_oem = NULL;
 	g_autoptr(FwupdJsonObject) json_slot = NULL;
@@ -564,7 +522,12 @@ fu_redfish_nvidia_device_slot_is_pending(FwupdJsonObject *json_member)
 	if (json_slot == NULL)
 		return FALSE;
 	state = fwupd_json_object_get_string(json_slot, "FirmwareState", NULL);
-	return g_strcmp0(state, "PendingActivation") == 0;
+	if (g_strcmp0(state, "PendingActivation") != 0)
+		return FALSE;
+
+	/* an empty version means the slot was erased, so nothing is staged */
+	version = fwupd_json_object_get_string(json_slot, "Version", NULL);
+	return version != NULL && version[0] != '\0';
 }
 
 static gboolean
@@ -639,9 +602,11 @@ fu_redfish_nvidia_device_probe(FuDevice *device, GError **error)
 /*
  * The PLDM bundle is an opaque blob of about 117MB, which is larger than the
  * FuFirmware base-class parse ceiling of FU_FIRMWARE_SIZE_MAX_DEFAULT, so read
- * it straight into a FuFirmware rather than parsing it. The real limit is the
- * device firmware size max set in probe(), which fu_device_prepare_firmware()
- * applies to the result.
+ * it straight into a FuFirmware rather than parsing it.
+ *
+ * fu_device_prepare_firmware() applies the device firmware size max set in
+ * probe(), but only once the whole stream has already been read into memory, so
+ * check the size here as well to bound the allocation.
  */
 static FuFirmware *
 fu_redfish_nvidia_device_prepare_firmware(FuDevice *device,
@@ -650,9 +615,23 @@ fu_redfish_nvidia_device_prepare_firmware(FuDevice *device,
 					  FuFirmwareParseFlags flags,
 					  GError **error)
 {
+	gsize streamsz = 0;
+	guint64 size_max = fu_device_get_firmware_size_max(device);
 	g_autoptr(GBytes) blob = NULL;
 
-	blob = fu_input_stream_read_bytes(stream, 0, G_MAXSIZE, progress, error);
+	if (!fu_input_stream_size(stream, &streamsz, error))
+		return NULL;
+	if (size_max > 0 && streamsz > size_max) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_FILE,
+			    "firmware is 0x%x bytes larger than the allowed maximum size of "
+			    "0x%x bytes",
+			    (guint)(streamsz - size_max),
+			    (guint)size_max);
+		return NULL;
+	}
+	blob = fu_input_stream_read_bytes(stream, 0, streamsz, progress, error);
 	if (blob == NULL)
 		return NULL;
 	return fu_firmware_new_from_bytes(blob);

--- a/plugins/redfish/fu-redfish-nvidia-device.h
+++ b/plugins/redfish/fu-redfish-nvidia-device.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 NVIDIA Corporation
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include "fu-redfish-device.h"
+
+#define FU_TYPE_REDFISH_NVIDIA_DEVICE (fu_redfish_nvidia_device_get_type())
+G_DECLARE_FINAL_TYPE(FuRedfishNvidiaDevice,
+		     fu_redfish_nvidia_device,
+		     FU,
+		     REDFISH_NVIDIA_DEVICE,
+		     FuRedfishDevice)
+
+typedef enum {
+	FU_REDFISH_NVIDIA_TASK_RUNNING,
+	FU_REDFISH_NVIDIA_TASK_COMPLETED,
+	FU_REDFISH_NVIDIA_TASK_FAILED,
+} FuRedfishNvidiaTaskState;
+
+typedef enum {
+	FU_REDFISH_NVIDIA_TASK_RESPONSE_TASK,
+	FU_REDFISH_NVIDIA_TASK_RESPONSE_REAPED,
+	FU_REDFISH_NVIDIA_TASK_RESPONSE_TRANSIENT,
+	FU_REDFISH_NVIDIA_TASK_RESPONSE_FATAL,
+} FuRedfishNvidiaTaskResponse;
+
+FuRedfishNvidiaTaskResponse
+fu_redfish_nvidia_device_classify_task_response(glong status_code,
+						gboolean request_succeeded,
+						gboolean has_json,
+						gboolean allow_empty_200);
+FuRedfishNvidiaTaskState
+fu_redfish_nvidia_device_parse_task(const gchar *task_uri,
+				    FwupdJsonObject *json_task,
+				    guint *out_percent,
+				    GError **error);

--- a/plugins/redfish/fu-redfish-nvidia-device.h
+++ b/plugins/redfish/fu-redfish-nvidia-device.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2026 NVIDIA Corporation
+ * Author: Vishnu Raghav <vraghav@nvidia.com>
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
@@ -18,7 +19,6 @@ G_DECLARE_FINAL_TYPE(FuRedfishNvidiaDevice,
 typedef enum {
 	FU_REDFISH_NVIDIA_TASK_RUNNING,
 	FU_REDFISH_NVIDIA_TASK_COMPLETED,
-	FU_REDFISH_NVIDIA_TASK_FAILED,
 } FuRedfishNvidiaTaskState;
 
 typedef enum {
@@ -33,8 +33,9 @@ fu_redfish_nvidia_device_classify_task_response(glong status_code,
 						gboolean request_succeeded,
 						gboolean has_json,
 						gboolean allow_empty_200);
-FuRedfishNvidiaTaskState
+gboolean
 fu_redfish_nvidia_device_parse_task(const gchar *task_uri,
 				    FwupdJsonObject *json_task,
-				    guint *out_percent,
-				    GError **error);
+				    FuRedfishNvidiaTaskState *task_state,
+				    guint *percentage,
+				    GError **error) G_GNUC_WARN_UNUSED_RESULT;

--- a/plugins/redfish/fu-redfish-plugin.c
+++ b/plugins/redfish/fu-redfish-plugin.c
@@ -431,7 +431,6 @@ fu_redfish_plugin_startup(FuPlugin *plugin, FuProgress *progress, GError **error
 #ifdef HAVE_LINUX_IPMI_H
 	gboolean credentials_invalid = FALSE;
 #endif
-	const gchar *session_token_file;
 	g_autofree gchar *password = NULL;
 	g_autofree gchar *bearer_token = NULL;
 	g_autofree gchar *session_key_file = NULL;

--- a/plugins/redfish/fu-redfish-plugin.c
+++ b/plugins/redfish/fu-redfish-plugin.c
@@ -431,6 +431,7 @@ fu_redfish_plugin_startup(FuPlugin *plugin, FuProgress *progress, GError **error
 #ifdef HAVE_LINUX_IPMI_H
 	gboolean credentials_invalid = FALSE;
 #endif
+	const gchar *session_token_file;
 	g_autofree gchar *password = NULL;
 	g_autofree gchar *bearer_token = NULL;
 	g_autofree gchar *session_key_file = NULL;

--- a/plugins/redfish/fu-redfish-plugin.c
+++ b/plugins/redfish/fu-redfish-plugin.c
@@ -434,6 +434,7 @@ fu_redfish_plugin_startup(FuPlugin *plugin, FuProgress *progress, GError **error
 	g_autofree gchar *password = NULL;
 	g_autofree gchar *bearer_token = NULL;
 	g_autofree gchar *session_key_file = NULL;
+	g_autofree gchar *session_key = NULL;
 	g_autofree gchar *redfish_uri = NULL;
 	g_autofree gchar *username = NULL;
 #ifdef HAVE_LINUX_IPMI_H
@@ -541,8 +542,13 @@ fu_redfish_plugin_startup(FuPlugin *plugin, FuProgress *progress, GError **error
 		}
 	}
 
-	/* we got neither a type 42 entry or config value, lets try IPMI */
-	if (fu_redfish_backend_get_username(self->backend) == NULL || credentials_invalid) {
+	/* we got neither a type 42 entry or config value, lets try IPMI; a session
+	 * key authenticates without a username or password, so skip IPMI when one
+	 * is configured.  The error is not interesting here -- a missing key is the
+	 * normal case and simply means we fall through to the checks below. */
+	session_key = fu_redfish_backend_get_session_key(self->backend, NULL);
+	if ((fu_redfish_backend_get_username(self->backend) == NULL || credentials_invalid) &&
+	    session_key == NULL) {
 		if (!fu_context_has_hwid_flag(fu_plugin_get_context(plugin), "ipmi-create-user")) {
 			g_set_error_literal(error,
 					    FWUPD_ERROR,

--- a/plugins/redfish/fu-redfish-request.c
+++ b/plugins/redfish/fu-redfish-request.c
@@ -18,6 +18,11 @@ struct _FuRedfishRequest {
 	FwupdJsonParser *json_parser;
 	FwupdJsonObject *json_obj;
 	GHashTable *cache; /* nullable */
+	/* Non-owning pointer to the backend's authentication header slist
+	 * (X-Auth-Token or similar).  Set once by the backend in request_new()
+	 * so perform_full() can merge them with Content-Type headers instead of
+	 * replacing them. */
+	struct curl_slist *auth_headers;
 };
 
 G_DEFINE_TYPE(FuRedfishRequest, fu_redfish_request, G_TYPE_OBJECT)
@@ -29,7 +34,7 @@ FwupdJsonObject *
 fu_redfish_request_get_json_object(FuRedfishRequest *self)
 {
 	g_return_val_if_fail(FU_IS_REDFISH_REQUEST(self), NULL);
-	return fwupd_json_object_ref(self->json_obj);
+	return self->json_obj != NULL ? fwupd_json_object_ref(self->json_obj) : NULL;
 }
 
 CURL *
@@ -260,6 +265,15 @@ fu_redfish_request_perform_full(FuRedfishRequest *self,
 	hs = curl_slist_append(hs, "Content-Type: application/json");
 	if (etag_header != NULL)
 		hs = curl_slist_append(hs, etag_header);
+	/* Merge backend authentication headers (X-Auth-Token etc.) into this
+	 * header list.  CURLOPT_HTTPHEADER replaces whatever was set in
+	 * request_new(), so we must re-append auth headers here to avoid
+	 * sending unauthenticated POST/PATCH requests (HTTP 401). */
+	if (self->auth_headers != NULL) {
+		struct curl_slist *h;
+		for (h = self->auth_headers; h != NULL; h = h->next)
+			hs = curl_slist_append(hs, h->data);
+	}
 	(void)curl_easy_setopt(self->curl, CURLOPT_HTTPHEADER, hs);
 	return fu_redfish_request_perform(self, path, flags, error);
 }
@@ -278,6 +292,14 @@ fu_redfish_request_set_path_prefix(FuRedfishRequest *self, const gchar *path_pre
 {
 	g_return_if_fail(FU_IS_REDFISH_REQUEST(self));
 	g_set_str(&self->path_prefix, path_prefix);
+}
+
+void
+fu_redfish_request_set_auth_headers(FuRedfishRequest *self, struct curl_slist *auth_headers)
+{
+	g_return_if_fail(FU_IS_REDFISH_REQUEST(self));
+	/* Non-owning: the slist is owned by the backend and outlives requests. */
+	self->auth_headers = auth_headers;
 }
 
 void

--- a/plugins/redfish/fu-redfish-request.c
+++ b/plugins/redfish/fu-redfish-request.c
@@ -17,12 +17,8 @@ struct _FuRedfishRequest {
 	glong status_code;
 	FwupdJsonParser *json_parser;
 	FwupdJsonObject *json_obj;
-	GHashTable *cache; /* nullable */
-	/* Non-owning pointer to the backend's authentication header slist
-	 * (X-Auth-Token or similar).  Set once by the backend in request_new()
-	 * so perform_full() can merge them with Content-Type headers instead of
-	 * replacing them. */
-	struct curl_slist *auth_headers;
+	GHashTable *cache;	    /* nullable */
+	struct curl_slist *headers; /* nullable */
 };
 
 G_DEFINE_TYPE(FuRedfishRequest, fu_redfish_request, G_TYPE_OBJECT)
@@ -265,15 +261,10 @@ fu_redfish_request_perform_full(FuRedfishRequest *self,
 	hs = curl_slist_append(hs, "Content-Type: application/json");
 	if (etag_header != NULL)
 		hs = curl_slist_append(hs, etag_header);
-	/* Merge backend authentication headers (X-Auth-Token etc.) into this
-	 * header list.  CURLOPT_HTTPHEADER replaces whatever was set in
-	 * request_new(), so we must re-append auth headers here to avoid
-	 * sending unauthenticated POST/PATCH requests (HTTP 401). */
-	if (self->auth_headers != NULL) {
-		struct curl_slist *h;
-		for (h = self->auth_headers; h != NULL; h = h->next)
-			hs = curl_slist_append(hs, h->data);
-	}
+	/* CURLOPT_HTTPHEADER replaces whatever fu_redfish_request_add_header() set, so
+	 * re-append those to avoid sending an unauthenticated POST or PATCH */
+	for (struct curl_slist *h = self->headers; h != NULL; h = h->next)
+		hs = curl_slist_append(hs, h->data);
 	(void)curl_easy_setopt(self->curl, CURLOPT_HTTPHEADER, hs);
 	return fu_redfish_request_perform(self, path, flags, error);
 }
@@ -295,11 +286,12 @@ fu_redfish_request_set_path_prefix(FuRedfishRequest *self, const gchar *path_pre
 }
 
 void
-fu_redfish_request_set_auth_headers(FuRedfishRequest *self, struct curl_slist *auth_headers)
+fu_redfish_request_add_header(FuRedfishRequest *self, const gchar *header)
 {
 	g_return_if_fail(FU_IS_REDFISH_REQUEST(self));
-	/* Non-owning: the slist is owned by the backend and outlives requests. */
-	self->auth_headers = auth_headers;
+	g_return_if_fail(header != NULL);
+	self->headers = curl_slist_append(self->headers, header);
+	(void)curl_easy_setopt(self->curl, CURLOPT_HTTPHEADER, self->headers);
 }
 
 void
@@ -345,6 +337,7 @@ fu_redfish_request_finalize(GObject *object)
 	g_byte_array_unref(self->buf);
 	g_free(self->path_prefix);
 	curl_easy_cleanup(self->curl);
+	curl_slist_free_all(self->headers);
 	curl_url_cleanup(self->uri);
 	G_OBJECT_CLASS(fu_redfish_request_parent_class)->finalize(object);
 }

--- a/plugins/redfish/fu-redfish-request.h
+++ b/plugins/redfish/fu-redfish-request.h
@@ -42,4 +42,4 @@ fu_redfish_request_set_path_prefix(FuRedfishRequest *self, const gchar *path_pre
 void
 fu_redfish_request_set_cache(FuRedfishRequest *self, GHashTable *cache);
 void
-fu_redfish_request_set_auth_headers(FuRedfishRequest *self, struct curl_slist *auth_headers);
+fu_redfish_request_add_header(FuRedfishRequest *self, const gchar *header);

--- a/plugins/redfish/fu-redfish-request.h
+++ b/plugins/redfish/fu-redfish-request.h
@@ -41,3 +41,5 @@ void
 fu_redfish_request_set_path_prefix(FuRedfishRequest *self, const gchar *path_prefix);
 void
 fu_redfish_request_set_cache(FuRedfishRequest *self, GHashTable *cache);
+void
+fu_redfish_request_set_auth_headers(FuRedfishRequest *self, struct curl_slist *auth_headers);

--- a/plugins/redfish/fu-self-test.c
+++ b/plugins/redfish/fu-self-test.c
@@ -16,6 +16,7 @@
 #include "fu-redfish-backend.h"
 #include "fu-redfish-common.h"
 #include "fu-redfish-network.h"
+#include "fu-redfish-nvidia-device.h"
 #include "fu-redfish-plugin.h"
 #include "fu-redfish-smc-device.h"
 #include "fu-redfish-struct.h"
@@ -360,6 +361,136 @@ fu_redfish_common_lenovo_func(void)
 		g_assert_cmpstr(build, ==, values[i].build);
 		g_assert_cmpstr(version, ==, values[i].version);
 	}
+}
+
+static void
+fu_redfish_nvidia_task_response_func(void)
+{
+	/* A task-shaped body must never override the HTTP status. */
+	g_assert_cmpint(fu_redfish_nvidia_device_classify_task_response(503,
+									 TRUE,
+									 TRUE,
+									 FALSE),
+			==,
+			FU_REDFISH_NVIDIA_TASK_RESPONSE_TRANSIENT);
+	g_assert_cmpint(fu_redfish_nvidia_device_classify_task_response(403,
+									 TRUE,
+									 TRUE,
+									 FALSE),
+			==,
+			FU_REDFISH_NVIDIA_TASK_RESPONSE_FATAL);
+	g_assert_cmpint(fu_redfish_nvidia_device_classify_task_response(404,
+									 TRUE,
+									 TRUE,
+									 FALSE),
+			==,
+			FU_REDFISH_NVIDIA_TASK_RESPONSE_REAPED);
+
+	/* Empty HTTP 200 is a reap signal only for the TaskMonitor URI. */
+	g_assert_cmpint(fu_redfish_nvidia_device_classify_task_response(200,
+									 TRUE,
+									 FALSE,
+									 FALSE),
+			==,
+			FU_REDFISH_NVIDIA_TASK_RESPONSE_TRANSIENT);
+	g_assert_cmpint(fu_redfish_nvidia_device_classify_task_response(200,
+									 TRUE,
+									 FALSE,
+									 TRUE),
+			==,
+			FU_REDFISH_NVIDIA_TASK_RESPONSE_REAPED);
+	g_assert_cmpint(fu_redfish_nvidia_device_classify_task_response(200,
+									 TRUE,
+									 TRUE,
+									 FALSE),
+			==,
+			FU_REDFISH_NVIDIA_TASK_RESPONSE_TASK);
+}
+
+static void
+fu_redfish_nvidia_task_parse_func(void)
+{
+	guint percent = 0;
+	FuRedfishNvidiaTaskState state;
+	g_autoptr(FwupdJsonObject) json_task = fwupd_json_object_new();
+	g_autoptr(GError) error = NULL;
+
+	fwupd_json_object_add_string(json_task, "TaskState", "Running");
+	fwupd_json_object_add_integer(json_task, "PercentComplete", 42);
+	state = fu_redfish_nvidia_device_parse_task("/redfish/v1/TaskService/Tasks/1",
+						     json_task,
+						     &percent,
+						     &error);
+	g_assert_no_error(error);
+	g_assert_cmpint(state, ==, FU_REDFISH_NVIDIA_TASK_RUNNING);
+	g_assert_cmpuint(percent, ==, 42);
+
+	/* The GB300 100% quirk applies only to a recognized running state. */
+	fwupd_json_object_clear(json_task);
+	fwupd_json_object_add_string(json_task, "TaskState", "Starting");
+	fwupd_json_object_add_integer(json_task, "PercentComplete", 100);
+	state = fu_redfish_nvidia_device_parse_task("/redfish/v1/TaskService/Tasks/1",
+						     json_task,
+						     &percent,
+						     &error);
+	g_assert_no_error(error);
+	g_assert_cmpint(state, ==, FU_REDFISH_NVIDIA_TASK_COMPLETED);
+
+	fwupd_json_object_clear(json_task);
+	state = fu_redfish_nvidia_device_parse_task("/redfish/v1/TaskService/Tasks/1",
+						     json_task,
+						     &percent,
+						     &error);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
+	g_assert_cmpint(state, ==, FU_REDFISH_NVIDIA_TASK_FAILED);
+	g_clear_error(&error);
+
+	fwupd_json_object_add_string(json_task, "TaskState", "VendorDefinedSuccess");
+	fwupd_json_object_add_integer(json_task, "PercentComplete", 100);
+	state = fu_redfish_nvidia_device_parse_task("/redfish/v1/TaskService/Tasks/1",
+						     json_task,
+						     &percent,
+						     &error);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
+	g_assert_cmpint(state, ==, FU_REDFISH_NVIDIA_TASK_FAILED);
+}
+
+static void
+fu_redfish_nvidia_firmware_size_func(void)
+{
+	const guint8 payload[] = {0x00, 0x01, 0x02, 0x03, 0x04};
+	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuDevice) device =
+	    g_object_new(FU_TYPE_REDFISH_NVIDIA_DEVICE, "context", ctx, NULL);
+	g_autoptr(FuFirmware) firmware = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	g_autoptr(GBytes) blob_exact = g_bytes_new_static(payload, 4);
+	g_autoptr(GBytes) blob_oversized = g_bytes_new_static(payload, sizeof(payload));
+	g_autoptr(FuInputStream) stream_exact = fu_memory_input_stream_new_from_bytes(blob_exact);
+	g_autoptr(FuInputStream) stream_oversized =
+	    fu_memory_input_stream_new_from_bytes(blob_oversized);
+	g_autoptr(GError) error = NULL;
+
+	/* exact advertised maximum must remain intact */
+	fu_device_set_firmware_size_max(device, 4);
+	firmware = fu_device_prepare_firmware(device,
+					      stream_exact,
+					      progress,
+					      FU_FIRMWARE_PARSE_FLAG_NONE,
+					      &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(firmware);
+	g_assert_cmpuint(fu_firmware_get_size(firmware), ==, 4);
+	g_clear_object(&firmware);
+
+	/* reject one byte beyond the maximum instead of truncating it */
+	firmware = fu_device_prepare_firmware(device,
+					      stream_oversized,
+					      progress,
+					      FU_FIRMWARE_PARSE_FLAG_NONE,
+					      &error);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
+	g_assert_null(firmware);
 }
 
 static void
@@ -766,6 +897,9 @@ main(int argc, char **argv)
 	g_test_add_func("/redfish/common", fu_redfish_common_func);
 	g_test_add_func("/redfish/common/version", fu_redfish_common_version_func);
 	g_test_add_func("/redfish/common/lenovo", fu_redfish_common_lenovo_func);
+	g_test_add_func("/redfish/nvidia/task-response", fu_redfish_nvidia_task_response_func);
+	g_test_add_func("/redfish/nvidia/task-parse", fu_redfish_nvidia_task_parse_func);
+	g_test_add_func("/redfish/nvidia/firmware-size", fu_redfish_nvidia_firmware_size_func);
 	g_test_add_func("/redfish/network/mac_addr", fu_redfish_network_mac_addr_func);
 	g_test_add_func("/redfish/network/vid_pid", fu_redfish_network_vid_pid_func);
 	g_test_add_data_func("/redfish/unlicensed-plugin/devices",

--- a/plugins/redfish/fu-self-test.c
+++ b/plugins/redfish/fu-self-test.c
@@ -6,6 +6,8 @@
 
 #include "config.h"
 
+#include <glib/gstdio.h>
+
 #include "fu-config-private.h"
 #include "fu-context-private.h"
 #include "fu-device-private.h"
@@ -18,6 +20,7 @@
 #include "fu-redfish-network.h"
 #include "fu-redfish-nvidia-device.h"
 #include "fu-redfish-plugin.h"
+#include "fu-redfish-request.h"
 #include "fu-redfish-smc-device.h"
 #include "fu-redfish-struct.h"
 
@@ -27,6 +30,7 @@ typedef struct {
 	FuPlugin *unlicensed_plugin;
 	FuPlugin *hpe_plugin;
 	FuPlugin *dell_plugin;
+	FuPlugin *nvidia_plugin;
 } FuTest;
 
 static void
@@ -124,6 +128,27 @@ fu_self_init(FuTest *self)
 		g_assert_no_error(error);
 		g_assert_true(ret);
 		ret = fu_plugin_runner_coldplug(self->hpe_plugin, progress, &error);
+		g_assert_no_error(error);
+		g_assert_true(ret);
+	}
+
+	/* NVIDIA DGX Station GB300 BMC */
+	self->nvidia_plugin = fu_plugin_new_from_gtype(fu_redfish_plugin_get_type(), ctx);
+	ret = fu_plugin_runner_startup(self->nvidia_plugin, progress, &error);
+	if (g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE)) {
+		g_debug("ignoring: %s", error->message);
+		g_test_skip("no redfish.py running");
+		g_clear_error(&error);
+	} else {
+		g_assert_no_error(error);
+		g_assert_true(ret);
+		fu_redfish_plugin_set_credentials(self->nvidia_plugin,
+						  "nvidia_username",
+						  "password2");
+		ret = fu_redfish_plugin_reload(self->nvidia_plugin, progress, &error);
+		g_assert_no_error(error);
+		g_assert_true(ret);
+		ret = fu_plugin_runner_coldplug(self->nvidia_plugin, progress, &error);
 		g_assert_no_error(error);
 		g_assert_true(ret);
 	}
@@ -364,45 +389,66 @@ fu_redfish_common_lenovo_func(void)
 }
 
 static void
+fu_redfish_session_key_file_func(void)
+{
+	gboolean ret;
+	g_autofree gchar *fn = NULL;
+	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuRedfishBackend) backend = fu_redfish_backend_new(ctx);
+	g_autoptr(FuRedfishRequest) request = NULL;
+	g_autoptr(GError) error = NULL;
+
+	fn = g_build_filename(g_get_tmp_dir(), "fwupd-redfish-session", NULL);
+
+	/* the token is read when the file is set */
+	ret = g_file_set_contents(fn, "tok1\n", -1, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	fu_redfish_backend_set_session_key_file(backend, fn);
+	g_assert_cmpstr(fu_redfish_backend_get_session_key(backend), ==, "tok1");
+
+	/* replacing the file re-authenticates without restarting the daemon */
+	ret = g_file_set_contents(fn, "  tok2  \n", -1, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	request = fu_redfish_backend_request_new(backend);
+	g_assert_nonnull(request);
+	g_assert_cmpstr(fu_redfish_backend_get_session_key(backend), ==, "tok2");
+
+	/* a partially written file must not clear the key */
+	ret = g_file_set_contents(fn, "\n", -1, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_clear_object(&request);
+	request = fu_redfish_backend_request_new(backend);
+	g_assert_nonnull(request);
+	g_assert_cmpstr(fu_redfish_backend_get_session_key(backend), ==, "tok2");
+
+	g_unlink(fn);
+}
+
+static void
 fu_redfish_nvidia_task_response_func(void)
 {
-	/* A task-shaped body must never override the HTTP status. */
-	g_assert_cmpint(fu_redfish_nvidia_device_classify_task_response(503,
-									 TRUE,
-									 TRUE,
-									 FALSE),
+	/* a task-shaped body must never override the HTTP status */
+	g_assert_cmpint(fu_redfish_nvidia_device_classify_task_response(503, TRUE, TRUE, FALSE),
 			==,
 			FU_REDFISH_NVIDIA_TASK_RESPONSE_TRANSIENT);
-	g_assert_cmpint(fu_redfish_nvidia_device_classify_task_response(403,
-									 TRUE,
-									 TRUE,
-									 FALSE),
+	g_assert_cmpint(fu_redfish_nvidia_device_classify_task_response(403, TRUE, TRUE, FALSE),
 			==,
 			FU_REDFISH_NVIDIA_TASK_RESPONSE_FATAL);
-	g_assert_cmpint(fu_redfish_nvidia_device_classify_task_response(404,
-									 TRUE,
-									 TRUE,
-									 FALSE),
+	g_assert_cmpint(fu_redfish_nvidia_device_classify_task_response(404, TRUE, TRUE, FALSE),
 			==,
 			FU_REDFISH_NVIDIA_TASK_RESPONSE_REAPED);
 
-	/* Empty HTTP 200 is a reap signal only for the TaskMonitor URI. */
-	g_assert_cmpint(fu_redfish_nvidia_device_classify_task_response(200,
-									 TRUE,
-									 FALSE,
-									 FALSE),
+	/* empty HTTP 200 is a reap signal only for the TaskMonitor URI */
+	g_assert_cmpint(fu_redfish_nvidia_device_classify_task_response(200, TRUE, FALSE, FALSE),
 			==,
 			FU_REDFISH_NVIDIA_TASK_RESPONSE_TRANSIENT);
-	g_assert_cmpint(fu_redfish_nvidia_device_classify_task_response(200,
-									 TRUE,
-									 FALSE,
-									 TRUE),
+	g_assert_cmpint(fu_redfish_nvidia_device_classify_task_response(200, TRUE, FALSE, TRUE),
 			==,
 			FU_REDFISH_NVIDIA_TASK_RESPONSE_REAPED);
-	g_assert_cmpint(fu_redfish_nvidia_device_classify_task_response(200,
-									 TRUE,
-									 TRUE,
-									 FALSE),
+	g_assert_cmpint(fu_redfish_nvidia_device_classify_task_response(200, TRUE, TRUE, FALSE),
 			==,
 			FU_REDFISH_NVIDIA_TASK_RESPONSE_TASK);
 }
@@ -410,87 +456,56 @@ fu_redfish_nvidia_task_response_func(void)
 static void
 fu_redfish_nvidia_task_parse_func(void)
 {
-	guint percent = 0;
-	FuRedfishNvidiaTaskState state;
+	gboolean ret;
+	guint percentage = 0;
+	FuRedfishNvidiaTaskState task_state;
 	g_autoptr(FwupdJsonObject) json_task = fwupd_json_object_new();
 	g_autoptr(GError) error = NULL;
 
 	fwupd_json_object_add_string(json_task, "TaskState", "Running");
 	fwupd_json_object_add_integer(json_task, "PercentComplete", 42);
-	state = fu_redfish_nvidia_device_parse_task("/redfish/v1/TaskService/Tasks/1",
-						     json_task,
-						     &percent,
-						     &error);
+	ret = fu_redfish_nvidia_device_parse_task("/redfish/v1/TaskService/Tasks/1",
+						  json_task,
+						  &task_state,
+						  &percentage,
+						  &error);
 	g_assert_no_error(error);
-	g_assert_cmpint(state, ==, FU_REDFISH_NVIDIA_TASK_RUNNING);
-	g_assert_cmpuint(percent, ==, 42);
+	g_assert_true(ret);
+	g_assert_cmpint(task_state, ==, FU_REDFISH_NVIDIA_TASK_RUNNING);
+	g_assert_cmpuint(percentage, ==, 42);
 
-	/* The GB300 100% quirk applies only to a recognized running state. */
+	/* the GB300 100% quirk applies only to a recognized running state */
 	fwupd_json_object_clear(json_task);
 	fwupd_json_object_add_string(json_task, "TaskState", "Starting");
 	fwupd_json_object_add_integer(json_task, "PercentComplete", 100);
-	state = fu_redfish_nvidia_device_parse_task("/redfish/v1/TaskService/Tasks/1",
-						     json_task,
-						     &percent,
-						     &error);
+	ret = fu_redfish_nvidia_device_parse_task("/redfish/v1/TaskService/Tasks/1",
+						  json_task,
+						  &task_state,
+						  &percentage,
+						  &error);
 	g_assert_no_error(error);
-	g_assert_cmpint(state, ==, FU_REDFISH_NVIDIA_TASK_COMPLETED);
+	g_assert_true(ret);
+	g_assert_cmpint(task_state, ==, FU_REDFISH_NVIDIA_TASK_COMPLETED);
 
 	fwupd_json_object_clear(json_task);
-	state = fu_redfish_nvidia_device_parse_task("/redfish/v1/TaskService/Tasks/1",
-						     json_task,
-						     &percent,
-						     &error);
+	ret = fu_redfish_nvidia_device_parse_task("/redfish/v1/TaskService/Tasks/1",
+						  json_task,
+						  &task_state,
+						  &percentage,
+						  &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
-	g_assert_cmpint(state, ==, FU_REDFISH_NVIDIA_TASK_FAILED);
+	g_assert_false(ret);
 	g_clear_error(&error);
 
 	fwupd_json_object_add_string(json_task, "TaskState", "VendorDefinedSuccess");
 	fwupd_json_object_add_integer(json_task, "PercentComplete", 100);
-	state = fu_redfish_nvidia_device_parse_task("/redfish/v1/TaskService/Tasks/1",
-						     json_task,
-						     &percent,
-						     &error);
+	ret = fu_redfish_nvidia_device_parse_task("/redfish/v1/TaskService/Tasks/1",
+						  json_task,
+						  &task_state,
+						  &percentage,
+						  &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
-	g_assert_cmpint(state, ==, FU_REDFISH_NVIDIA_TASK_FAILED);
-}
-
-static void
-fu_redfish_nvidia_firmware_size_func(void)
-{
-	const guint8 payload[] = {0x00, 0x01, 0x02, 0x03, 0x04};
-	g_autoptr(FuContext) ctx = fu_context_new();
-	g_autoptr(FuDevice) device =
-	    g_object_new(FU_TYPE_REDFISH_NVIDIA_DEVICE, "context", ctx, NULL);
-	g_autoptr(FuFirmware) firmware = NULL;
-	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
-	g_autoptr(GBytes) blob_exact = g_bytes_new_static(payload, 4);
-	g_autoptr(GBytes) blob_oversized = g_bytes_new_static(payload, sizeof(payload));
-	g_autoptr(FuInputStream) stream_exact = fu_memory_input_stream_new_from_bytes(blob_exact);
-	g_autoptr(FuInputStream) stream_oversized =
-	    fu_memory_input_stream_new_from_bytes(blob_oversized);
-	g_autoptr(GError) error = NULL;
-
-	/* exact advertised maximum must remain intact */
-	fu_device_set_firmware_size_max(device, 4);
-	firmware = fu_device_prepare_firmware(device,
-					      stream_exact,
-					      progress,
-					      FU_FIRMWARE_PARSE_FLAG_NONE,
-					      &error);
-	g_assert_no_error(error);
-	g_assert_nonnull(firmware);
-	g_assert_cmpuint(fu_firmware_get_size(firmware), ==, 4);
-	g_clear_object(&firmware);
-
-	/* reject one byte beyond the maximum instead of truncating it */
-	firmware = fu_device_prepare_firmware(device,
-					      stream_oversized,
-					      progress,
-					      FU_FIRMWARE_PARSE_FLAG_NONE,
-					      &error);
-	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
-	g_assert_null(firmware);
+	g_assert_false(ret);
 }
 
 static void
@@ -679,6 +694,109 @@ fu_redfish_dell_devices_func(gconstpointer user_data)
 	g_assert_true(FU_IS_REDFISH_DEVICE(dev));
 	g_assert_true(
 	    fu_device_has_guid(dev, "REDFISH\\VENDOR_Lenovo&SYSTEMID_0C60&SOFTWAREID_UEFI-AFE1-6"));
+}
+
+/* drives the whole GB300 flow against redfish.py: detection, the multipart
+ * upload parameters, deriving the persistent task from the monitor URI, the
+ * aux-rail power cycle on activation, and the three shapes the BMC can use to
+ * report the task monitor -- a Location header, the @odata.id fallback when the
+ * header is absent, and a non-string @odata.id that has to be rejected.
+ *
+ * The empty-200 monitor quirk is deliberately not claimed here: /Tasks/900
+ * reports Completed on the first poll, so the monitor URI is never requested.
+ * That path is covered by fu_redfish_nvidia_task_response_func() instead. */
+static void
+fu_redfish_nvidia_update_func(gconstpointer user_data)
+{
+	FuDevice *dev;
+	FuTest *self = (FuTest *)user_data;
+	GPtrArray *devices;
+	gboolean ret;
+	g_autoptr(FuFirmware) firmware = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	g_autoptr(FuProgress) progress_nolocation = fu_progress_new(G_STRLOC);
+	g_autoptr(FuProgress) progress_badodata = fu_progress_new(G_STRLOC);
+	g_autoptr(GBytes) blob_fw = NULL;
+	g_autoptr(GError) error = NULL;
+
+	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_NO_PROFILE);
+	fu_progress_add_flag(progress_nolocation, FU_PROGRESS_FLAG_NO_PROFILE);
+	fu_progress_add_flag(progress_badodata, FU_PROGRESS_FLAG_NO_PROFILE);
+
+	devices = fu_plugin_get_devices(self->nvidia_plugin);
+	g_assert_nonnull(devices);
+	if (devices->len == 0) {
+		g_test_skip("no redfish support");
+		return;
+	}
+	g_assert_cmpint(devices->len, ==, 1);
+	dev = g_ptr_array_index(devices, 0);
+
+	/* the GB300 is detected by chassis model, so the NVIDIA subclass must have
+	 * been chosen over the generic multipart device */
+	g_assert_true(FU_IS_REDFISH_NVIDIA_DEVICE(dev));
+
+	/* every inventory entry is called "Software Inventory", so the device
+	 * renames itself after the URI basename to stay distinguishable;
+	 * fu_device_set_name() turns the underscores into spaces */
+	g_assert_cmpstr(fu_device_get_name(dev), ==, "FW BMC 0");
+	g_assert_true(fu_device_has_instance_id(dev,
+						"NVIDIA_OOB\\URI_/redfish/v1/UpdateService/"
+						"FirmwareInventory/FW_BMC_0",
+						FU_DEVICE_INSTANCE_FLAG_VISIBLE));
+	g_assert_true(fu_device_has_instance_id(dev,
+						"NVIDIA_OOB\\SWID_0xFF00",
+						FU_DEVICE_INSTANCE_FLAG_VISIBLE));
+
+	/* redfish.py rejects the upload unless Targets is empty, ForceUpdate is
+	 * set and the apply time is Immediate */
+	blob_fw = g_bytes_new_static("hello", 5);
+	firmware = fu_firmware_new_from_bytes(blob_fw);
+	ret = fu_plugin_runner_write_firmware(self->nvidia_plugin,
+					      dev,
+					      firmware,
+					      progress,
+					      FWUPD_INSTALL_FLAG_NONE,
+					      &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* a completed write stages the firmware rather than applying it; this is
+	 * deliberately not done in attach(), which also runs after a failed write */
+	g_assert_true(fu_device_has_flag(dev, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION));
+	g_assert_false(fu_device_has_flag(dev, FWUPD_DEVICE_FLAG_NEEDS_SHUTDOWN));
+
+	/* activation finds the OEM action on BMC_0 and asks for the aux cycle;
+	 * redfish.py rejects any ResetType other than AuxPowerCycleForce */
+	ret = fu_plugin_runner_activate(self->nvidia_plugin, dev, progress, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_false(fu_device_has_flag(dev, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION));
+
+	/* the second upload comes back without a Location header, so the monitor
+	 * URI has to be taken from @odata.id in the response body instead */
+	ret = fu_plugin_runner_write_firmware(self->nvidia_plugin,
+					      dev,
+					      firmware,
+					      progress_nolocation,
+					      FWUPD_INSTALL_FLAG_NONE,
+					      &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_true(fu_device_has_flag(dev, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION));
+
+	/* the third has no Location header either, and its @odata.id is a number
+	 * rather than a string -- testing only that the node exists accepts this and
+	 * leaves the location NULL, so the write has to fail here rather than go on
+	 * to poll a NULL task */
+	ret = fu_plugin_runner_write_firmware(self->nvidia_plugin,
+					      dev,
+					      firmware,
+					      progress_badodata,
+					      FWUPD_INSTALL_FLAG_NONE,
+					      &error);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
+	g_assert_false(ret);
 }
 
 static void
@@ -897,9 +1015,9 @@ main(int argc, char **argv)
 	g_test_add_func("/redfish/common", fu_redfish_common_func);
 	g_test_add_func("/redfish/common/version", fu_redfish_common_version_func);
 	g_test_add_func("/redfish/common/lenovo", fu_redfish_common_lenovo_func);
+	g_test_add_func("/redfish/session-key-file", fu_redfish_session_key_file_func);
 	g_test_add_func("/redfish/nvidia/task-response", fu_redfish_nvidia_task_response_func);
 	g_test_add_func("/redfish/nvidia/task-parse", fu_redfish_nvidia_task_parse_func);
-	g_test_add_func("/redfish/nvidia/firmware-size", fu_redfish_nvidia_firmware_size_func);
 	g_test_add_func("/redfish/network/mac_addr", fu_redfish_network_mac_addr_func);
 	g_test_add_func("/redfish/network/vid_pid", fu_redfish_network_vid_pid_func);
 	g_test_add_data_func("/redfish/unlicensed-plugin/devices",
@@ -908,6 +1026,7 @@ main(int argc, char **argv)
 	g_test_add_data_func("/redfish/smc_plugin/devices", self, fu_redfish_smc_devices_func);
 	g_test_add_data_func("/redfish/smc-plugin/update", self, fu_redfish_smc_update_func);
 	g_test_add_data_func("/redfish/hpe-plugin/update", self, fu_redfish_hpe_update_func);
+	g_test_add_data_func("/redfish/nvidia-plugin/update", self, fu_redfish_nvidia_update_func);
 	g_test_add_data_func("/redfish/plugin/devices", self, fu_redfish_devices_func);
 	g_test_add_data_func("/redfish/dell/devices", self, fu_redfish_dell_devices_func);
 	g_test_add_data_func("/redfish/plugin/update", self, fu_redfish_update_func);

--- a/plugins/redfish/meson.build
+++ b/plugins/redfish/meson.build
@@ -28,6 +28,7 @@ plugin_builtin_redfish = static_library(
     'fu-redfish-multipart-device.c',
     'fu-redfish-network.c',
     'fu-redfish-network-device.c',
+    'fu-redfish-nvidia-device.c',
     'fu-redfish-request.c',
     'fu-redfish-smbios.c', # fuzzing
     ipmi_src,

--- a/plugins/redfish/tests/redfish.py
+++ b/plugins/redfish/tests/redfish.py
@@ -15,12 +15,14 @@ HARDCODED_SMC_USERNAME = "smc_username"
 HARDCODED_UNL_USERNAME = "unlicensed_username"
 HARDCODED_HPE_USERNAME = "hpe_username"
 HARDCODED_DELL_USERNAME = "dell_username"
+HARDCODED_NVIDIA_USERNAME = "nvidia_username"
 HARDCODED_USERNAMES = {
     "username2",
     HARDCODED_SMC_USERNAME,
     HARDCODED_UNL_USERNAME,
     HARDCODED_HPE_USERNAME,
     HARDCODED_DELL_USERNAME,
+    HARDCODED_NVIDIA_USERNAME,
 }
 HARDCODED_PASSWORD = "password2"
 
@@ -28,6 +30,8 @@ app._percentage545: int = 0
 app._percentage546: int = 0
 app._hpeupdatestate: str = "Idle"
 app._hpeupdateresult = None
+app._nvidia_auxpowerreset: int = 0
+app._nvidia_upload: int = 0
 
 
 def _failure(msg: str, status=400):
@@ -39,6 +43,29 @@ def _failure(msg: str, status=400):
     )
 
 
+def _username() -> str:
+    try:
+        return request.authorization["username"]
+    except (KeyError, TypeError):
+        return ""
+
+
+def _is_nvidia() -> bool:
+    return _username() == HARDCODED_NVIDIA_USERNAME
+
+
+def _not_found(uri: str):
+    # a real Redfish service always sets error.code; _failure() omits it, and an
+    # absent code makes the plugin's error mapping dereference NULL
+    res = {
+        "error": {
+            "code": "Base.1.8.ResourceMissingAtURI",
+            "message": f"The resource at {uri} was not found.",
+        }
+    }
+    return Response(response=json.dumps(res), status=404, mimetype="application/json")
+
+
 @app.route("/redfish/v1/")
 def index():
     # reset counter
@@ -46,6 +73,7 @@ def index():
     app._percentage546 = 0
     app._hpeupdatestate = "Idle"
     app._hpeupdateresult = None
+    app._nvidia_upload = 0
 
     # check password from the config file
     try:
@@ -149,14 +177,174 @@ def update_service():
         if app._hpeupdateresult is not None:
             res["Oem"]["Hpe"]["Result"] = app._hpeupdateresult
         res["HttpPushUri"] = "/FWUpdate-hpe"
+    elif _is_nvidia():
+        res["MultipartHttpPushUri"] = "/FWUpdate-nvidia"
     else:
         res["MultipartHttpPushUri"] = "/FWUpdate"
 
     return Response(json.dumps(res), status=200, mimetype="application/json")
 
 
+# ── NVIDIA DGX Station GB300 ──────────────────────────────────────────────────
+# The plugin recognises a GB300 by probing Chassis_0 for Manufacturer=NVIDIA and
+# a Model containing both "GB300" and "Station"; every other persona must fail
+# that check so it keeps the generic multipart device.
+@app.route("/redfish/v1/Chassis/Chassis_0")
+def chassis_chassis_0():
+    if not _is_nvidia():
+        return _not_found("/redfish/v1/Chassis/Chassis_0")
+    res = {
+        "@odata.id": "/redfish/v1/Chassis/Chassis_0",
+        "@odata.type": "#Chassis.v1_25_0.Chassis",
+        "Id": "Chassis_0",
+        "Manufacturer": "NVIDIA",
+        "Model": "DGX Station GB300",
+        "Name": "Chassis",
+    }
+    return Response(json.dumps(res), status=200, mimetype="application/json")
+
+
+# The aux-rail reset is advertised by BMC_0, deliberately not by the chassis used
+# for detection above -- the plugin has to read the action target from here.
+@app.route("/redfish/v1/Chassis/BMC_0")
+def chassis_bmc_0():
+    if not _is_nvidia():
+        return _not_found("/redfish/v1/Chassis/BMC_0")
+    res = {
+        "@odata.id": "/redfish/v1/Chassis/BMC_0",
+        "@odata.type": "#Chassis.v1_25_0.Chassis",
+        "Id": "BMC_0",
+        "Manufacturer": "NVIDIA",
+        "Name": "BMC",
+        "Actions": {
+            "Oem": {
+                "#NvidiaChassis.AuxPowerReset": {
+                    "@Redfish.ActionInfo": "/redfish/v1/Chassis/BMC_0/Oem/Nvidia/AuxPowerResetActionInfo",
+                    "target": "/redfish/v1/Chassis/BMC_0/Actions/Oem/NvidiaChassis.AuxPowerReset",
+                }
+            }
+        },
+    }
+    return Response(json.dumps(res), status=200, mimetype="application/json")
+
+
+@app.route(
+    "/redfish/v1/Chassis/BMC_0/Actions/Oem/NvidiaChassis.AuxPowerReset",
+    methods=["POST"],
+)
+def chassis_bmc_0_auxpowerreset():
+    if not _is_nvidia():
+        return _not_found("/redfish/v1/Chassis/BMC_0")
+    try:
+        reset_type = request.get_json(force=True)["ResetType"]
+    except (TypeError, KeyError):
+        return _failure("no ResetType")
+    if reset_type != "AuxPowerCycleForce":
+        return _failure(f"unsupported ResetType {reset_type}")
+    # a real BMC drops the rail here and the connection dies; the mock has to
+    # answer so the test can assert the request was well formed
+    app._nvidia_auxpowerreset += 1
+    return Response(status=204)
+
+
+@app.route("/redfish/v1/UpdateService/FirmwareInventory/FW_BMC_0")
+def firmware_inventory_nvidia_bmc():
+    res = {
+        "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/FW_BMC_0",
+        "@odata.type": "#SoftwareInventory.v1_2_3.SoftwareInventory",
+        "Id": "FW_BMC_0",
+        "Manufacturer": "NVIDIA",
+        # every GB300 inventory entry is named this, which is why the device
+        # renames itself after the URI basename
+        "Name": "Software Inventory",
+        "SoftwareId": "0xFF00",
+        "Updateable": True,
+        "Version": "GB300-1.00",
+    }
+    return Response(json.dumps(res), status=200, mimetype="application/json")
+
+
+@app.route("/FWUpdate-nvidia", methods=["POST"])
+def fwupdate_nvidia():
+    data = json.loads(request.form["UpdateParameters"])
+    # the GB300 BMC rejects a populated Targets array, needs ForceUpdate, and
+    # accepts only Immediate -- assert the plugin honours all three
+    if data.get("Targets") != []:
+        return _failure("Targets must be empty")
+    if data.get("ForceUpdate") is not True:
+        return _failure("ForceUpdate must be true")
+    if data.get("@Redfish.OperationApplyTime") != "Immediate":
+        return _failure("apply time invalid")
+    fileitem = request.files["UpdateFile"]
+    if fileitem.read().decode() != "hello":
+        return _failure("payload invalid")
+    # successive uploads exercise the three ways the task monitor can come back;
+    # the plugin has to derive the persistent /Tasks/<id> resource from all of
+    # them, or reject the response outright
+    app._nvidia_upload += 1
+
+    # 1: the Location header, which is what the shipping BMC firmware sends
+    if app._nvidia_upload == 1:
+        return Response(
+            json.dumps({"Accepted": {"code": "Base.v1_4_0.Accepted"}}),
+            status=202,
+            mimetype="application/json",
+            headers={"Location": "/redfish/v1/TaskService/Tasks/900/Monitor"},
+        )
+
+    # 2: no Location header at all, so the monitor URI has to be taken from
+    # @odata.id in the response body instead
+    if app._nvidia_upload == 2:
+        return Response(
+            json.dumps({"@odata.id": "/redfish/v1/TaskService/Tasks/900/Monitor"}),
+            status=202,
+            mimetype="application/json",
+        )
+
+    # 3: no Location header, and @odata.id is a number rather than a string.
+    # Testing the node's presence rather than its parsed value accepts this and
+    # leaves the location NULL, so the plugin has to reject the response rather
+    # than poll a NULL task
+    return Response(
+        json.dumps({"@odata.id": 12345}),
+        status=202,
+        mimetype="application/json",
+    )
+
+
+@app.route("/redfish/v1/TaskService/Tasks/900")
+def task_status_900():
+    res = {
+        "@odata.id": "/redfish/v1/TaskService/Tasks/900",
+        "@odata.type": "#Task.v1_4_3.Task",
+        "Id": "900",
+        "Name": "Task 900",
+        "PercentComplete": 100,
+        "TaskState": "Completed",
+        "TaskStatus": "OK",
+    }
+    return Response(json.dumps(res), status=200, mimetype="application/json")
+
+
+@app.route("/redfish/v1/TaskService/Tasks/900/Monitor")
+def task_monitor_900():
+    # the GB300 quirk: once the task is done the monitor answers 200 with an
+    # empty body rather than the canonical 404
+    return Response(status=200)
+
+
 @app.route("/redfish/v1/UpdateService/FirmwareInventory")
 def firmware_inventory():
+    if _is_nvidia():
+        res = {
+            "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory",
+            "@odata.type": "#SoftwareInventoryCollection.SoftwareInventoryCollection",
+            "Members": [
+                {"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/FW_BMC_0"},
+            ],
+            "Members@odata.count": 1,
+        }
+        return Response(json.dumps(res), status=200, mimetype="application/json")
     res = {
         "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory",
         "@odata.type": "#SoftwareInventoryCollection.SoftwareInventoryCollection",


### PR DESCRIPTION
## Summary

Adds a new `FuRedfishNvidiaDevice` subclass to the upstream Redfish plugin
to support OOB firmware updates for the NVIDIA DGX Station GB300 via the
BMC Redfish interface.

### Changes

- `fu-redfish-nvidia-device.c/.h`: New device type implementing the GB300-specific
  PLDM bundle upload and task-monitoring flow via `MultipartHttpPushUri`
- `fu-redfish-backend.c/.h`: GB300 BMC detection via chassis model check;
  X-Auth-Token session support with `session_xauth_header`
- `fu-redfish-device.c/.h`: Added `fu_redfish_device_get_json_obj_member()` getter
- `fu-redfish-plugin.c`: Reads `FWUPD_SESSION_TOKEN_FILE` env var for pre-authenticated sessions
- `fu-redfish-request.c/.h`: Added `fu_redfish_request_set_auth_headers()` to prevent
  X-Auth-Token being dropped in `perform_full()` POST/PATCH requests
- `meson.build`: Adds `fu-redfish-nvidia-device.c` to plugin sources
- `fu-self-test.c`: Unit tests for GB300-specific task state classification

### GB300-specific behaviours handled

- `MultipartHttpPushUri` upload with empty `Targets[]` (BMC resolves from PLDM manifest)
- `ForceUpdate=true` required; `OperationApplyTime=Immediate` only accepted value
- `PercentComplete` only updated on `/Tasks/<id>`, not `/Tasks/<id>/Monitor`
- HTTP 200 + empty body signals TaskMonitor reaped (not canonical 404)
- `saw_persistent_task` guard prevents false-success when only Monitor URI was observed
- Chassis model check (`GB300` + `Station`) gates GB300-specific behaviour so other NVIDIA Redfish BMCs are unaffected

### Session authentication

The plugin reads a pre-created X-Auth-Token from `FWUPD_SESSION_TOKEN_FILE`
(set by a platform-specific service via a systemd drop-in). When absent,
falls through to existing Basic Auth. No NVIDIA-specific code paths in the
session handling — any vendor can set this env var.

## Test plan

- [ ] `fwupdmgr get-devices` enumerates all 10 OOB firmware components on DGX Station GB300
- [ ] PLDM bundle upload completes and task polls to 100%
- [ ] Firmware activates after AC power cycle
- [ ] Non-GB300 NVIDIA Redfish systems unaffected (chassis check)
- [ ] Unit tests pass: `ninja -C build test -k 0 2>&1 | grep redfish`