### PR TITLE
trivial: Declare the image GType accepted by FuSrecFirmware

### DIFF
--- a/libfwupdplugin/fu-srec-firmware.c
+++ b/libfwupdplugin/fu-srec-firmware.c
@@ -677,6 +677,7 @@ fu_srec_firmware_class_init(FuSrecFirmwareClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	fu_firmware_add_image_gtype(firmware_class, FU_TYPE_FIRMWARE);
 	object_class->finalize = fu_srec_firmware_finalize;
 	fu_firmware_set_size_max(firmware_class, 32 * FU_MB);
 	firmware_class->parse = fu_srec_firmware_parse;


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

---

Converting into SREC emits a g_critical, and aborts fwupdtool under `G_DEBUG=fatal-criticals`:

```
FuFirmware  FuSrecFirmware did not add image GType FuFirmware with fu_firmware_add_image_gtype()
```

`firmware-convert` adds the source image with `fu_firmware_add_image()`, but `FuSrecFirmware` never declared an accepted image GType. Declare `FU_TYPE_FIRMWARE` like `FuIhexFirmware` does; the conversion now fails cleanly with `no payload set` instead of SIGABRT.

Reproduce:

```
echo '<firmware gtype="FuSrecFirmware"><id>HDR</id><data>aGVsbG8gd29ybGQ=</data></firmware>' > blob.builder.xml
fwupdtool firmware-build blob.builder.xml blob.srec
G_DEBUG=fatal-criticals fwupdtool firmware-convert blob.srec out.bin srec srec
```

Full test suite passes (144/144 OK). `FuDfuFirmware`, `FuUf2Firmware` and `FuCcgxFirmware` have the same missing declaration; happy to follow up with the same one-liner for those if wanted.
