### PR TITLE
focal-moc: Add update protocol v2 with an encrypted TransportSec channel

### DIFF
--- a/plugins/focal-moc/README.md
+++ b/plugins/focal-moc/README.md
@@ -14,8 +14,9 @@ FocalTech Systems Co., Ltd.
 
 The daemon decompresses the cabinet archive and extracts a flat binary firmware blob.
 No additional wrapping is expected.  The plugin computes a CRC32 over the full image, sends it in
-the SHO header, then streams the image in 1 KiB STX blocks followed by a zero-padded EOT block for
-any remainder.
+the SOH header, then streams the image in 1 KiB STX blocks followed by a zero-padded EOT block for
+any remainder.  The update stream is limited to 255 1 KiB data frames because the protocol uses an
+8-bit frame number.
 
 This plugin supports the following protocol ID:
 
@@ -29,10 +30,16 @@ These devices use the standard USB instance ID values such as `USB\VID_2808&PID_
 
 The firmware is deployed when the device is in normal runtime mode.
 The plugin first switches the device to bootloader (IAP) mode (`detach`), then streams the firmware
-image using the 3-phase SHO/STX/EOT protocol.
+image using the 3-phase SOH/STX/EOT protocol.
 The device reboots automatically after the final ACK; the plugin then issues a return-to-app
 command (`attach`) in case the device has not yet rebooted.
 The device re-enumerates after each mode switch.
+
+Before the transfer the wake-up command confirms the device is responsive rather than discovering
+a dead device part way through the frames.  A bootloader is probed once to tell its legacy status
+codes apart from the unified ones, so an ambiguous failure is not reported as though it had a
+known meaning.  Reply parsing locates the checksum from the declared length, allowing only the
+padding the firmware appends past the declared frame.
 
 Both modes use the same USB product ID, so the mode is taken from the `_APP_` or `_IAP_` marker in
 the version string reported by the device.

--- a/plugins/focal-moc/README.md
+++ b/plugins/focal-moc/README.md
@@ -10,6 +10,11 @@ transfer.
 The communication protocol is derived from the reference `UpgradeTool` source code provided by
 FocalTech Systems Co., Ltd.
 
+Devices use one of two generations of the vendor firmware-update protocol.  The default device
+type detaches with plaintext runtime commands and retains the runtime PID in IAP mode.  Newer
+devices, matched to `FuFocalMocSignedDevice` in `focal-moc.quirk`, require an encrypted
+TransportSec channel for runtime commands and re-enumerate the IAP at PID `0x0201`.
+
 ## Firmware Format
 
 The daemon decompresses the cabinet archive and extracts a flat binary firmware blob.
@@ -17,6 +22,13 @@ No additional wrapping is expected.  The plugin computes a CRC32 over the full i
 the SOH header, then streams the image in 1 KiB STX blocks followed by a zero-padded EOT block for
 any remainder.  The update stream is limited to 255 1 KiB data frames because the protocol uses an
 8-bit frame number.
+
+Newer devices instead use a 256-byte `FWHD` header followed by the application body.  The magic
+0x46574844 ("FWHD") is stored little-endian, so the file starts with the raw bytes `DHWF`.  The
+header identifies an APP image, supplies the monotonic version, and contains the body digest and
+ECDSA-P256 signature.  The complete signed image is streamed using 16-bit frame numbers, and the
+IAP checks the image CRC and signature before booting it; if verification fails and the previous
+application is valid, the IAP restores that backup.
 
 This plugin supports the following protocol ID:
 
@@ -41,10 +53,19 @@ codes apart from the unified ones, so an ambiguous failure is not reported as th
 known meaning.  Reply parsing locates the checksum from the declared length, allowing only the
 padding the firmware appends past the declared frame.
 
-Both modes use the same USB product ID, so the mode is taken from the `_APP_` or `_IAP_` marker in
-the version string reported by the device.
+Default devices use the same USB product ID in both modes, so the mode is taken from the `_APP_`
+or `_IAP_` marker in the version string reported by the device.
 A device left in bootloader mode by an interrupted update is detected as such, and an update can
 start without another mode switch.
+
+Newer devices establish an ephemeral ECDH P-256 TransportSec session before any runtime command:
+the handshake derives direction-specific AES-256-CTR, HMAC-SHA256, and IV keys and confirms them,
+and every command then travels in an authenticated cipher frame with strict sequence numbers and
+fragment reassembly.  The runtime detach command is encrypted; the `0x0201` IAP then accepts the
+signed `FWHD` image in plaintext, so a device stuck in IAP stays recoverable.
+
+TransportSec requires GnuTLS 3.8.2 or later.  Builds using an older GnuTLS keep these runtime
+devices visible but not updatable.
 
 ## Vendor ID Security
 

--- a/plugins/focal-moc/focal-moc.quirk
+++ b/plugins/focal-moc/focal-moc.quirk
@@ -7,6 +7,9 @@ Plugin = focal_moc
 [USB\VID_2808&PID_A27A]
 Plugin = focal_moc
 
+[USB\VID_2808&PID_A101]
+Plugin = focal_moc
+
 [USB\VID_2808&PID_A959]
 Plugin = focal_moc
 
@@ -14,6 +17,9 @@ Plugin = focal_moc
 Plugin = focal_moc
 
 [USB\VID_2808&PID_A57A]
+Plugin = focal_moc
+
+[USB\VID_2808&PID_A77A]
 Plugin = focal_moc
 
 [USB\VID_2808&PID_A78A]

--- a/plugins/focal-moc/focal-moc.quirk
+++ b/plugins/focal-moc/focal-moc.quirk
@@ -42,3 +42,15 @@ Plugin = focal_moc
 
 [USB\VID_2808&PID_6553]
 Plugin = focal_moc
+
+# newer devices require an encrypted TransportSec channel to enter IAP
+[USB\VID_2808&PID_AA7A]
+Plugin = focal_moc
+GType = FuFocalMocSignedDevice
+CounterpartGuid = USB\VID_2808&PID_0201
+
+[USB\VID_2808&PID_0201]
+Plugin = focal_moc
+GType = FuFocalMocSignedDevice
+Flags = is-bootloader,is-iap
+CounterpartGuid = USB\VID_2808&PID_AA7A

--- a/plugins/focal-moc/fu-focal-moc-common.c
+++ b/plugins/focal-moc/fu-focal-moc-common.c
@@ -7,74 +7,88 @@
 #include "config.h"
 
 #include "fu-focal-moc-common.h"
-#include "fu-focal-moc-struct.h"
+
+#define FU_FOCAL_MOC_FP_VERSION_MAX_SIZE 64
 
 GByteArray *
-fu_focal_moc_packet_new(guint8 cmd, const guint8 *buf, gsize bufsz, GError **error)
+fu_focal_moc_packet_new(guint8 command, const guint8 *buf, gsize bufsz, GError **error)
 {
-	g_autoptr(FuStructFocalMocCmdReq) st_req = fu_struct_focal_moc_cmd_req_new();
+	g_autoptr(FuStructFocalMocPacketHeader) st = NULL;
 
-	g_return_val_if_fail(buf != NULL || bufsz == 0, NULL);
-
+	if (bufsz > 0 && buf == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "payload is missing");
+		return NULL;
+	}
 	if (bufsz > G_MAXUINT16 - 1) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INVALID_DATA,
-			    "payload too large: 0x%x",
-			    (guint)bufsz);
+			    "payload too large: 0x%zx",
+			    bufsz);
 		return NULL;
 	}
-
-	/* the length counts the trailing checksum as well as the payload */
-	fu_struct_focal_moc_cmd_req_set_ln(st_req, (guint16)bufsz + 1);
-	fu_struct_focal_moc_cmd_req_set_cmd(st_req, cmd);
+	st = fu_struct_focal_moc_packet_header_new();
+	fu_struct_focal_moc_packet_header_set_length(st, (guint16)bufsz + 1);
+	fu_struct_focal_moc_packet_header_set_command(st, command);
 	if (bufsz > 0)
-		g_byte_array_append(st_req->buf, buf, bufsz);
-	fu_byte_array_append_uint8(st_req->buf,
-				   fu_xor8(st_req->buf->data + 1, st_req->buf->len - 1));
+		g_byte_array_append(st->buf, buf, bufsz);
+	fu_byte_array_append_uint8(st->buf, fu_xor8(st->buf->data + 1, st->buf->len - 1));
 
 	/* success */
-	return g_byte_array_ref(st_req->buf);
+	return g_byte_array_ref(st->buf);
 }
 
 GByteArray *
-fu_focal_moc_packet_parse(const guint8 *buf, gsize bufsz, GError **error)
+fu_focal_moc_packet_parse(const guint8 *buf,
+			  gsize bufsz,
+			  gboolean allow_legacy_trailer,
+			  guint8 *status,
+			  GError **error)
 {
 	gsize packet_sz;
-	guint16 ln;
+	guint16 length;
 	guint8 bcc = 0;
 	guint8 bcc_actual = 0;
-	g_autoptr(FuStructFocalMocCmdRsp) st = NULL;
+	g_autoptr(FuStructFocalMocPacketHeader) st = NULL;
 	g_autoptr(GByteArray) data = g_byte_array_new();
 
-	g_return_val_if_fail(buf != NULL, NULL);
-	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
-
-	st = fu_struct_focal_moc_cmd_rsp_parse(buf, bufsz, 0, error);
-	if (st == NULL)
-		return NULL;
-	ln = fu_struct_focal_moc_cmd_rsp_get_ln(st);
-	if (ln < 1) {
+	/* a zero-length USB read hands us a NULL buffer; this is device data,
+	 * not a programmer error */
+	if (buf == NULL || bufsz == 0) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_INVALID_DATA,
-				    "invalid packet length 0x0");
+				    "packet is empty");
 		return NULL;
 	}
-
-	/* the device pads the response, so the declared length rather than the
-	 * transfer size locates the checksum */
-	packet_sz = (gsize)ln + FU_STRUCT_FOCAL_MOC_CMD_RSP_SIZE;
-	if (bufsz < packet_sz) {
+	st = fu_struct_focal_moc_packet_header_parse(buf, bufsz, 0, error);
+	if (st == NULL)
+		return NULL;
+	length = fu_struct_focal_moc_packet_header_get_length(st);
+	if (length < 1) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "packet length excludes status");
+		return NULL;
+	}
+	/* update protocol v1 firmware transmits one byte of stale buffer past the
+	 * declared frame; accept exactly that one trailing byte there while still
+	 * computing the BCC over the declared range only */
+	packet_sz = (gsize)length + 4;
+	if (bufsz != packet_sz && !(allow_legacy_trailer && bufsz == packet_sz + 1)) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INVALID_DATA,
-			    "packet truncated: got 0x%x, expected 0x%x",
-			    (guint)bufsz,
-			    (guint)packet_sz);
+			    "packet size invalid: got=0x%zx expected=0x%zx",
+			    bufsz,
+			    packet_sz);
 		return NULL;
 	}
-	if (!fu_xor8_safe(buf, bufsz, 0x1, (gsize)ln + 2, &bcc, error))
+	if (!fu_xor8_safe(buf, bufsz, 0x1, (gsize)length + 2, &bcc, error))
 		return NULL;
 	if (!fu_memread_uint8_safe(buf, bufsz, packet_sz - 1, &bcc_actual, error))
 		return NULL;
@@ -82,17 +96,80 @@ fu_focal_moc_packet_parse(const guint8 *buf, gsize bufsz, GError **error)
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INVALID_DATA,
-			    "checksum mismatch: got 0x%02x, expected 0x%02x",
+			    "packet BCC mismatch: got=0x%02x expected=0x%02x",
 			    bcc_actual,
 			    bcc);
 		return NULL;
 	}
-
-	if (ln > 1)
-		g_byte_array_append(data, buf + FU_STRUCT_FOCAL_MOC_CMD_RSP_SIZE, ln - 1);
+	if (status != NULL)
+		*status = fu_struct_focal_moc_packet_header_get_command(st);
+	if (length > 1)
+		g_byte_array_append(data, buf + FU_STRUCT_FOCAL_MOC_PACKET_HEADER_SIZE, length - 1);
 
 	/* success */
 	return g_steal_pointer(&data);
+}
+
+GByteArray *
+fu_focal_moc_ymodem_build_soh(gsize firmware_sz, guint32 crc32, GError **error)
+{
+	g_autoptr(FuStructFocalMocSohV1) st = fu_struct_focal_moc_soh_v1_new();
+
+	if (firmware_sz > G_MAXUINT32) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "firmware too large: 0x%zx",
+			    firmware_sz);
+		return NULL;
+	}
+	if (!fu_struct_focal_moc_soh_v1_set_filename(st, "app.bin", error))
+		return NULL;
+	fu_struct_focal_moc_soh_v1_set_firmware_size(st, (guint32)firmware_sz);
+	fu_struct_focal_moc_soh_v1_set_crc32(st, crc32);
+	return g_byte_array_ref(st->buf);
+}
+
+GByteArray *
+fu_focal_moc_ymodem_build_data(FuFocalMocFrame kind,
+			       guint16 sequence,
+			       const guint8 *buf,
+			       gsize bufsz,
+			       GError **error)
+{
+	g_autoptr(FuStructFocalMocDataV1) st = fu_struct_focal_moc_data_v1_new();
+
+	if (kind != FU_FOCAL_MOC_FRAME_STX && kind != FU_FOCAL_MOC_FRAME_EOT) {
+		const gchar *kindstr = fu_focal_moc_frame_to_string(kind);
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "data frame kind invalid: %s",
+			    kindstr != NULL ? kindstr : "unknown");
+		return NULL;
+	}
+	if (buf == NULL || bufsz > FU_FOCAL_MOC_YMODEM_DATA_SIZE) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "data frame size invalid: 0x%zx",
+			    bufsz);
+		return NULL;
+	}
+	/* the frame number is a single byte on the wire */
+	if (sequence > G_MAXUINT8) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "frame sequence invalid: %u",
+			    sequence);
+		return NULL;
+	}
+	fu_struct_focal_moc_data_v1_set_kind(st, kind);
+	fu_struct_focal_moc_data_v1_set_sequence(st, (guint8)sequence);
+	if (!fu_struct_focal_moc_data_v1_set_data(st, buf, bufsz, error))
+		return NULL;
+	return g_byte_array_ref(st->buf);
 }
 
 gchar *
@@ -101,51 +178,312 @@ fu_focal_moc_version_parse(const guint8 *buf, gsize bufsz, gboolean *is_bootload
 	const gchar *suffix;
 	gboolean has_app;
 	gboolean has_iap;
-	g_autofree gchar *version = NULL;
+	g_autofree gchar *version_full = NULL;
 
-	g_return_val_if_fail(is_bootloader != NULL, NULL);
-	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
-
-	if (buf == NULL || bufsz == 0) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_INVALID_DATA,
-				    "version payload is empty");
-		return NULL;
-	}
-	version = g_strndup((const gchar *)buf, bufsz);
-	if (version[0] == '\0' || !g_utf8_validate(version, -1, NULL)) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_INVALID_DATA,
-				    "version is not valid text");
-		return NULL;
-	}
-
-	suffix = strrchr(version, '_');
-	if (suffix == NULL || suffix[1] == '\0') {
+	if (buf == NULL || bufsz == 0 || bufsz > FU_FOCAL_MOC_VERSION_MAX_SIZE) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INVALID_DATA,
-			    "version has no build number: %s",
-			    version);
+			    "firmware version size invalid: 0x%zx",
+			    bufsz);
 		return NULL;
 	}
-
+	version_full = g_strndup((const gchar *)buf, bufsz);
+	if (version_full[0] == '\0' || !g_utf8_validate(version_full, -1, NULL)) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "firmware version is not valid text");
+		return NULL;
+	}
 	/* the runtime and the bootloader share a USB product ID, so only the
 	 * build string tells them apart */
-	has_iap = g_strstr_len(version, -1, "_IAP_") != NULL;
-	has_app = g_strstr_len(version, -1, "_APP_") != NULL;
+	has_iap = g_strstr_len(version_full, -1, "_IAP_") != NULL;
+	has_app = g_strstr_len(version_full, -1, "_APP_") != NULL;
 	if (has_iap == has_app) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INVALID_DATA,
 			    "cannot determine mode from version: %s",
-			    version);
+			    version_full);
 		return NULL;
 	}
-	*is_bootloader = has_iap;
+	if (is_bootloader != NULL)
+		*is_bootloader = has_iap;
+
+	suffix = strrchr(version_full, '_');
+	if (suffix == NULL || suffix[1] == '\0') {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "version has no build number: %s",
+			    version_full);
+		return NULL;
+	}
 
 	/* success */
 	return g_strdup(suffix + 1);
+}
+
+gboolean
+fu_focal_moc_fp_version_validate(const guint8 *buf, gsize bufsz, GError **error)
+{
+	g_autofree gchar *version = NULL;
+
+	if (buf != NULL && bufsz > 0)
+		version = fu_strsafe((const gchar *)buf, bufsz);
+	if (version == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "sensor firmware version is empty");
+		return FALSE;
+	}
+	if (strlen(version) > FU_FOCAL_MOC_FP_VERSION_MAX_SIZE) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "sensor firmware version too long: 0x%zx",
+			    strlen(version));
+		return FALSE;
+	}
+	/* fu_strsafe() maps anything unprintable to a dot, so only the raw bytes
+	 * can tell a substitution apart from a version that really has one */
+	if (strchr(version, '.') != NULL) {
+		for (gsize i = 0; i < bufsz && buf[i] != '\0'; i++) {
+			if (!g_ascii_isprint((gchar)buf[i])) {
+				g_set_error_literal(
+				    error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "sensor firmware version is not printable text");
+				return FALSE;
+			}
+		}
+	}
+
+	/* success */
+	return TRUE;
+}
+
+gboolean
+fu_focal_moc_iap_probe_required(gboolean is_bootloader)
+{
+	/* the runtime firmware always implements the probed command whatever its
+	 * status layout, so probing it would prove nothing */
+	return is_bootloader;
+}
+
+gboolean
+fu_focal_moc_iap_status_layout_from_probe(guint8 status,
+					  const guint8 *buf,
+					  gsize bufsz,
+					  FuFocalMocIapStatusLayout *layout,
+					  GError **error)
+{
+	g_return_val_if_fail(layout != NULL, FALSE);
+
+	if (status == FU_FOCAL_MOC_STATUS_OK) {
+		if (!fu_focal_moc_fp_version_validate(buf, bufsz, error)) {
+			g_prefix_error_literal(error, "capability probe accepted: ");
+			return FALSE;
+		}
+		*layout = FU_FOCAL_MOC_IAP_STATUS_LAYOUT_ALIGNED;
+		return TRUE;
+	}
+	if (status == FU_FOCAL_MOC_STATUS_INVALID_COMMAND) {
+		*layout = FU_FOCAL_MOC_IAP_STATUS_LAYOUT_LEGACY;
+		return TRUE;
+	}
+
+	/* fail closed: without a decisive answer the status layout, and so every
+	 * error the update would report, cannot be trusted */
+	g_set_error(error,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_NOT_SUPPORTED,
+		    "bootloader capability unknown: probe status=0x%02x",
+		    status);
+	return FALSE;
+}
+
+gboolean
+fu_focal_moc_status_to_error(guint8 status,
+			     const gchar *context,
+			     FwupdError invalid_command_code,
+			     gboolean status_aligned,
+			     GByteArray *data,
+			     GError **error)
+{
+	g_return_val_if_fail(data != NULL, FALSE);
+
+	/* these codes only have a meaning in the unified layout; a legacy
+	 * bootloader reuses them for unrelated conditions */
+	if (!status_aligned) {
+		switch (status) {
+		case FU_FOCAL_MOC_STATUS_NO_MEMORY:
+		case FU_FOCAL_MOC_STATUS_CHECK_ERROR:
+		case FU_FOCAL_MOC_STATUS_EXECUTION_FAILURE:
+		case FU_FOCAL_MOC_STATUS_COMMAND_MASTER_KEY_INVALID:
+		case FU_FOCAL_MOC_STATUS_MASTER_KEY_INVALID:
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "%s: status=0x%02x (legacy IAP status)",
+				    context,
+				    status);
+			return FALSE;
+		default:
+			break;
+		}
+	}
+	switch (status) {
+	case FU_FOCAL_MOC_STATUS_INVALID_PARAMETER:
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "%s: status=0x%02x (invalid parameter)",
+			    context,
+			    status);
+		return FALSE;
+	case FU_FOCAL_MOC_STATUS_TIMEOUT:
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_TIMED_OUT,
+			    "%s: status=0x%02x (device timeout)",
+			    context,
+			    status);
+		return FALSE;
+	case FU_FOCAL_MOC_STATUS_INVALID_COMMAND:
+		if (invalid_command_code == FWUPD_ERROR_SIGNATURE_INVALID) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    invalid_command_code,
+				    "%s: status=0x%02x (image validation or recovery failed)",
+				    context,
+				    status);
+			return FALSE;
+		}
+		if (invalid_command_code == FWUPD_ERROR_WRITE) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    invalid_command_code,
+				    "%s: status=0x%02x (firmware transfer failed)",
+				    context,
+				    status);
+			return FALSE;
+		}
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    invalid_command_code,
+			    "%s: status=0x%02x (invalid command)",
+			    context,
+			    status);
+		return FALSE;
+	case FU_FOCAL_MOC_STATUS_NO_MEMORY:
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "%s: status=0x%02x (device out of memory)",
+			    context,
+			    status);
+		return FALSE;
+	case FU_FOCAL_MOC_STATUS_CHECK_ERROR:
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "%s: status=0x%02x (command check failed)",
+			    context,
+			    status);
+		return FALSE;
+	case FU_FOCAL_MOC_STATUS_EXECUTION_FAILURE:
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "%s: status=0x%02x (command execution failed)",
+			    context,
+			    status);
+		return FALSE;
+	case FU_FOCAL_MOC_STATUS_COMMAND_MASTER_KEY_INVALID:
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_AUTH_FAILED,
+			    "%s: status=0x%02x (command and master key invalid)",
+			    context,
+			    status);
+		return FALSE;
+	case FU_FOCAL_MOC_STATUS_MASTER_KEY_INVALID:
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_AUTH_FAILED,
+			    "%s: status=0x%02x (master key invalid)",
+			    context,
+			    status);
+		return FALSE;
+	case FU_FOCAL_MOC_STATUS_FIRMWARE_SEQUENCE: {
+		guint16 expected = 0;
+		if (data->len >= sizeof(expected) && fu_memread_uint16_safe(data->data,
+									    data->len,
+									    0,
+									    &expected,
+									    G_BIG_ENDIAN,
+									    NULL)) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_WRITE,
+				    "%s: status=0x%02x (sequence mismatch expected=%u)",
+				    context,
+				    status,
+				    expected);
+			return FALSE;
+		}
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_WRITE,
+			    "%s: status=0x%02x (sequence mismatch)",
+			    context,
+			    status);
+		return FALSE;
+	}
+	case FU_FOCAL_MOC_STATUS_FIRMWARE_FLASH:
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_WRITE,
+			    "%s: status=0x%02x (flash write failed)",
+			    context,
+			    status);
+		return FALSE;
+	case FU_FOCAL_MOC_STATUS_FIRMWARE_NO_SESSION:
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "%s: status=0x%02x (no firmware session)",
+			    context,
+			    status);
+		return FALSE;
+	case FU_FOCAL_MOC_STATUS_FIRMWARE_VERIFY:
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_SIGNATURE_INVALID,
+			    "%s: status=0x%02x (device rejected image; previous firmware restored)",
+			    context,
+			    status);
+		return FALSE;
+	case FU_FOCAL_MOC_STATUS_FIRMWARE_RECOVER:
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_WRITE,
+			    "%s: status=0x%02x (device stays in bootloader; run the update again)",
+			    context,
+			    status);
+		return FALSE;
+	default:
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "%s: status=0x%02x (%s)",
+			    context,
+			    status,
+			    status_aligned ? "unrecognized device status" : "legacy IAP status");
+		return FALSE;
+	}
 }

--- a/plugins/focal-moc/fu-focal-moc-common.c
+++ b/plugins/focal-moc/fu-focal-moc-common.c
@@ -131,6 +131,26 @@ fu_focal_moc_ymodem_build_soh(gsize firmware_sz, guint32 crc32, GError **error)
 }
 
 GByteArray *
+fu_focal_moc_ymodem_build_soh_v2(gsize firmware_sz, guint32 crc32, GError **error)
+{
+	g_autoptr(FuStructFocalMocSohV2) st = fu_struct_focal_moc_soh_v2_new();
+
+	if (firmware_sz > G_MAXUINT32) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "firmware too large: 0x%zx",
+			    firmware_sz);
+		return NULL;
+	}
+	if (!fu_struct_focal_moc_soh_v2_set_filename(st, "app.bin", error))
+		return NULL;
+	fu_struct_focal_moc_soh_v2_set_firmware_size(st, (guint32)firmware_sz);
+	fu_struct_focal_moc_soh_v2_set_crc32(st, crc32);
+	return g_byte_array_ref(st->buf);
+}
+
+GByteArray *
 fu_focal_moc_ymodem_build_data(FuFocalMocFrame kind,
 			       guint16 sequence,
 			       const guint8 *buf,
@@ -168,6 +188,39 @@ fu_focal_moc_ymodem_build_data(FuFocalMocFrame kind,
 	fu_struct_focal_moc_data_v1_set_kind(st, kind);
 	fu_struct_focal_moc_data_v1_set_sequence(st, (guint8)sequence);
 	if (!fu_struct_focal_moc_data_v1_set_data(st, buf, bufsz, error))
+		return NULL;
+	return g_byte_array_ref(st->buf);
+}
+
+GByteArray *
+fu_focal_moc_ymodem_build_data_v2(FuFocalMocFrame kind,
+				  guint16 sequence,
+				  const guint8 *buf,
+				  gsize bufsz,
+				  GError **error)
+{
+	g_autoptr(FuStructFocalMocDataV2) st = fu_struct_focal_moc_data_v2_new();
+
+	if (kind != FU_FOCAL_MOC_FRAME_STX && kind != FU_FOCAL_MOC_FRAME_EOT) {
+		const gchar *kindstr = fu_focal_moc_frame_to_string(kind);
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "data frame kind invalid: %s",
+			    kindstr != NULL ? kindstr : "unknown");
+		return NULL;
+	}
+	if (buf == NULL || bufsz > FU_FOCAL_MOC_YMODEM_DATA_SIZE) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "data frame size invalid: 0x%zx",
+			    bufsz);
+		return NULL;
+	}
+	fu_struct_focal_moc_data_v2_set_kind(st, kind);
+	fu_struct_focal_moc_data_v2_set_sequence(st, sequence);
+	if (!fu_struct_focal_moc_data_v2_set_data(st, buf, bufsz, error))
 		return NULL;
 	return g_byte_array_ref(st->buf);
 }

--- a/plugins/focal-moc/fu-focal-moc-common.h
+++ b/plugins/focal-moc/fu-focal-moc-common.h
@@ -30,11 +30,23 @@ fu_focal_moc_ymodem_build_soh(gsize firmware_sz,
 			      GError **error) G_GNUC_WARN_UNUSED_RESULT;
 
 GByteArray *
+fu_focal_moc_ymodem_build_soh_v2(gsize firmware_sz,
+				 guint32 crc32,
+				 GError **error) G_GNUC_WARN_UNUSED_RESULT;
+
+GByteArray *
 fu_focal_moc_ymodem_build_data(FuFocalMocFrame kind,
 			       guint16 sequence,
 			       const guint8 *buf,
 			       gsize bufsz,
 			       GError **error) G_GNUC_WARN_UNUSED_RESULT;
+
+GByteArray *
+fu_focal_moc_ymodem_build_data_v2(FuFocalMocFrame kind,
+				  guint16 sequence,
+				  const guint8 *buf,
+				  gsize bufsz,
+				  GError **error) G_GNUC_WARN_UNUSED_RESULT;
 
 gchar *
 fu_focal_moc_version_parse(const guint8 *buf, gsize bufsz, gboolean *is_bootloader, GError **error)

--- a/plugins/focal-moc/fu-focal-moc-common.h
+++ b/plugins/focal-moc/fu-focal-moc-common.h
@@ -8,9 +8,57 @@
 
 #include <fwupdplugin.h>
 
+#include "fu-focal-moc-struct.h"
+
+#define FU_FOCAL_MOC_YMODEM_DATA_SIZE 1024
+#define FU_FOCAL_MOC_VERSION_MAX_SIZE 64
+
 GByteArray *
-fu_focal_moc_packet_new(guint8 cmd, const guint8 *buf, gsize bufsz, GError **error);
+fu_focal_moc_packet_new(guint8 command, const guint8 *buf, gsize bufsz, GError **error)
+    G_GNUC_WARN_UNUSED_RESULT;
+
 GByteArray *
-fu_focal_moc_packet_parse(const guint8 *buf, gsize bufsz, GError **error);
+fu_focal_moc_packet_parse(const guint8 *buf,
+			  gsize bufsz,
+			  gboolean allow_legacy_trailer,
+			  guint8 *status,
+			  GError **error) G_GNUC_WARN_UNUSED_RESULT;
+
+GByteArray *
+fu_focal_moc_ymodem_build_soh(gsize firmware_sz,
+			      guint32 crc32,
+			      GError **error) G_GNUC_WARN_UNUSED_RESULT;
+
+GByteArray *
+fu_focal_moc_ymodem_build_data(FuFocalMocFrame kind,
+			       guint16 sequence,
+			       const guint8 *buf,
+			       gsize bufsz,
+			       GError **error) G_GNUC_WARN_UNUSED_RESULT;
+
 gchar *
-fu_focal_moc_version_parse(const guint8 *buf, gsize bufsz, gboolean *is_bootloader, GError **error);
+fu_focal_moc_version_parse(const guint8 *buf, gsize bufsz, gboolean *is_bootloader, GError **error)
+    G_GNUC_WARN_UNUSED_RESULT;
+
+gboolean
+fu_focal_moc_fp_version_validate(const guint8 *buf,
+				 gsize bufsz,
+				 GError **error) G_GNUC_WARN_UNUSED_RESULT;
+
+gboolean
+fu_focal_moc_iap_probe_required(gboolean is_bootloader);
+
+gboolean
+fu_focal_moc_iap_status_layout_from_probe(guint8 status,
+					  const guint8 *buf,
+					  gsize bufsz,
+					  FuFocalMocIapStatusLayout *layout,
+					  GError **error) G_GNUC_WARN_UNUSED_RESULT;
+
+gboolean
+fu_focal_moc_status_to_error(guint8 status,
+			     const gchar *context,
+			     FwupdError invalid_command_code,
+			     gboolean status_aligned,
+			     GByteArray *data,
+			     GError **error);

--- a/plugins/focal-moc/fu-focal-moc-device.c
+++ b/plugins/focal-moc/fu-focal-moc-device.c
@@ -10,15 +10,15 @@
 #include "fu-focal-moc-device.h"
 #include "fu-focal-moc-struct.h"
 
-struct _FuFocalMocDevice {
-	FuUsbDevice parent_instance;
+typedef struct {
 	guint8 ep_in;
 	guint8 ep_out;
 	guint8 iface;
 	FuFocalMocIapStatusLayout iap_status_layout;
-};
+} FuFocalMocDevicePrivate;
 
-G_DEFINE_TYPE(FuFocalMocDevice, fu_focal_moc_device, FU_TYPE_USB_DEVICE)
+G_DEFINE_TYPE_WITH_PRIVATE(FuFocalMocDevice, fu_focal_moc_device, FU_TYPE_USB_DEVICE)
+#define GET_PRIVATE(o) (fu_focal_moc_device_get_instance_private(o))
 
 #define FU_FOCAL_MOC_USB_INTERFACE	    0
 #define FU_FOCAL_MOC_USB_TIMEOUT_MS	    5000
@@ -35,29 +35,43 @@ static void
 fu_focal_moc_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuFocalMocDevice *self = FU_FOCAL_MOC_DEVICE(device);
+	FuFocalMocDevicePrivate *priv = GET_PRIVATE(self);
 
-	fwupd_codec_string_append_hex(str, idt, "Interface", self->iface);
-	fwupd_codec_string_append_hex(str, idt, "EndpointIn", self->ep_in);
-	fwupd_codec_string_append_hex(str, idt, "EndpointOut", self->ep_out);
+	fwupd_codec_string_append_hex(str, idt, "Interface", priv->iface);
+	fwupd_codec_string_append_hex(str, idt, "EndpointIn", priv->ep_in);
+	fwupd_codec_string_append_hex(str, idt, "EndpointOut", priv->ep_out);
 	fwupd_codec_string_append(
 	    str,
 	    idt,
 	    "IapStatusLayout",
-	    fu_focal_moc_iap_status_layout_to_string(self->iap_status_layout));
+	    fu_focal_moc_iap_status_layout_to_string(priv->iap_status_layout));
 }
 
-static gboolean
+void
+fu_focal_moc_device_set_iap_status_layout(FuFocalMocDevice *self,
+					  FuFocalMocIapStatusLayout iap_status_layout)
+{
+	FuFocalMocDevicePrivate *priv = GET_PRIVATE(self);
+
+	g_return_if_fail(FU_IS_FOCAL_MOC_DEVICE(self));
+	priv->iap_status_layout = iap_status_layout;
+}
+
+gboolean
 fu_focal_moc_device_send_raw(FuFocalMocDevice *self,
 			     const guint8 *buf,
 			     gsize bufsz,
 			     guint timeout_ms,
 			     GError **error)
 {
+	FuFocalMocDevicePrivate *priv = GET_PRIVATE(self);
 	gsize actual = 0;
+
+	g_return_val_if_fail(FU_IS_FOCAL_MOC_DEVICE(self), FALSE);
 
 	fu_dump_full(G_LOG_DOMAIN, "request", buf, bufsz, 16, FU_DUMP_FLAG_SHOW_ADDRESSES);
 	if (!fu_usb_device_bulk_transfer(FU_USB_DEVICE(self),
-					 self->ep_out,
+					 priv->ep_out,
 					 (guint8 *)buf,
 					 bufsz,
 					 &actual,
@@ -86,15 +100,18 @@ fu_focal_moc_device_send(FuFocalMocDevice *self, GByteArray *buf, guint timeout_
 	return fu_focal_moc_device_send_raw(self, buf->data, buf->len, timeout_ms, error);
 }
 
-static GByteArray *
+GByteArray *
 fu_focal_moc_device_receive_raw(FuFocalMocDevice *self, guint timeout_ms, GError **error)
 {
+	FuFocalMocDevicePrivate *priv = GET_PRIVATE(self);
 	gsize actual = 0;
 	guint8 buf[FU_FOCAL_MOC_RESPONSE_SIZE] = {0};
 	g_autoptr(GByteArray) data = g_byte_array_new();
 
+	g_return_val_if_fail(FU_IS_FOCAL_MOC_DEVICE(self), NULL);
+
 	if (!fu_usb_device_bulk_transfer(FU_USB_DEVICE(self),
-					 self->ep_in,
+					 priv->ep_in,
 					 buf,
 					 sizeof(buf),
 					 &actual,
@@ -121,17 +138,22 @@ fu_focal_moc_device_receive(FuFocalMocDevice *self,
 	response = fu_focal_moc_device_receive_raw(self, timeout_ms, error);
 	if (response == NULL)
 		return NULL;
-	return fu_focal_moc_packet_parse(response->data, response->len, TRUE, status, error);
+	return fu_focal_moc_packet_parse(
+	    response->data,
+	    response->len,
+	    fu_device_has_private_flag(FU_DEVICE(self), FU_FOCAL_MOC_DEVICE_FLAG_LEGACY_TRAILER),
+	    status,
+	    error);
 }
 
 static GByteArray *
-fu_focal_moc_device_command(FuFocalMocDevice *self,
-			    FuFocalMocCmd command,
-			    const guint8 *payload,
-			    gsize payload_sz,
-			    guint timeout_ms,
-			    guint8 *status,
-			    GError **error)
+fu_focal_moc_device_command_plaintext(FuFocalMocDevice *self,
+				      guint8 command,
+				      const guint8 *payload,
+				      gsize payload_sz,
+				      guint timeout_ms,
+				      guint8 *status,
+				      GError **error)
 {
 	g_autoptr(GByteArray) request = NULL;
 
@@ -143,6 +165,19 @@ fu_focal_moc_device_command(FuFocalMocDevice *self,
 	return fu_focal_moc_device_receive(self, timeout_ms, status, error);
 }
 
+static GByteArray *
+fu_focal_moc_device_command(FuFocalMocDevice *self,
+			    guint8 command,
+			    const guint8 *payload,
+			    gsize payload_sz,
+			    guint timeout_ms,
+			    guint8 *status,
+			    GError **error)
+{
+	FuFocalMocDeviceClass *klass = FU_FOCAL_MOC_DEVICE_GET_CLASS(self);
+	return klass->command(self, command, payload, payload_sz, timeout_ms, status, error);
+}
+
 static gboolean
 fu_focal_moc_device_status_error(FuFocalMocDevice *self,
 				 guint8 status,
@@ -151,12 +186,13 @@ fu_focal_moc_device_status_error(FuFocalMocDevice *self,
 				 GByteArray *data,
 				 GError **error)
 {
+	FuFocalMocDevicePrivate *priv = GET_PRIVATE(self);
 	gboolean status_aligned = TRUE;
 
 	/* only a bootloader that failed the capability probe uses the legacy
 	 * layout; the runtime firmware always uses the unified one */
 	if (fu_device_has_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER) &&
-	    self->iap_status_layout == FU_FOCAL_MOC_IAP_STATUS_LAYOUT_LEGACY)
+	    priv->iap_status_layout == FU_FOCAL_MOC_IAP_STATUS_LAYOUT_LEGACY)
 		status_aligned = FALSE;
 	return fu_focal_moc_status_to_error(status,
 					    context,
@@ -350,9 +386,38 @@ fu_focal_moc_device_send_frame(FuFocalMocDevice *self,
 	return TRUE;
 }
 
+static GByteArray *
+fu_focal_moc_device_build_soh(FuFocalMocDevice *self,
+			      gsize firmware_sz,
+			      guint32 crc32,
+			      GError **error)
+{
+	return fu_focal_moc_ymodem_build_soh(firmware_sz, crc32, error);
+}
+
+static GByteArray *
+fu_focal_moc_device_build_data(FuFocalMocDevice *self,
+			       FuFocalMocFrame kind,
+			       guint16 sequence,
+			       const guint8 *buf,
+			       gsize bufsz,
+			       GError **error)
+{
+	return fu_focal_moc_ymodem_build_data(kind, sequence, buf, bufsz, error);
+}
+
+static FuInputStream *
+fu_focal_moc_device_get_firmware_stream(FuFocalMocDevice *self,
+					FuFirmware *firmware,
+					GError **error)
+{
+	return fu_firmware_get_stream(firmware, error);
+}
+
 static gboolean
 fu_focal_moc_device_write_soh(FuFocalMocDevice *self, FuInputStream *stream, GError **error)
 {
+	FuFocalMocDeviceClass *klass = FU_FOCAL_MOC_DEVICE_GET_CLASS(self);
 	gsize streamsz = 0;
 	/* only this seed makes fu_input_stream_compute_crc32() agree with fu_crc32() */
 	guint32 crc32 = G_MAXUINT32;
@@ -362,7 +427,7 @@ fu_focal_moc_device_write_soh(FuFocalMocDevice *self, FuInputStream *stream, GEr
 		return FALSE;
 	if (!fu_input_stream_compute_crc32(stream, FU_CRC_KIND_B32_STANDARD, &crc32, error))
 		return FALSE;
-	frame = fu_focal_moc_ymodem_build_soh(streamsz, crc32, error);
+	frame = klass->build_soh(self, streamsz, crc32, error);
 	if (frame == NULL)
 		return FALSE;
 
@@ -376,6 +441,8 @@ fu_focal_moc_device_write_chunks(FuFocalMocDevice *self,
 				 FuProgress *progress,
 				 GError **error)
 {
+	FuFocalMocDeviceClass *klass = FU_FOCAL_MOC_DEVICE_GET_CLASS(self);
+
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
@@ -386,12 +453,12 @@ fu_focal_moc_device_write_chunks(FuFocalMocDevice *self,
 		chk = fu_chunk_array_index(chunks, i, error);
 		if (chk == NULL)
 			return FALSE;
-		frame = fu_focal_moc_ymodem_build_data(is_last ? FU_FOCAL_MOC_FRAME_EOT
-							       : FU_FOCAL_MOC_FRAME_STX,
-						       (guint16)(i + 1),
-						       fu_chunk_get_data(chk),
-						       fu_chunk_get_data_sz(chk),
-						       error);
+		frame = klass->build_data(self,
+					  is_last ? FU_FOCAL_MOC_FRAME_EOT : FU_FOCAL_MOC_FRAME_STX,
+					  (guint16)(i + 1),
+					  fu_chunk_get_data(chk),
+					  fu_chunk_get_data_sz(chk),
+					  error);
 		if (frame == NULL)
 			return FALSE;
 		if (!fu_focal_moc_device_send_frame(self,
@@ -489,8 +556,9 @@ fu_focal_moc_device_write_ymodem(FuFocalMocDevice *self,
 }
 
 static gboolean
-fu_focal_moc_device_ensure_iap_status_layout(FuFocalMocDevice *self, GError **error)
+fu_focal_moc_device_ensure_bootloader_layout(FuFocalMocDevice *self, GError **error)
 {
+	FuFocalMocDevicePrivate *priv = GET_PRIVATE(self);
 	guint8 status = 0;
 	g_autoptr(GByteArray) data = NULL;
 
@@ -511,19 +579,21 @@ fu_focal_moc_device_ensure_iap_status_layout(FuFocalMocDevice *self, GError **er
 	return fu_focal_moc_iap_status_layout_from_probe(status,
 							 data->data,
 							 data->len,
-							 &self->iap_status_layout,
+							 &priv->iap_status_layout,
 							 error);
 }
 
 static gboolean
 fu_focal_moc_device_ensure_version(FuFocalMocDevice *self, GError **error)
 {
+	FuFocalMocDeviceClass *klass = FU_FOCAL_MOC_DEVICE_GET_CLASS(self);
+	FuFocalMocDevicePrivate *priv = GET_PRIVATE(self);
 	gboolean is_bootloader = FALSE;
 	g_autofree gchar *version = NULL;
 	g_autoptr(GByteArray) data = NULL;
 
 	/* never reuse a layout probed on a previous enumeration */
-	self->iap_status_layout = FU_FOCAL_MOC_IAP_STATUS_LAYOUT_UNKNOWN;
+	priv->iap_status_layout = FU_FOCAL_MOC_IAP_STATUS_LAYOUT_UNKNOWN;
 	data = fu_focal_moc_device_command_ok(self,
 					      FU_FOCAL_MOC_CMD_GET_FW_VERSION,
 					      NULL,
@@ -542,7 +612,7 @@ fu_focal_moc_device_ensure_version(FuFocalMocDevice *self, GError **error)
 	else
 		fu_device_remove_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 	if (fu_focal_moc_iap_probe_required(is_bootloader)) {
-		if (!fu_focal_moc_device_ensure_iap_status_layout(self, error))
+		if (!klass->ensure_bootloader_layout(self, error))
 			return FALSE;
 	}
 
@@ -554,6 +624,7 @@ static gboolean
 fu_focal_moc_device_probe(FuDevice *device, GError **error)
 {
 	FuFocalMocDevice *self = FU_FOCAL_MOC_DEVICE(device);
+	FuFocalMocDevicePrivate *priv = GET_PRIVATE(self);
 	g_autoptr(GPtrArray) interfaces = NULL;
 
 	if (!FU_DEVICE_CLASS(fu_focal_moc_device_parent_class)->probe(device, error))
@@ -573,21 +644,21 @@ fu_focal_moc_device_probe(FuDevice *device, GError **error)
 			FuUsbEndpoint *endpoint = g_ptr_array_index(endpoints, j);
 			if (fu_usb_endpoint_get_direction(endpoint) ==
 			    FU_USB_DIRECTION_DEVICE_TO_HOST)
-				self->ep_in = fu_usb_endpoint_get_address(endpoint);
+				priv->ep_in = fu_usb_endpoint_get_address(endpoint);
 			else
-				self->ep_out = fu_usb_endpoint_get_address(endpoint);
+				priv->ep_out = fu_usb_endpoint_get_address(endpoint);
 		}
-		self->iface = fu_usb_interface_get_number(iface);
+		priv->iface = fu_usb_interface_get_number(iface);
 		break;
 	}
-	if (self->ep_in == 0 || self->ep_out == 0) {
+	if (priv->ep_in == 0 || priv->ep_out == 0) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_NOT_FOUND,
 				    "bulk endpoint pair not found on interface 0");
 		return FALSE;
 	}
-	fu_usb_device_add_interface(FU_USB_DEVICE(self), self->iface);
+	fu_usb_device_add_interface(FU_USB_DEVICE(self), priv->iface);
 
 	/* success */
 	return TRUE;
@@ -640,6 +711,7 @@ fu_focal_moc_device_write_firmware(FuDevice *device,
 				   GError **error)
 {
 	FuFocalMocDevice *self = FU_FOCAL_MOC_DEVICE(device);
+	FuFocalMocDeviceClass *klass = FU_FOCAL_MOC_DEVICE_GET_CLASS(self);
 	g_autoptr(FuInputStream) stream = NULL;
 
 	if (!fu_device_has_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
@@ -649,7 +721,7 @@ fu_focal_moc_device_write_firmware(FuDevice *device,
 				    "firmware write requires IAP mode");
 		return FALSE;
 	}
-	stream = fu_firmware_get_stream(firmware, error);
+	stream = klass->get_firmware_stream(self, firmware, error);
 	if (stream == NULL)
 		return FALSE;
 	if (!fu_focal_moc_device_probe_alive(self, FU_FOCAL_MOC_USB_TIMEOUT_MS, error)) {
@@ -680,6 +752,7 @@ fu_focal_moc_device_set_progress(FuDevice *device, FuProgress *progress)
 static void
 fu_focal_moc_device_init(FuFocalMocDevice *self)
 {
+	fu_device_add_private_flag(FU_DEVICE(self), FU_FOCAL_MOC_DEVICE_FLAG_LEGACY_TRAILER);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SELF_RECOVERY);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_RETRY_OPEN);
@@ -703,4 +776,10 @@ fu_focal_moc_device_class_init(FuFocalMocDeviceClass *klass)
 	device_class->detach = fu_focal_moc_device_detach;
 	device_class->write_firmware = fu_focal_moc_device_write_firmware;
 	device_class->set_progress = fu_focal_moc_device_set_progress;
+	klass->command = fu_focal_moc_device_command_plaintext;
+	klass->build_soh = fu_focal_moc_device_build_soh;
+	klass->build_data = fu_focal_moc_device_build_data;
+	klass->get_firmware_stream = fu_focal_moc_device_get_firmware_stream;
+	klass->ensure_bootloader_layout = fu_focal_moc_device_ensure_bootloader_layout;
+	fu_device_register_private_flag(device_class, FU_FOCAL_MOC_DEVICE_FLAG_LEGACY_TRAILER);
 }

--- a/plugins/focal-moc/fu-focal-moc-device.c
+++ b/plugins/focal-moc/fu-focal-moc-device.c
@@ -12,59 +12,67 @@
 
 struct _FuFocalMocDevice {
 	FuUsbDevice parent_instance;
+	guint8 ep_in;
+	guint8 ep_out;
+	guint8 iface;
+	FuFocalMocIapStatusLayout iap_status_layout;
 };
 
 G_DEFINE_TYPE(FuFocalMocDevice, fu_focal_moc_device, FU_TYPE_USB_DEVICE)
 
-/* USB bulk transfer endpoints */
-#define FU_FOCAL_MOC_USB_EP_IN	   (1 | 0x80)
-#define FU_FOCAL_MOC_USB_EP_OUT	   (2 | 0x00)
-#define FU_FOCAL_MOC_USB_INTERFACE 0
+#define FU_FOCAL_MOC_USB_INTERFACE	    0
+#define FU_FOCAL_MOC_USB_TIMEOUT_MS	    5000
+#define FU_FOCAL_MOC_FRAME_TIMEOUT_MS	    8000
+#define FU_FOCAL_MOC_COMMIT_TIMEOUT_MS	    15000
+#define FU_FOCAL_MOC_RESPONSE_SIZE	    2048
+#define FU_FOCAL_MOC_MAX_FIRMWARE_SIZE	    (G_MAXUINT8 * FU_FOCAL_MOC_YMODEM_DATA_SIZE)
+#define FU_FOCAL_MOC_FIFO_CLEAR_RETRIES	    50
+#define FU_FOCAL_MOC_FIFO_CLEAR_CONSECUTIVE 3
+#define FU_FOCAL_MOC_FRAME_RETRIES	    3
+#define FU_FOCAL_MOC_INSTALL_DURATION	    15
 
-#define FU_FOCAL_MOC_USB_TIMEOUT	1000 /* ms — send */
-#define FU_FOCAL_MOC_RECV_TIMEOUT	1000 /* ms — receive */
-#define FU_FOCAL_MOC_RECV_FINAL_TIMEOUT 2000 /* ms — longer wait after EOT */
+static void
+fu_focal_moc_device_to_string(FuDevice *device, guint idt, GString *str)
+{
+	FuFocalMocDevice *self = FU_FOCAL_MOC_DEVICE(device);
 
-/* firmware-download packet constants */
-#define FU_FOCAL_MOC_DL_BLOCK_SIZE 1024		 /* bytes per STX/EOT data block */
-#define FU_FOCAL_MOC_FW_MAX_SIZE   (256 * FU_KB) /* hard limit */
-
-/* transfer timing delays */
-#define FU_FOCAL_MOC_DELAY_CMD_MS   5	/* after version/mode commands */
-#define FU_FOCAL_MOC_DELAY_DL_MS    10	/* between download packets */
-#define FU_FOCAL_MOC_DELAY_FINAL_MS 200 /* before reading final ACK */
-
-/* maximum receive buffer (covers any response packet) */
-#define FU_FOCAL_MOC_MAX_RSP_SIZE 256
-
-/* the emulation event key includes the requested transfer size, so the version
- * reply has to keep asking for the smaller size it was recorded with */
-#define FU_FOCAL_MOC_VERSION_RSP_SIZE 64
+	fwupd_codec_string_append_hex(str, idt, "Interface", self->iface);
+	fwupd_codec_string_append_hex(str, idt, "EndpointIn", self->ep_in);
+	fwupd_codec_string_append_hex(str, idt, "EndpointOut", self->ep_out);
+	fwupd_codec_string_append(
+	    str,
+	    idt,
+	    "IapStatusLayout",
+	    fu_focal_moc_iap_status_layout_to_string(self->iap_status_layout));
+}
 
 static gboolean
-fu_focal_moc_device_send(FuFocalMocDevice *self, GByteArray *pkt, GError **error)
+fu_focal_moc_device_send_raw(FuFocalMocDevice *self,
+			     const guint8 *buf,
+			     gsize bufsz,
+			     guint timeout_ms,
+			     GError **error)
 {
 	gsize actual = 0;
 
-	fu_dump_full(G_LOG_DOMAIN, "SEND", pkt->data, pkt->len, 16, FU_DUMP_FLAG_SHOW_ADDRESSES);
-
+	fu_dump_full(G_LOG_DOMAIN, "request", buf, bufsz, 16, FU_DUMP_FLAG_SHOW_ADDRESSES);
 	if (!fu_usb_device_bulk_transfer(FU_USB_DEVICE(self),
-					 FU_FOCAL_MOC_USB_EP_OUT,
-					 pkt->data,
-					 pkt->len,
+					 self->ep_out,
+					 (guint8 *)buf,
+					 bufsz,
 					 &actual,
-					 FU_FOCAL_MOC_USB_TIMEOUT,
+					 timeout_ms,
 					 error)) {
-		g_prefix_error_literal(error, "send failed: ");
+		g_prefix_error_literal(error, "failed to send command: ");
 		return FALSE;
 	}
-	if (actual != pkt->len) {
+	if (actual != bufsz) {
 		g_set_error(error,
 			    FWUPD_ERROR,
-			    FWUPD_ERROR_INTERNAL,
-			    "short write: sent %zu of %u bytes",
+			    FWUPD_ERROR_WRITE,
+			    "short USB write: actual=0x%zx expected=0x%zx",
 			    actual,
-			    pkt->len);
+			    bufsz);
 		return FALSE;
 	}
 
@@ -72,56 +80,439 @@ fu_focal_moc_device_send(FuFocalMocDevice *self, GByteArray *pkt, GError **error
 	return TRUE;
 }
 
-/* read one response packet, verify it is an ACK and return any payload */
+static gboolean
+fu_focal_moc_device_send(FuFocalMocDevice *self, GByteArray *buf, guint timeout_ms, GError **error)
+{
+	return fu_focal_moc_device_send_raw(self, buf->data, buf->len, timeout_ms, error);
+}
+
 static GByteArray *
-fu_focal_moc_device_recv(FuFocalMocDevice *self, guint timeout_ms, gsize bufsz, GError **error)
+fu_focal_moc_device_receive_raw(FuFocalMocDevice *self, guint timeout_ms, GError **error)
 {
 	gsize actual = 0;
-	guint8 buf[FU_FOCAL_MOC_MAX_RSP_SIZE] = {0};
-
-	g_return_val_if_fail(bufsz <= sizeof(buf), NULL);
+	guint8 buf[FU_FOCAL_MOC_RESPONSE_SIZE] = {0};
+	g_autoptr(GByteArray) data = g_byte_array_new();
 
 	if (!fu_usb_device_bulk_transfer(FU_USB_DEVICE(self),
-					 FU_FOCAL_MOC_USB_EP_IN,
+					 self->ep_in,
 					 buf,
-					 bufsz,
+					 sizeof(buf),
 					 &actual,
 					 timeout_ms,
 					 error)) {
-		g_prefix_error_literal(error, "recv failed: ");
+		g_prefix_error_literal(error, "failed to receive response: ");
 		return NULL;
 	}
-	fu_dump_full(G_LOG_DOMAIN, "RECV", buf, actual, 16, FU_DUMP_FLAG_SHOW_ADDRESSES);
-	return fu_focal_moc_packet_parse(buf, actual, error);
+	fu_dump_full(G_LOG_DOMAIN, "response", buf, actual, 16, FU_DUMP_FLAG_SHOW_ADDRESSES);
+	g_byte_array_append(data, buf, actual);
+
+	/* success */
+	return g_steal_pointer(&data);
+}
+
+static GByteArray *
+fu_focal_moc_device_receive(FuFocalMocDevice *self,
+			    guint timeout_ms,
+			    guint8 *status,
+			    GError **error)
+{
+	g_autoptr(GByteArray) response = NULL;
+
+	response = fu_focal_moc_device_receive_raw(self, timeout_ms, error);
+	if (response == NULL)
+		return NULL;
+	return fu_focal_moc_packet_parse(response->data, response->len, TRUE, status, error);
+}
+
+static GByteArray *
+fu_focal_moc_device_command(FuFocalMocDevice *self,
+			    FuFocalMocCmd command,
+			    const guint8 *payload,
+			    gsize payload_sz,
+			    guint timeout_ms,
+			    guint8 *status,
+			    GError **error)
+{
+	g_autoptr(GByteArray) request = NULL;
+
+	request = fu_focal_moc_packet_new(command, payload, payload_sz, error);
+	if (request == NULL)
+		return NULL;
+	if (!fu_focal_moc_device_send(self, request, timeout_ms, error))
+		return NULL;
+	return fu_focal_moc_device_receive(self, timeout_ms, status, error);
 }
 
 static gboolean
-fu_focal_moc_device_recv_ack(FuFocalMocDevice *self, guint timeout_ms, GError **error)
+fu_focal_moc_device_status_error(FuFocalMocDevice *self,
+				 guint8 status,
+				 const gchar *context,
+				 FwupdError invalid_command_code,
+				 GByteArray *data,
+				 GError **error)
 {
+	gboolean status_aligned = TRUE;
+
+	/* only a bootloader that failed the capability probe uses the legacy
+	 * layout; the runtime firmware always uses the unified one */
+	if (fu_device_has_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER) &&
+	    self->iap_status_layout == FU_FOCAL_MOC_IAP_STATUS_LAYOUT_LEGACY)
+		status_aligned = FALSE;
+	return fu_focal_moc_status_to_error(status,
+					    context,
+					    invalid_command_code,
+					    status_aligned,
+					    data,
+					    error);
+}
+
+static GByteArray *
+fu_focal_moc_device_command_ok(FuFocalMocDevice *self,
+			       FuFocalMocCmd command,
+			       const guint8 *payload,
+			       gsize payload_sz,
+			       guint timeout_ms,
+			       const gchar *context,
+			       GError **error)
+{
+	guint8 status = 0;
 	g_autoptr(GByteArray) data = NULL;
-	data = fu_focal_moc_device_recv(self, timeout_ms, FU_FOCAL_MOC_MAX_RSP_SIZE, error);
-	return data != NULL;
+
+	data = fu_focal_moc_device_command(self,
+					   command,
+					   payload,
+					   payload_sz,
+					   timeout_ms,
+					   &status,
+					   error);
+	if (data == NULL)
+		return NULL;
+	if (status != FU_FOCAL_MOC_STATUS_OK) {
+		fu_focal_moc_device_status_error(self,
+						 status,
+						 context,
+						 FWUPD_ERROR_NOT_SUPPORTED,
+						 data,
+						 error);
+		return NULL;
+	}
+
+	/* success */
+	return g_steal_pointer(&data);
 }
 
-/* send a standard command packet and receive the ACK */
 static gboolean
-fu_focal_moc_device_cmd_xfer(FuFocalMocDevice *self,
-			     FuFocalMocCmd cmd,
-			     const guint8 *buf,
-			     gsize buf_len,
-			     guint delay_ms,
-			     GError **error)
+fu_focal_moc_device_probe_alive(FuFocalMocDevice *self, guint timeout_ms, GError **error)
 {
-	g_autoptr(GByteArray) pkt = fu_focal_moc_packet_new(cmd, buf, buf_len, error);
+	g_autoptr(FuStructFocalMocWakeUp) st = NULL;
+	g_autoptr(GByteArray) data = NULL;
 
-	if (pkt == NULL)
+	data = fu_focal_moc_device_command_ok(self,
+					      FU_FOCAL_MOC_CMD_WAKE_UP,
+					      NULL,
+					      0,
+					      timeout_ms,
+					      "wake-up rejected",
+					      error);
+	if (data == NULL)
 		return FALSE;
-	if (!fu_focal_moc_device_send(self, pkt, error))
+	/* an ACK with no payload leaves data->data NULL, which the parser rejects
+	 * with a critical rather than a GError */
+	if (data->len < FU_STRUCT_FOCAL_MOC_WAKE_UP_SIZE) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "wake-up response too small: 0x%x",
+			    data->len);
+		return FALSE;
+	}
+	st = fu_struct_focal_moc_wake_up_parse(data->data, data->len, 0x0, error);
+	if (st == NULL) {
+		g_prefix_error_literal(error, "wake-up response invalid: ");
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+typedef struct {
+	guint consecutive;
+} FuFocalMocDeviceFifoHelper;
+
+static gboolean
+fu_focal_moc_device_fifo_clear_cb(FuDevice *device, gpointer user_data, GError **error)
+{
+	FuFocalMocDevice *self = FU_FOCAL_MOC_DEVICE(device);
+	FuFocalMocDeviceFifoHelper *helper = user_data;
+	g_autoptr(GError) error_local = NULL;
+
+	if (!fu_focal_moc_device_probe_alive(self, 250, &error_local)) {
+		helper->consecutive = 0;
+		g_propagate_prefixed_error(error,
+					   g_steal_pointer(&error_local),
+					   "FIFO did not clear: ");
+		return FALSE;
+	}
+	/* a single response may be stale buffer, so require a quiet run */
+	helper->consecutive++;
+	if (helper->consecutive < FU_FOCAL_MOC_FIFO_CLEAR_CONSECUTIVE) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_BUSY,
+			    "FIFO returned %u of %u consecutive wake-up responses",
+			    helper->consecutive,
+			    (guint)FU_FOCAL_MOC_FIFO_CLEAR_CONSECUTIVE);
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_focal_moc_device_wait_fifo_clear(FuFocalMocDevice *self, GError **error)
+{
+	FuFocalMocDeviceFifoHelper helper = {0};
+	return fu_device_retry_full(FU_DEVICE(self),
+				    fu_focal_moc_device_fifo_clear_cb,
+				    FU_FOCAL_MOC_FIFO_CLEAR_RETRIES,
+				    5, /* ms */
+				    &helper,
+				    error);
+}
+
+typedef struct {
+	GByteArray *frame;
+	GByteArray *data;
+	guint attempts;
+	guint8 status;
+} FuFocalMocDeviceFrameHelper;
+
+static gboolean
+fu_focal_moc_device_send_frame_cb(FuDevice *device, gpointer user_data, GError **error)
+{
+	FuFocalMocDevice *self = FU_FOCAL_MOC_DEVICE(device);
+	FuFocalMocDeviceFrameHelper *helper = user_data;
+	g_autoptr(GByteArray) data = NULL;
+
+	/* leftover frames from the failed attempt block the endpoint until they
+	 * are drained */
+	if (helper->attempts++ > 0) {
+		if (!fu_focal_moc_device_wait_fifo_clear(self, error))
+			return FALSE;
+	}
+	data = fu_focal_moc_device_command(self,
+					   FU_FOCAL_MOC_CMD_SEND_FIRMWARE,
+					   helper->frame->data,
+					   helper->frame->len,
+					   FU_FOCAL_MOC_FRAME_TIMEOUT_MS,
+					   &helper->status,
+					   error);
+	if (data == NULL)
+		return FALSE;
+	helper->data = g_steal_pointer(&data);
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_focal_moc_device_send_frame(FuFocalMocDevice *self,
+			       GByteArray *frame,
+			       guint16 sequence,
+			       const gchar *kind,
+			       GError **error)
+{
+	FuFocalMocDeviceFrameHelper helper = {.frame = frame};
+	g_autoptr(GByteArray) data = NULL;
+
+	if (!fu_device_retry_full(FU_DEVICE(self),
+				  fu_focal_moc_device_send_frame_cb,
+				  FU_FOCAL_MOC_FRAME_RETRIES,
+				  5, /* ms */
+				  &helper,
+				  error)) {
+		g_prefix_error(error, "%s frame failed: seq=%u: ", kind, sequence);
+		return FALSE;
+	}
+	data = helper.data;
+	if (helper.status != FU_FOCAL_MOC_STATUS_OK) {
+		return fu_focal_moc_device_status_error(self,
+							helper.status,
+							kind,
+							FWUPD_ERROR_WRITE,
+							data,
+							error);
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_focal_moc_device_write_soh(FuFocalMocDevice *self, FuInputStream *stream, GError **error)
+{
+	gsize streamsz = 0;
+	/* only this seed makes fu_input_stream_compute_crc32() agree with fu_crc32() */
+	guint32 crc32 = G_MAXUINT32;
+	g_autoptr(GByteArray) frame = NULL;
+
+	if (!fu_input_stream_size(stream, &streamsz, error))
+		return FALSE;
+	if (!fu_input_stream_compute_crc32(stream, FU_CRC_KIND_B32_STANDARD, &crc32, error))
+		return FALSE;
+	frame = fu_focal_moc_ymodem_build_soh(streamsz, crc32, error);
+	if (frame == NULL)
 		return FALSE;
 
-	fu_device_sleep(FU_DEVICE(self), delay_ms);
+	/* success */
+	return fu_focal_moc_device_send_frame(self, frame, 0, "SOH rejected", error);
+}
 
-	return fu_focal_moc_device_recv_ack(self, FU_FOCAL_MOC_RECV_TIMEOUT, error);
+static gboolean
+fu_focal_moc_device_write_chunks(FuFocalMocDevice *self,
+				 FuChunkArray *chunks,
+				 FuProgress *progress,
+				 GError **error)
+{
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		gboolean is_last = i + 1 == fu_chunk_array_length(chunks);
+		g_autoptr(FuChunk) chk = NULL;
+		g_autoptr(GByteArray) frame = NULL;
+
+		chk = fu_chunk_array_index(chunks, i, error);
+		if (chk == NULL)
+			return FALSE;
+		frame = fu_focal_moc_ymodem_build_data(is_last ? FU_FOCAL_MOC_FRAME_EOT
+							       : FU_FOCAL_MOC_FRAME_STX,
+						       (guint16)(i + 1),
+						       fu_chunk_get_data(chk),
+						       fu_chunk_get_data_sz(chk),
+						       error);
+		if (frame == NULL)
+			return FALSE;
+		if (!fu_focal_moc_device_send_frame(self,
+						    frame,
+						    (guint16)(i + 1),
+						    is_last ? "EOT rejected" : "STX rejected",
+						    error))
+			return FALSE;
+		fu_progress_step_done(progress);
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_focal_moc_device_commit(FuFocalMocDevice *self, GError **error)
+{
+	guint8 mode = FU_FOCAL_MOC_BOOT_MODE_APP;
+	guint8 status = 0;
+	g_autoptr(GByteArray) data = NULL;
+	g_autoptr(GByteArray) request = NULL;
+	g_autoptr(GError) error_local = NULL;
+
+	request =
+	    fu_focal_moc_packet_new(FU_FOCAL_MOC_CMD_SET_BOOT_MODE, &mode, sizeof(mode), error);
+	if (request == NULL)
+		return FALSE;
+	if (!fu_focal_moc_device_send(self, request, FU_FOCAL_MOC_COMMIT_TIMEOUT_MS, error))
+		return FALSE;
+	data = fu_focal_moc_device_receive(self,
+					   FU_FOCAL_MOC_COMMIT_TIMEOUT_MS,
+					   &status,
+					   &error_local);
+	if (data == NULL) {
+		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT) ||
+		    g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND)) {
+			g_debug("commit response unavailable after request: %s",
+				error_local->message);
+			return TRUE;
+		}
+		g_propagate_prefixed_error(error,
+					   g_steal_pointer(&error_local),
+					   "failed to read commit response: ");
+		return FALSE;
+	}
+	if (status != FU_FOCAL_MOC_STATUS_OK) {
+		return fu_focal_moc_device_status_error(self,
+							status,
+							"commit rejected",
+							FWUPD_ERROR_SIGNATURE_INVALID,
+							data,
+							error);
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_focal_moc_device_write_ymodem(FuFocalMocDevice *self,
+				 FuInputStream *stream,
+				 FuProgress *progress,
+				 GError **error)
+{
+	g_autoptr(FuChunkArray) chunks = NULL;
+
+	/* the last chunk is sent as EOT, so a payload that is an exact multiple of
+	 * the frame size ends on a full frame rather than an empty one */
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						FU_FOCAL_MOC_YMODEM_DATA_SIZE,
+						error);
+	if (chunks == NULL)
+		return FALSE;
+
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 1, "soh");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 94, "chunks");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 5, "commit");
+
+	if (!fu_focal_moc_device_write_soh(self, stream, error))
+		return FALSE;
+	fu_progress_step_done(progress);
+	if (!fu_focal_moc_device_write_chunks(self, chunks, fu_progress_get_child(progress), error))
+		return FALSE;
+	fu_progress_step_done(progress);
+	if (!fu_focal_moc_device_commit(self, error))
+		return FALSE;
+	fu_progress_step_done(progress);
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_focal_moc_device_ensure_iap_status_layout(FuFocalMocDevice *self, GError **error)
+{
+	guint8 status = 0;
+	g_autoptr(GByteArray) data = NULL;
+
+	/* the raw status is required: a bootloader without the command replies
+	 * INVALID_COMMAND, which fu_focal_moc_device_command_ok() would turn
+	 * into a generic error */
+	data = fu_focal_moc_device_command(self,
+					   FU_FOCAL_MOC_CMD_GET_FP_VERSION,
+					   NULL,
+					   0,
+					   FU_FOCAL_MOC_USB_TIMEOUT_MS,
+					   &status,
+					   error);
+	if (data == NULL) {
+		g_prefix_error_literal(error, "bootloader capability probe failed: ");
+		return FALSE;
+	}
+	return fu_focal_moc_iap_status_layout_from_probe(status,
+							 data->data,
+							 data->len,
+							 &self->iap_status_layout,
+							 error);
 }
 
 static gboolean
@@ -130,81 +521,76 @@ fu_focal_moc_device_ensure_version(FuFocalMocDevice *self, GError **error)
 	gboolean is_bootloader = FALSE;
 	g_autofree gchar *version = NULL;
 	g_autoptr(GByteArray) data = NULL;
-	g_autoptr(GByteArray) pkt = NULL;
 
-	pkt = fu_focal_moc_packet_new(FU_FOCAL_MOC_CMD_GET_FW_VERSION, NULL, 0, error);
-	if (pkt == NULL)
+	/* never reuse a layout probed on a previous enumeration */
+	self->iap_status_layout = FU_FOCAL_MOC_IAP_STATUS_LAYOUT_UNKNOWN;
+	data = fu_focal_moc_device_command_ok(self,
+					      FU_FOCAL_MOC_CMD_GET_FW_VERSION,
+					      NULL,
+					      0,
+					      FU_FOCAL_MOC_USB_TIMEOUT_MS,
+					      "version command rejected",
+					      error);
+	if (data == NULL)
 		return FALSE;
-	if (!fu_focal_moc_device_send(self, pkt, error)) {
-		g_prefix_error_literal(error, "version: ");
-		return FALSE;
-	}
-	fu_device_sleep(FU_DEVICE(self), FU_FOCAL_MOC_DELAY_CMD_MS);
-	data = fu_focal_moc_device_recv(self,
-					FU_FOCAL_MOC_RECV_TIMEOUT,
-					FU_FOCAL_MOC_VERSION_RSP_SIZE,
-					error);
-	if (data == NULL) {
-		g_prefix_error_literal(error, "version recv: ");
-		return FALSE;
-	}
-
-	/* e.g. "FT9769DL_APP_FT9001_USB_DEC_SV0.1_7396" */
 	version = fu_focal_moc_version_parse(data->data, data->len, &is_bootloader, error);
 	if (version == NULL)
 		return FALSE;
 	fu_device_set_version(FU_DEVICE(self), version);
-	if (is_bootloader) {
+	if (is_bootloader)
 		fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
-	} else {
+	else
 		fu_device_remove_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
+	if (fu_focal_moc_iap_probe_required(is_bootloader)) {
+		if (!fu_focal_moc_device_ensure_iap_status_layout(self, error))
+			return FALSE;
 	}
 
 	/* success */
 	return TRUE;
 }
 
-/*
- * fu_focal_moc_device_set_boot_mode:
- *
- * CMD 0x32 — set device boot mode
- *
- * Packet: [ 0x02 | 0x00 0x02 | 0x32 | mode | BCC ]
- *   LEN = 2  (1 data byte + 1 BCC)
- */
 static gboolean
-fu_focal_moc_device_set_boot_mode(FuFocalMocDevice *self, FuFocalMocBootMode mode, GError **error)
+fu_focal_moc_device_probe(FuDevice *device, GError **error)
 {
-	guint8 buf = (guint8)mode;
-	return fu_focal_moc_device_cmd_xfer(self,
-					    FU_FOCAL_MOC_CMD_SET_BOOT_MODE,
-					    &buf,
-					    1,
-					    FU_FOCAL_MOC_DELAY_CMD_MS,
-					    error);
-}
+	FuFocalMocDevice *self = FU_FOCAL_MOC_DEVICE(device);
+	g_autoptr(GPtrArray) interfaces = NULL;
 
-static gboolean
-fu_focal_moc_device_dl_pkt(FuFocalMocDevice *self,
-			   FuFocalMocMagic magic,
-			   guint8 seq,
-			   const guint8 *data,
-			   gsize data_len,
-			   GError **error)
-{
-	guint8 bcc;
-	g_autoptr(FuStructFocalMocDlHdr) st_req = fu_struct_focal_moc_dl_hdr_new();
+	if (!FU_DEVICE_CLASS(fu_focal_moc_device_parent_class)->probe(device, error))
+		return FALSE;
 
-	fu_struct_focal_moc_dl_hdr_set_ln(st_req, (guint16)(3 + data_len));
-	fu_struct_focal_moc_dl_hdr_set_cmd(st_req, FU_FOCAL_MOC_CMD_FW_DOWNLOAD);
-	fu_struct_focal_moc_dl_hdr_set_magic(st_req, magic);
-	fu_struct_focal_moc_dl_hdr_set_seq(st_req, seq);
-	if (data != NULL && data_len > 0)
-		g_byte_array_append(st_req->buf, data, data_len);
-	bcc = fu_xor8(st_req->buf->data + 1, st_req->buf->len - 1);
-	fu_byte_array_append_uint8(st_req->buf, bcc);
+	interfaces = fu_usb_device_get_interfaces(FU_USB_DEVICE(self), error);
+	if (interfaces == NULL)
+		return FALSE;
+	for (guint i = 0; i < interfaces->len; i++) {
+		FuUsbInterface *iface = g_ptr_array_index(interfaces, i);
+		g_autoptr(GPtrArray) endpoints = NULL;
 
-	return fu_focal_moc_device_send(self, st_req->buf, error);
+		if (fu_usb_interface_get_number(iface) != FU_FOCAL_MOC_USB_INTERFACE)
+			continue;
+		endpoints = fu_usb_interface_get_endpoints(iface);
+		for (guint j = 0; endpoints != NULL && j < endpoints->len; j++) {
+			FuUsbEndpoint *endpoint = g_ptr_array_index(endpoints, j);
+			if (fu_usb_endpoint_get_direction(endpoint) ==
+			    FU_USB_DIRECTION_DEVICE_TO_HOST)
+				self->ep_in = fu_usb_endpoint_get_address(endpoint);
+			else
+				self->ep_out = fu_usb_endpoint_get_address(endpoint);
+		}
+		self->iface = fu_usb_interface_get_number(iface);
+		break;
+	}
+	if (self->ep_in == 0 || self->ep_out == 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
+				    "bulk endpoint pair not found on interface 0");
+		return FALSE;
+	}
+	fu_usb_device_add_interface(FU_USB_DEVICE(self), self->iface);
+
+	/* success */
+	return TRUE;
 }
 
 static gboolean
@@ -214,11 +600,9 @@ fu_focal_moc_device_setup(FuDevice *device, GError **error)
 
 	if (!FU_DEVICE_CLASS(fu_focal_moc_device_parent_class)->setup(device, error))
 		return FALSE;
-
-	if (!fu_focal_moc_device_ensure_version(self, error)) {
-		g_prefix_error_literal(error, "failed to read firmware version: ");
+	if (!fu_focal_moc_device_ensure_version(self, error))
 		return FALSE;
-	}
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 
 	/* success */
 	return TRUE;
@@ -228,147 +612,21 @@ static gboolean
 fu_focal_moc_device_detach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuFocalMocDevice *self = FU_FOCAL_MOC_DEVICE(device);
+	guint8 mode = FU_FOCAL_MOC_BOOT_MODE_IAP;
+	g_autoptr(GByteArray) data = NULL;
 
-	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
-		g_debug("already in bootloader mode, skipping");
+	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER))
 		return TRUE;
-	}
-	if (!fu_focal_moc_device_set_boot_mode(self, FU_FOCAL_MOC_BOOT_MODE_ENTER_BOOT, error)) {
-		g_prefix_error_literal(error, "failed to enter bootloader mode: ");
+	data = fu_focal_moc_device_command_ok(self,
+					      FU_FOCAL_MOC_CMD_SET_BOOT_MODE,
+					      &mode,
+					      sizeof(mode),
+					      FU_FOCAL_MOC_USB_TIMEOUT_MS,
+					      "enter IAP rejected",
+					      error);
+	if (data == NULL)
 		return FALSE;
-	}
-
-	/* success */
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
-	return TRUE;
-}
-
-static gboolean
-fu_focal_moc_device_write_sho(FuFocalMocDevice *self,
-			      FuInputStream *stream,
-			      guint8 *seq,
-			      GError **error)
-{
-	guint32 crc32 = G_MAXUINT32;
-	gsize streamsz = 0;
-	g_autoptr(FuStructFocalMocShoData) st_sho = fu_struct_focal_moc_sho_data_new();
-
-	if (!fu_struct_focal_moc_sho_data_set_filename(st_sho, "firmware.bin", error))
-		return FALSE;
-	if (!fu_input_stream_size(stream, &streamsz, error))
-		return FALSE;
-	fu_struct_focal_moc_sho_data_set_filesize(st_sho, (guint32)streamsz);
-	if (!fu_input_stream_compute_crc32(stream, FU_CRC_KIND_B32_STANDARD, &crc32, error))
-		return FALSE;
-	fu_struct_focal_moc_sho_data_set_crc32(st_sho, crc32);
-
-	if (!fu_focal_moc_device_dl_pkt(self,
-					FU_FOCAL_MOC_MAGIC_SHO,
-					(*seq)++,
-					st_sho->buf->data,
-					st_sho->buf->len,
-					error)) {
-		g_prefix_error_literal(error, "SHO packet send failed: ");
-		return FALSE;
-	}
-	fu_device_sleep(FU_DEVICE(self), FU_FOCAL_MOC_DELAY_DL_MS);
-	if (!fu_focal_moc_device_recv_ack(self, FU_FOCAL_MOC_RECV_TIMEOUT, error)) {
-		g_prefix_error_literal(error, "SHO ACK failed: ");
-		return FALSE;
-	}
-
-	/* success; short settle after SHO ACK */
-	fu_device_sleep(FU_DEVICE(self), 15);
-	return TRUE;
-}
-
-static gboolean
-fu_focal_moc_device_write_stx_chunk(FuFocalMocDevice *self,
-				    FuChunk *chk,
-				    guint8 *seq,
-				    GError **error)
-{
-	if (!fu_focal_moc_device_dl_pkt(self,
-					FU_FOCAL_MOC_MAGIC_STX,
-					(*seq)++,
-					fu_chunk_get_data(chk),
-					fu_chunk_get_data_sz(chk),
-					error)) {
-		g_prefix_error(error, "block %u send failed: ", fu_chunk_get_idx(chk));
-		return FALSE;
-	}
-
-	/* collect per-block ACK */
-	fu_device_sleep(FU_DEVICE(self), FU_FOCAL_MOC_DELAY_DL_MS);
-	if (!fu_focal_moc_device_recv_ack(self, FU_FOCAL_MOC_RECV_TIMEOUT, error)) {
-		g_prefix_error(error, "block %u ACK failed: ", fu_chunk_get_idx(chk));
-		return FALSE;
-	}
-
-	/* success */
-	return TRUE;
-}
-
-static gboolean
-fu_focal_moc_device_write_eot_chunk(FuFocalMocDevice *self,
-				    FuChunk *chk,
-				    guint8 *seq,
-				    GError **error)
-{
-	g_autoptr(GByteArray) tail_buf = g_byte_array_new();
-	g_byte_array_append(tail_buf, fu_chunk_get_data(chk), fu_chunk_get_data_sz(chk));
-	fu_byte_array_set_size(tail_buf, FU_FOCAL_MOC_DL_BLOCK_SIZE, 0x0);
-	if (!fu_focal_moc_device_dl_pkt(self,
-					FU_FOCAL_MOC_MAGIC_EOT,
-					(*seq)++,
-					tail_buf->data,
-					tail_buf->len,
-					error)) {
-		g_prefix_error_literal(error, "EOT packet send failed: ");
-		return FALSE;
-	}
-
-	/* success */
-	return TRUE;
-}
-
-static gboolean
-fu_focal_moc_device_write_stx_chunks(FuFocalMocDevice *self,
-				     FuChunkArray *chunks,
-				     guint8 *seq,
-				     FuProgress *progress,
-				     GError **error)
-{
-	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
-
-	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
-		g_autoptr(FuChunk) chk = NULL;
-		chk = fu_chunk_array_index(chunks, i, error);
-		if (chk == NULL)
-			return FALSE;
-		if (i < fu_chunk_array_length(chunks) - 1) {
-			if (!fu_focal_moc_device_write_stx_chunk(self, chk, seq, error))
-				return FALSE;
-		} else {
-			if (!fu_focal_moc_device_write_eot_chunk(self, chk, seq, error))
-				return FALSE;
-		}
-		fu_progress_step_done(progress);
-	}
-
-	/* success */
-	return TRUE;
-}
-
-static gboolean
-fu_focal_moc_device_write_final_ack(FuFocalMocDevice *self, GError **error)
-{
-	fu_device_sleep(FU_DEVICE(self), FU_FOCAL_MOC_DELAY_FINAL_MS);
-	if (!fu_focal_moc_device_recv_ack(self, FU_FOCAL_MOC_RECV_FINAL_TIMEOUT, error)) {
-		g_prefix_error_literal(error, "final ACK failed: ");
-		return FALSE;
-	}
 
 	/* success */
 	return TRUE;
@@ -382,108 +640,67 @@ fu_focal_moc_device_write_firmware(FuDevice *device,
 				   GError **error)
 {
 	FuFocalMocDevice *self = FU_FOCAL_MOC_DEVICE(device);
-	guint8 seq = 0;
 	g_autoptr(FuInputStream) stream = NULL;
-	g_autoptr(FuChunkArray) chunks = NULL;
 
-	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 1, "sho");
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 98, "chunks");
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 1, "final-ack");
-
+	if (!fu_device_has_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "firmware write requires IAP mode");
+		return FALSE;
+	}
 	stream = fu_firmware_get_stream(firmware, error);
 	if (stream == NULL)
 		return FALSE;
-
-	/* send header packet with filename, file size, CRC32; then wait for ACK */
-	if (!fu_focal_moc_device_write_sho(self, stream, &seq, error))
+	if (!fu_focal_moc_device_probe_alive(self, FU_FOCAL_MOC_USB_TIMEOUT_MS, error)) {
+		g_prefix_error_literal(error, "IAP communication probe failed: ");
 		return FALSE;
-	fu_progress_step_done(progress);
-
-	/* send 1024-byte data blocks; wait for ACK after each */
-	chunks = fu_chunk_array_new_from_stream(stream,
-						FU_CHUNK_ADDR_OFFSET_NONE,
-						FU_CHUNK_PAGESZ_NONE,
-						FU_FOCAL_MOC_DL_BLOCK_SIZE,
-						error);
-	if (chunks == NULL)
-		return FALSE;
-	if (!fu_focal_moc_device_write_stx_chunks(self,
-						  chunks,
-						  &seq,
-						  fu_progress_get_child(progress),
-						  error))
-		return FALSE;
-	fu_progress_step_done(progress);
-
-	/* send remaining (<1024) bytes; wait for final ACK */
-	if (!fu_focal_moc_device_write_final_ack(self, error))
-		return FALSE;
-	fu_progress_step_done(progress);
-
-	/* success */
-	return TRUE;
-}
-
-static gboolean
-fu_focal_moc_device_attach(FuDevice *device, FuProgress *progress, GError **error)
-{
-	FuFocalMocDevice *self = FU_FOCAL_MOC_DEVICE(device);
-	g_autoptr(GError) error_local = NULL;
-
-	/* some firmware images trigger an automatic reboot after the EOT+ACK;
-	 * others (e.g. test payloads) do not; sending ENTER_APP explicitly covers both cases */
-	if (!fu_focal_moc_device_set_boot_mode(self,
-					       FU_FOCAL_MOC_BOOT_MODE_ENTER_APP,
-					       &error_local)) {
-		g_debug("ENTER_APP command failed (device may have already rebooted): %s",
-			error_local->message);
 	}
+	if (!fu_focal_moc_device_write_ymodem(self, stream, progress, error))
+		return FALSE;
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 
 	/* success */
-	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 	return TRUE;
 }
 
 static void
 fu_focal_moc_device_set_progress(FuDevice *device, FuProgress *progress)
 {
+	/* the write step also waits for the runtime to re-enumerate, so attach and
+	 * reload complete immediately */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 2, "detach");
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 74, "write");
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 24, "attach");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 15, "detach");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 85, "write");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0, "attach");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 0, "reload");
 }
 
 static void
 fu_focal_moc_device_init(FuFocalMocDevice *self)
 {
-	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SELF_RECOVERY);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
-	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INSTALL_SKIP_VERSION_CHECK);
-	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_ENSURE_SEMVER);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_RETRY_OPEN);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_USE_RUNTIME_VERSION);
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PLAIN);
-	fu_device_set_remove_delay(FU_DEVICE(self), 10000);
+	fu_device_set_remove_delay(FU_DEVICE(self), 30000);
+	fu_device_set_firmware_size_max(FU_DEVICE(self), FU_FOCAL_MOC_MAX_FIRMWARE_SIZE);
+	fu_device_set_install_duration(FU_DEVICE(self), FU_FOCAL_MOC_INSTALL_DURATION);
 	fu_device_add_protocol(FU_DEVICE(self), "com.focal.moc");
 	fu_device_set_name(FU_DEVICE(self), "Fingerprint Sensor");
-	fu_device_set_summary(FU_DEVICE(self), "Match-On-Chip fingerprint sensor");
-	fu_device_set_install_duration(FU_DEVICE(self), 15);
-	fu_device_set_firmware_size_min(FU_DEVICE(self), 2 * FU_FOCAL_MOC_DL_BLOCK_SIZE);
-	fu_device_set_firmware_size_max(FU_DEVICE(self), FU_FOCAL_MOC_FW_MAX_SIZE);
-	fu_usb_device_add_interface(FU_USB_DEVICE(self), FU_FOCAL_MOC_USB_INTERFACE);
+	fu_device_set_summary(FU_DEVICE(self), "Match-on-chip fingerprint sensor");
 }
 
 static void
 fu_focal_moc_device_class_init(FuFocalMocDeviceClass *klass)
 {
 	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_focal_moc_device_to_string;
+	device_class->probe = fu_focal_moc_device_probe;
 	device_class->setup = fu_focal_moc_device_setup;
 	device_class->detach = fu_focal_moc_device_detach;
 	device_class->write_firmware = fu_focal_moc_device_write_firmware;
-	device_class->attach = fu_focal_moc_device_attach;
 	device_class->set_progress = fu_focal_moc_device_set_progress;
 }

--- a/plugins/focal-moc/fu-focal-moc-device.h
+++ b/plugins/focal-moc/fu-focal-moc-device.h
@@ -8,5 +8,52 @@
 
 #include <fwupdplugin.h>
 
+#include "fu-focal-moc-struct.h"
+
 #define FU_TYPE_FOCAL_MOC_DEVICE (fu_focal_moc_device_get_type())
-G_DECLARE_FINAL_TYPE(FuFocalMocDevice, fu_focal_moc_device, FU, FOCAL_MOC_DEVICE, FuUsbDevice)
+G_DECLARE_DERIVABLE_TYPE(FuFocalMocDevice, fu_focal_moc_device, FU, FOCAL_MOC_DEVICE, FuUsbDevice)
+
+struct _FuFocalMocDeviceClass {
+	FuUsbDeviceClass parent_class;
+	GByteArray *(*command)(FuFocalMocDevice *self,
+			       guint8 command,
+			       const guint8 *payload,
+			       gsize payload_sz,
+			       guint timeout_ms,
+			       guint8 *status,
+			       GError **error)G_GNUC_NON_NULL(1);
+	GByteArray *(*build_soh)(FuFocalMocDevice *self,
+				 gsize firmware_sz,
+				 guint32 crc32,
+				 GError **error)G_GNUC_NON_NULL(1);
+	GByteArray *(*build_data)(FuFocalMocDevice *self,
+				  FuFocalMocFrame kind,
+				  guint16 sequence,
+				  const guint8 *buf,
+				  gsize bufsz,
+				  GError **error)G_GNUC_NON_NULL(1);
+	FuInputStream *(*get_firmware_stream)(FuFocalMocDevice *self,
+					      FuFirmware *firmware,
+					      GError **error)G_GNUC_NON_NULL(1, 2);
+	gboolean (*ensure_bootloader_layout)(FuFocalMocDevice *self, GError **error)
+	    G_GNUC_NON_NULL(1);
+};
+
+/* the reply carries one byte of stale buffer past the declared frame */
+#define FU_FOCAL_MOC_DEVICE_FLAG_LEGACY_TRAILER "legacy-trailer"
+
+gboolean
+fu_focal_moc_device_send_raw(FuFocalMocDevice *self,
+			     const guint8 *buf,
+			     gsize bufsz,
+			     guint timeout_ms,
+			     GError **error) G_GNUC_NON_NULL(1, 2);
+
+GByteArray *
+fu_focal_moc_device_receive_raw(FuFocalMocDevice *self, guint timeout_ms, GError **error)
+    G_GNUC_NON_NULL(1) G_GNUC_WARN_UNUSED_RESULT;
+
+void
+fu_focal_moc_device_set_iap_status_layout(FuFocalMocDevice *self,
+					  FuFocalMocIapStatusLayout iap_status_layout)
+    G_GNUC_NON_NULL(1);

--- a/plugins/focal-moc/fu-focal-moc-firmware.c
+++ b/plugins/focal-moc/fu-focal-moc-firmware.c
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2026 FocalTech Systems Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-focal-moc-firmware.h"
+#include "fu-focal-moc-struct.h"
+
+struct _FuFocalMocFirmware {
+	FuFirmware parent_instance;
+	guint32 entry_offset;
+	GBytes *digest;
+	GBytes *signature;
+};
+
+G_DEFINE_TYPE(FuFocalMocFirmware, fu_focal_moc_firmware, FU_TYPE_FIRMWARE)
+
+static gboolean
+fu_focal_moc_firmware_validate(FuFirmware *firmware,
+			       FuInputStream *stream,
+			       gsize offset,
+			       GError **error)
+{
+	return fu_struct_focal_moc_firmware_header_validate_stream(stream, offset, error);
+}
+
+static gboolean
+fu_focal_moc_firmware_check_reserved(FuStructFocalMocFirmwareHeader *st, GError **error)
+{
+	const struct {
+		gsize offset;
+		gsize end;
+	} regions[] = {
+	    {FU_STRUCT_FOCAL_MOC_FIRMWARE_HEADER_OFFSET_ENTRY_OFFSET + sizeof(guint32),
+	     FU_STRUCT_FOCAL_MOC_FIRMWARE_HEADER_OFFSET_DIGEST},
+	    {FU_STRUCT_FOCAL_MOC_FIRMWARE_HEADER_OFFSET_SIGNATURE +
+		 FU_STRUCT_FOCAL_MOC_FIRMWARE_HEADER_SIZE_SIGNATURE,
+	     FU_STRUCT_FOCAL_MOC_FIRMWARE_HEADER_SIZE},
+	};
+
+	/* the writer rebuilds these regions as zeros, so nonzero content would
+	 * not survive a parse-write cycle */
+	for (guint i = 0; i < G_N_ELEMENTS(regions); i++) {
+		for (gsize off = regions[i].offset; off < regions[i].end; off++) {
+			guint8 value = 0;
+			if (!fu_memread_uint8_safe(st->buf->data, st->buf->len, off, &value, error))
+				return FALSE;
+			if (value != 0x0) {
+				g_set_error(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_FILE,
+					    "reserved header byte not zero at 0x%zx",
+					    off);
+				return FALSE;
+			}
+		}
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_focal_moc_firmware_parse(FuFirmware *firmware,
+			    FuInputStream *stream,
+			    FuFirmwareParseFlags flags,
+			    GError **error)
+{
+	FuFocalMocFirmware *self = FU_FOCAL_MOC_FIRMWARE(firmware);
+	gsize streamsz = 0;
+	guint32 body_sz;
+	guint32 version;
+	g_autoptr(FuStructFocalMocFirmwareHeader) st = NULL;
+	g_autoptr(FuInputStream) stream_body = NULL;
+
+	st = fu_struct_focal_moc_firmware_header_parse_stream(stream, 0, error);
+	if (st == NULL)
+		return FALSE;
+	if (fu_struct_focal_moc_firmware_header_get_kind(st) != FU_FOCAL_MOC_FIRMWARE_KIND_APP) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_FILE,
+			    "firmware type invalid: got=0x%x expected=0x%x",
+			    fu_struct_focal_moc_firmware_header_get_kind(st),
+			    (guint)FU_FOCAL_MOC_FIRMWARE_KIND_APP);
+		return FALSE;
+	}
+	if (!fu_focal_moc_firmware_check_reserved(st, error))
+		return FALSE;
+	if (!fu_input_stream_size(stream, &streamsz, error))
+		return FALSE;
+	body_sz = fu_struct_focal_moc_firmware_header_get_size(st);
+	if (body_sz == 0 || streamsz != FU_STRUCT_FOCAL_MOC_FIRMWARE_HEADER_SIZE + body_sz) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_FILE,
+			    "firmware size invalid: header=0x%x file=0x%zx expected=0x%x",
+			    body_sz,
+			    streamsz,
+			    FU_STRUCT_FOCAL_MOC_FIRMWARE_HEADER_SIZE + body_sz);
+		return FALSE;
+	}
+	self->entry_offset = fu_struct_focal_moc_firmware_header_get_entry_offset(st);
+	if (self->entry_offset >= body_sz) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_FILE,
+			    "firmware entry offset invalid: offset=0x%x size=0x%x",
+			    self->entry_offset,
+			    body_sz);
+		return FALSE;
+	}
+	version = fu_struct_focal_moc_firmware_header_get_version(st);
+	if (version > G_MAXUINT16) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_FILE,
+			    "firmware version exceeds four hex digits: 0x%x",
+			    version);
+		return FALSE;
+	}
+	fu_firmware_set_version_raw(firmware, version);
+
+	self->digest = g_bytes_new(fu_struct_focal_moc_firmware_header_get_digest(st, NULL),
+				   FU_STRUCT_FOCAL_MOC_FIRMWARE_HEADER_SIZE_DIGEST);
+	self->signature = g_bytes_new(fu_struct_focal_moc_firmware_header_get_signature(st, NULL),
+				      FU_STRUCT_FOCAL_MOC_FIRMWARE_HEADER_SIZE_SIGNATURE);
+
+	stream_body = fu_partial_input_stream_new(stream,
+						  FU_STRUCT_FOCAL_MOC_FIRMWARE_HEADER_SIZE,
+						  body_sz,
+						  error);
+	if (stream_body == NULL)
+		return FALSE;
+	if (!fu_firmware_set_stream(firmware, stream_body, error))
+		return FALSE;
+
+	/* success */
+	return TRUE;
+}
+
+static GByteArray *
+fu_focal_moc_firmware_write(FuFirmware *firmware, GError **error)
+{
+	FuFocalMocFirmware *self = FU_FOCAL_MOC_FIRMWARE(firmware);
+	guint64 version = 0;
+	g_autoptr(FuStructFocalMocFirmwareHeader) st = fu_struct_focal_moc_firmware_header_new();
+	g_autoptr(GBytes) blob = fu_firmware_get_bytes_with_patches(firmware, error);
+
+	if (blob == NULL)
+		return NULL;
+	if (g_bytes_get_size(blob) == 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "firmware body is empty");
+		return NULL;
+	}
+	if (self->entry_offset >= g_bytes_get_size(blob)) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "firmware entry offset invalid: offset=0x%x size=0x%zx",
+			    self->entry_offset,
+			    g_bytes_get_size(blob));
+		return NULL;
+	}
+	version = fu_firmware_get_version_raw(firmware);
+	if (version > G_MAXUINT16) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "firmware version exceeds four hex digits: 0x%" G_GINT64_MODIFIER "x",
+			    version);
+		return NULL;
+	}
+	fu_struct_focal_moc_firmware_header_set_kind(st, FU_FOCAL_MOC_FIRMWARE_KIND_APP);
+	fu_struct_focal_moc_firmware_header_set_version(st, (guint32)version);
+	fu_struct_focal_moc_firmware_header_set_size(st, (guint32)g_bytes_get_size(blob));
+	fu_struct_focal_moc_firmware_header_set_entry_offset(st, self->entry_offset);
+	if (self->digest != NULL) {
+		if (!fu_struct_focal_moc_firmware_header_set_digest(
+			st,
+			g_bytes_get_data(self->digest, NULL),
+			g_bytes_get_size(self->digest),
+			error))
+			return NULL;
+	}
+	if (self->signature != NULL) {
+		if (!fu_struct_focal_moc_firmware_header_set_signature(
+			st,
+			g_bytes_get_data(self->signature, NULL),
+			g_bytes_get_size(self->signature),
+			error))
+			return NULL;
+	}
+	fu_byte_array_append_bytes(st->buf, blob);
+
+	/* success */
+	return g_byte_array_ref(st->buf);
+}
+
+static void
+fu_focal_moc_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuilderNode *bn)
+{
+	FuFocalMocFirmware *self = FU_FOCAL_MOC_FIRMWARE(firmware);
+
+	fu_xmlb_builder_insert_kx(bn, "entry_offset", self->entry_offset);
+	if (self->digest != NULL) {
+		g_autofree gchar *str = fu_bytes_to_string(self->digest);
+		fu_xmlb_builder_insert_kv(bn, "digest", str);
+	}
+	if (self->signature != NULL) {
+		g_autofree gchar *str = fu_bytes_to_string(self->signature);
+		fu_xmlb_builder_insert_kv(bn, "signature", str);
+	}
+}
+
+static gboolean
+fu_focal_moc_firmware_build(FuFirmware *firmware, XbNode *n, GError **error)
+{
+	FuFocalMocFirmware *self = FU_FOCAL_MOC_FIRMWARE(firmware);
+	const gchar *tmp;
+	guint64 value;
+
+	value = xb_node_query_text_as_uint(n, "entry_offset", NULL);
+	if (value != G_MAXUINT64 && value <= G_MAXUINT32)
+		self->entry_offset = (guint32)value;
+	tmp = xb_node_query_text(n, "digest", NULL);
+	if (tmp != NULL) {
+		g_autoptr(GBytes) blob = fu_bytes_from_string(tmp, error);
+		if (blob == NULL)
+			return FALSE;
+		if (g_bytes_get_size(blob) != FU_STRUCT_FOCAL_MOC_FIRMWARE_HEADER_SIZE_DIGEST) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "digest size invalid: 0x%zx",
+				    g_bytes_get_size(blob));
+			return FALSE;
+		}
+		g_clear_pointer(&self->digest, g_bytes_unref);
+		self->digest = g_steal_pointer(&blob);
+	}
+	tmp = xb_node_query_text(n, "signature", NULL);
+	if (tmp != NULL) {
+		g_autoptr(GBytes) blob = fu_bytes_from_string(tmp, error);
+		if (blob == NULL)
+			return FALSE;
+		if (g_bytes_get_size(blob) != FU_STRUCT_FOCAL_MOC_FIRMWARE_HEADER_SIZE_SIGNATURE) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "signature size invalid: 0x%zx",
+				    g_bytes_get_size(blob));
+			return FALSE;
+		}
+		g_clear_pointer(&self->signature, g_bytes_unref);
+		self->signature = g_steal_pointer(&blob);
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gchar *
+fu_focal_moc_firmware_convert_version(FuFirmware *firmware, guint64 version_raw)
+{
+	return g_strdup_printf("%04" G_GINT64_MODIFIER "x", version_raw);
+}
+
+static void
+fu_focal_moc_firmware_init(FuFocalMocFirmware *self)
+{
+	fu_firmware_set_version_format(FU_FIRMWARE(self), FWUPD_VERSION_FORMAT_PLAIN);
+}
+
+static void
+fu_focal_moc_firmware_finalize(GObject *object)
+{
+	FuFocalMocFirmware *self = FU_FOCAL_MOC_FIRMWARE(object);
+
+	g_clear_pointer(&self->digest, g_bytes_unref);
+	g_clear_pointer(&self->signature, g_bytes_unref);
+	G_OBJECT_CLASS(fu_focal_moc_firmware_parent_class)->finalize(object);
+}
+
+static void
+fu_focal_moc_firmware_class_init(FuFocalMocFirmwareClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	object_class->finalize = fu_focal_moc_firmware_finalize;
+	firmware_class->convert_version = fu_focal_moc_firmware_convert_version;
+	firmware_class->validate = fu_focal_moc_firmware_validate;
+	firmware_class->parse = fu_focal_moc_firmware_parse;
+	firmware_class->write = fu_focal_moc_firmware_write;
+	firmware_class->export = fu_focal_moc_firmware_export;
+	firmware_class->build = fu_focal_moc_firmware_build;
+	fu_firmware_set_size_max(firmware_class, FU_FOCAL_MOC_FIRMWARE_SIZE_MAX);
+}
+
+FuFirmware *
+fu_focal_moc_firmware_new(void)
+{
+	return FU_FIRMWARE(g_object_new(FU_TYPE_FOCAL_MOC_FIRMWARE, NULL));
+}

--- a/plugins/focal-moc/fu-focal-moc-firmware.h
+++ b/plugins/focal-moc/fu-focal-moc-firmware.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2026 FocalTech Systems Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_FOCAL_MOC_FIRMWARE (fu_focal_moc_firmware_get_type())
+G_DECLARE_FINAL_TYPE(FuFocalMocFirmware, fu_focal_moc_firmware, FU, FOCAL_MOC_FIRMWARE, FuFirmware)
+
+/* the APP flash region limit, including the FWHD header */
+#define FU_FOCAL_MOC_FIRMWARE_SIZE_MAX (384 * FU_KB)
+
+FuFirmware *
+fu_focal_moc_firmware_new(void);

--- a/plugins/focal-moc/fu-focal-moc-plugin.c
+++ b/plugins/focal-moc/fu-focal-moc-plugin.c
@@ -7,6 +7,7 @@
 #include "config.h"
 
 #include "fu-focal-moc-device.h"
+#include "fu-focal-moc-firmware.h"
 #include "fu-focal-moc-plugin.h"
 
 struct _FuFocalMocPlugin {
@@ -26,6 +27,7 @@ fu_focal_moc_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_FOCAL_MOC_DEVICE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_FOCAL_MOC_FIRMWARE);
 
 	/* chain up to parent */
 	G_OBJECT_CLASS(fu_focal_moc_plugin_parent_class)->constructed(obj);

--- a/plugins/focal-moc/fu-focal-moc-plugin.c
+++ b/plugins/focal-moc/fu-focal-moc-plugin.c
@@ -9,6 +9,7 @@
 #include "fu-focal-moc-device.h"
 #include "fu-focal-moc-firmware.h"
 #include "fu-focal-moc-plugin.h"
+#include "fu-focal-moc-signed-device.h"
 
 struct _FuFocalMocPlugin {
 	FuPlugin parent_instance;
@@ -26,7 +27,8 @@ fu_focal_moc_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
-	fu_plugin_add_device_gtype(plugin, FU_TYPE_FOCAL_MOC_DEVICE);
+	fu_plugin_add_device_gtype(plugin, FU_TYPE_FOCAL_MOC_SIGNED_DEVICE);
+	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_FOCAL_MOC_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_FOCAL_MOC_FIRMWARE);
 
 	/* chain up to parent */

--- a/plugins/focal-moc/fu-focal-moc-signed-device.c
+++ b/plugins/focal-moc/fu-focal-moc-signed-device.c
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2026 FocalTech Systems Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-focal-moc-common.h"
+#include "fu-focal-moc-firmware.h"
+#include "fu-focal-moc-signed-device.h"
+#include "fu-focal-moc-struct.h"
+#include "fu-focal-moc-transport.h"
+
+struct _FuFocalMocSignedDevice {
+	FuFocalMocDevice parent_instance;
+	FuFocalMocTransport *transport;
+};
+
+static void
+fu_focal_moc_signed_device_transport_impl_iface_init(FuFocalMocTransportImplInterface *iface);
+
+G_DEFINE_TYPE_WITH_CODE(FuFocalMocSignedDevice,
+			fu_focal_moc_signed_device,
+			FU_TYPE_FOCAL_MOC_DEVICE,
+			G_IMPLEMENT_INTERFACE(FU_TYPE_FOCAL_MOC_TRANSPORT_IMPL,
+					      fu_focal_moc_signed_device_transport_impl_iface_init))
+
+#define FU_FOCAL_MOC_SIGNED_DEVICE_INSTALL_DURATION 25
+
+/* the plaintext IAP interface, set from the quirk file */
+#define FU_FOCAL_MOC_SIGNED_DEVICE_FLAG_IS_IAP "is-iap"
+
+/* a valid P-256 keypair packed as x||y||scalar; only used for emulations,
+ * so secrecy is not required */
+#define FU_FOCAL_MOC_SIGNED_DEVICE_EMULATION_HOST_KEY                                              \
+	"509507d9afe7885875ec3e82f27f3f26b101438117aa843f827b3cc8ff3a9cbb"                         \
+	"1376086829ab873a45e968a030485bdf98f2766b35fda2496c43e9606392e337"                         \
+	"59567a7e2a43194bdef67291ed1273a5d677258d48662f282467a710f37923f2"
+
+static gboolean
+fu_focal_moc_signed_device_is_iap(FuFocalMocSignedDevice *self)
+{
+	return fu_device_has_private_flag(FU_DEVICE(self), FU_FOCAL_MOC_SIGNED_DEVICE_FLAG_IS_IAP);
+}
+
+static void
+fu_focal_moc_signed_device_to_string(FuDevice *device, guint idt, GString *str)
+{
+	FuFocalMocSignedDevice *self = FU_FOCAL_MOC_SIGNED_DEVICE(device);
+
+	fwupd_codec_string_append_bool(str,
+				       idt,
+				       "TransportActive",
+				       fu_focal_moc_transport_is_active(self->transport));
+}
+
+static gboolean
+fu_focal_moc_signed_device_transport_write(FuFocalMocTransportImpl *impl,
+					   const guint8 *buf,
+					   gsize bufsz,
+					   guint timeout_ms,
+					   GError **error)
+{
+	return fu_focal_moc_device_send_raw(FU_FOCAL_MOC_DEVICE(impl),
+					    buf,
+					    bufsz,
+					    timeout_ms,
+					    error);
+}
+
+static GByteArray *
+fu_focal_moc_signed_device_transport_read(FuFocalMocTransportImpl *impl,
+					  guint timeout_ms,
+					  GError **error)
+{
+	return fu_focal_moc_device_receive_raw(FU_FOCAL_MOC_DEVICE(impl), timeout_ms, error);
+}
+
+static void
+fu_focal_moc_signed_device_transport_impl_iface_init(FuFocalMocTransportImplInterface *iface)
+{
+	iface->write = fu_focal_moc_signed_device_transport_write;
+	iface->read = fu_focal_moc_signed_device_transport_read;
+}
+
+static GByteArray *
+fu_focal_moc_signed_device_command(FuFocalMocDevice *device,
+				   guint8 command,
+				   const guint8 *payload,
+				   gsize payload_sz,
+				   guint timeout_ms,
+				   guint8 *status,
+				   GError **error)
+{
+	FuFocalMocSignedDevice *self = FU_FOCAL_MOC_SIGNED_DEVICE(device);
+
+	/* the IAP is plaintext, so a device stuck in IAP stays recoverable */
+	if (fu_focal_moc_signed_device_is_iap(self)) {
+		return FU_FOCAL_MOC_DEVICE_CLASS(fu_focal_moc_signed_device_parent_class)
+		    ->command(device, command, payload, payload_sz, timeout_ms, status, error);
+	}
+	/* make the ephemeral key predictable, so a recording and its replay
+	 * derive identical session keys; the context flag covers recording,
+	 * where the device flag is not yet set during setup */
+	if (fu_device_has_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_EMULATED) ||
+	    fu_context_has_flag(fu_device_get_context(FU_DEVICE(self)),
+				FU_CONTEXT_FLAG_SAVE_EVENTS)) {
+		g_autoptr(GBytes) host_key =
+		    fu_bytes_from_string(FU_FOCAL_MOC_SIGNED_DEVICE_EMULATION_HOST_KEY, error);
+		if (host_key == NULL)
+			return NULL;
+		fu_focal_moc_transport_set_fixed_host_key(self->transport,
+							  g_bytes_get_data(host_key, NULL),
+							  g_bytes_get_size(host_key));
+	} else {
+		fu_focal_moc_transport_clear_fixed_host_key(self->transport);
+	}
+	if (!fu_focal_moc_transport_handshake(self->transport, error)) {
+		g_prefix_error_literal(error, "transport handshake failed: ");
+		return NULL;
+	}
+	return fu_focal_moc_transport_command(self->transport,
+					      command,
+					      payload,
+					      payload_sz,
+					      timeout_ms,
+					      status,
+					      error);
+}
+
+static GByteArray *
+fu_focal_moc_signed_device_build_soh(FuFocalMocDevice *device,
+				     gsize firmware_sz,
+				     guint32 crc32,
+				     GError **error)
+{
+	return fu_focal_moc_ymodem_build_soh_v2(firmware_sz, crc32, error);
+}
+
+static GByteArray *
+fu_focal_moc_signed_device_build_data(FuFocalMocDevice *device,
+				      FuFocalMocFrame kind,
+				      guint16 sequence,
+				      const guint8 *buf,
+				      gsize bufsz,
+				      GError **error)
+{
+	return fu_focal_moc_ymodem_build_data_v2(kind, sequence, buf, bufsz, error);
+}
+
+static FuInputStream *
+fu_focal_moc_signed_device_get_firmware_stream(FuFocalMocDevice *device,
+					       FuFirmware *firmware,
+					       GError **error)
+{
+	g_autoptr(GBytes) blob = NULL;
+
+	/* the parsed firmware keeps only the image body as its stream, but the
+	 * IAP flashes and verifies the complete signed image, so rebuild the
+	 * FWHD header in front of the body */
+	blob = fu_firmware_write(firmware, error);
+	if (blob == NULL)
+		return NULL;
+	return fu_memory_input_stream_new_from_bytes(blob);
+}
+
+static gboolean
+fu_focal_moc_signed_device_ensure_bootloader_layout(FuFocalMocDevice *device, GError **error)
+{
+	/* the bootloader already uses the unified status layout */
+	fu_focal_moc_device_set_iap_status_layout(device, FU_FOCAL_MOC_IAP_STATUS_LAYOUT_ALIGNED);
+	return TRUE;
+}
+
+static gboolean
+fu_focal_moc_signed_device_setup(FuDevice *device, GError **error)
+{
+	FuFocalMocSignedDevice *self = FU_FOCAL_MOC_SIGNED_DEVICE(device);
+
+	if (!fu_focal_moc_signed_device_is_iap(self) && !fu_focal_moc_transport_is_supported()) {
+		fu_device_set_update_error(device, "TransportSec requires GnuTLS 3.8.2 or later");
+		return TRUE;
+	}
+	return FU_DEVICE_CLASS(fu_focal_moc_signed_device_parent_class)->setup(device, error);
+}
+
+static gboolean
+fu_focal_moc_signed_device_close(FuDevice *device, GError **error)
+{
+	FuFocalMocSignedDevice *self = FU_FOCAL_MOC_SIGNED_DEVICE(device);
+
+	/* a fresh handshake is negotiated per engine operation, so a stale
+	 * session never spans a mode switch */
+	fu_focal_moc_transport_teardown(self->transport);
+	return FU_DEVICE_CLASS(fu_focal_moc_signed_device_parent_class)->close(device, error);
+}
+
+static void
+fu_focal_moc_signed_device_init(FuFocalMocSignedDevice *self)
+{
+	self->transport = fu_focal_moc_transport_new(FU_FOCAL_MOC_TRANSPORT_IMPL(self));
+	fu_device_remove_private_flag(FU_DEVICE(self), FU_FOCAL_MOC_DEVICE_FLAG_LEGACY_TRAILER);
+	fu_device_set_firmware_gtype(FU_DEVICE(self), FU_TYPE_FOCAL_MOC_FIRMWARE);
+	fu_device_set_firmware_size_max(FU_DEVICE(self), FU_FOCAL_MOC_FIRMWARE_SIZE_MAX);
+	fu_device_set_install_duration(FU_DEVICE(self),
+				       FU_FOCAL_MOC_SIGNED_DEVICE_INSTALL_DURATION);
+}
+
+static void
+fu_focal_moc_signed_device_finalize(GObject *object)
+{
+	FuFocalMocSignedDevice *self = FU_FOCAL_MOC_SIGNED_DEVICE(object);
+
+	fu_focal_moc_transport_free(self->transport);
+	G_OBJECT_CLASS(fu_focal_moc_signed_device_parent_class)->finalize(object);
+}
+
+static void
+fu_focal_moc_signed_device_class_init(FuFocalMocSignedDeviceClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	FuFocalMocDeviceClass *moc_class = FU_FOCAL_MOC_DEVICE_CLASS(klass);
+	object_class->finalize = fu_focal_moc_signed_device_finalize;
+	device_class->to_string = fu_focal_moc_signed_device_to_string;
+	device_class->setup = fu_focal_moc_signed_device_setup;
+	device_class->close = fu_focal_moc_signed_device_close;
+	moc_class->command = fu_focal_moc_signed_device_command;
+	moc_class->build_soh = fu_focal_moc_signed_device_build_soh;
+	moc_class->build_data = fu_focal_moc_signed_device_build_data;
+	moc_class->get_firmware_stream = fu_focal_moc_signed_device_get_firmware_stream;
+	moc_class->ensure_bootloader_layout = fu_focal_moc_signed_device_ensure_bootloader_layout;
+	fu_device_register_private_flag(device_class, FU_FOCAL_MOC_SIGNED_DEVICE_FLAG_IS_IAP);
+}

--- a/plugins/focal-moc/fu-focal-moc-signed-device.h
+++ b/plugins/focal-moc/fu-focal-moc-signed-device.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2026 FocalTech Systems Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include "fu-focal-moc-device.h"
+
+#define FU_TYPE_FOCAL_MOC_SIGNED_DEVICE (fu_focal_moc_signed_device_get_type())
+G_DECLARE_FINAL_TYPE(FuFocalMocSignedDevice,
+		     fu_focal_moc_signed_device,
+		     FU,
+		     FOCAL_MOC_SIGNED_DEVICE,
+		     FuFocalMocDevice)

--- a/plugins/focal-moc/fu-focal-moc-test-device.c
+++ b/plugins/focal-moc/fu-focal-moc-test-device.c
@@ -1,0 +1,401 @@
+/*
+ * Copyright 2026 FocalTech Systems Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-focal-moc-common.h"
+#include "fu-focal-moc-struct.h"
+#include "fu-focal-moc-test-device.h"
+
+#ifdef FU_FOCAL_MOC_TEST_HAVE_ECDH
+static void
+fu_focal_moc_test_device_hmac(const guint8 *key, GByteArray *input, guint8 *out, gsize out_sz)
+{
+	gsize digest_sz = 32;
+	guint8 digest[32] = {0};
+	g_autoptr(GHmac) hmac = g_hmac_new(G_CHECKSUM_SHA256, key, 32);
+
+	g_hmac_update(hmac, input->data, input->len);
+	g_hmac_get_digest(hmac, digest, &digest_sz);
+	g_assert_cmpuint(digest_sz, ==, sizeof(digest));
+	g_assert_cmpuint(out_sz, <=, sizeof(digest));
+	g_assert_true(fu_memcpy_safe(out, out_sz, 0, digest, sizeof(digest), 0, out_sz, NULL));
+}
+
+static void
+fu_focal_moc_test_device_kc_tag(FuFocalMocTestDevice *self,
+				const gchar *label,
+				const guint8 *key_mac,
+				guint8 *tag)
+{
+	g_autoptr(GByteArray) input = g_byte_array_new();
+
+	g_byte_array_append(input, (const guint8 *)label, strlen(label));
+	g_byte_array_append(input, self->pk_host, sizeof(self->pk_host));
+	g_byte_array_append(input, self->pk_device, sizeof(self->pk_device));
+	fu_focal_moc_test_device_hmac(key_mac, input, tag, 16);
+}
+
+static void
+fu_focal_moc_test_device_derive_keys(FuFocalMocTestDevice *self, const guint8 *shared_secret)
+{
+	const gchar *labels[] = {
+	    "AES_KEY_D2M",
+	    "MAC_KEY_D2M",
+	    "IV__KEY_D2M",
+	    "AES_KEY_M2D",
+	    "MAC_KEY_M2D",
+	    "IV__KEY_M2D",
+	};
+	guint8 *keys[] = {
+	    self->key_aes_d2m,
+	    self->key_mac_d2m,
+	    self->key_iv_d2m,
+	    self->key_aes_m2d,
+	    self->key_mac_m2d,
+	    self->key_iv_m2d,
+	};
+	guint8 context[130] = {0};
+	guint8 transcript[32] = {0};
+	g_autoptr(GByteArray) info = g_byte_array_new();
+
+	g_byte_array_append(info,
+			    (const guint8 *)"SDCPv4-Transport-v1",
+			    strlen("SDCPv4-Transport-v1"));
+	fu_focal_moc_test_device_hmac(shared_secret, info, transcript, sizeof(transcript));
+	g_assert_true(fu_memcpy_safe(context,
+				     sizeof(context),
+				     0,
+				     self->pk_host,
+				     sizeof(self->pk_host),
+				     0,
+				     sizeof(self->pk_host),
+				     NULL));
+	g_assert_true(fu_memcpy_safe(context,
+				     sizeof(context),
+				     sizeof(self->pk_host),
+				     self->pk_device,
+				     sizeof(self->pk_device),
+				     0,
+				     sizeof(self->pk_device),
+				     NULL));
+	for (guint i = 0; i < G_N_ELEMENTS(labels); i++) {
+		g_autoptr(GError) error = NULL;
+
+		g_assert_true(fu_focal_moc_transport_kdf_expand(transcript,
+								sizeof(transcript),
+								labels[i],
+								context,
+								sizeof(context),
+								keys[i],
+								32,
+								&error));
+		g_assert_no_error(error);
+	}
+}
+
+static void
+fu_focal_moc_test_device_handle_key_exchange(FuFocalMocTestDevice *self, GByteArray *data)
+{
+	gnutls_datum_t secret = {0};
+	gnutls_datum_t x = {0};
+	gnutls_datum_t y = {0};
+	gnutls_datum_t peer_x = {.data = self->pk_host + 1, .size = 32};
+	gnutls_datum_t peer_y = {.data = self->pk_host + 33, .size = 32};
+	gnutls_ecc_curve_t curve = GNUTLS_ECC_CURVE_INVALID;
+	gnutls_privkey_t private_key = NULL;
+	gnutls_pubkey_t public_key = NULL;
+	gnutls_pubkey_t peer_key = NULL;
+	guint8 shared_secret[32] = {0};
+	g_autoptr(GByteArray) response = NULL;
+	g_autoptr(GError) error = NULL;
+
+	g_assert_cmpuint(data->len, ==, sizeof(self->pk_host));
+	g_assert_cmphex(data->data[0], ==, 0x04);
+	g_assert_true(fu_memcpy_safe(self->pk_host,
+				     sizeof(self->pk_host),
+				     0,
+				     data->data,
+				     data->len,
+				     0,
+				     data->len,
+				     NULL));
+	g_assert_cmpint(gnutls_privkey_init(&private_key), ==, 0);
+	g_assert_cmpint(gnutls_privkey_generate(private_key,
+						GNUTLS_PK_ECDSA,
+						GNUTLS_CURVE_TO_BITS(GNUTLS_ECC_CURVE_SECP256R1),
+						0),
+			==,
+			0);
+	g_assert_cmpint(gnutls_pubkey_init(&public_key), ==, 0);
+	g_assert_cmpint(gnutls_pubkey_import_privkey(public_key, private_key, 0, 0), ==, 0);
+	g_assert_cmpint(
+	    gnutls_pubkey_export_ecc_raw2(public_key, &curve, &x, &y, GNUTLS_EXPORT_FLAG_NO_LZ),
+	    ==,
+	    0);
+	g_assert_cmpint(curve, ==, GNUTLS_ECC_CURVE_SECP256R1);
+	g_assert_cmpuint(x.size, <=, 32);
+	g_assert_cmpuint(y.size, <=, 32);
+	memset(self->pk_device, 0, sizeof(self->pk_device));
+	self->pk_device[0] = 0x04;
+	g_assert_true(fu_memcpy_safe(self->pk_device,
+				     sizeof(self->pk_device),
+				     1 + 32 - x.size,
+				     x.data,
+				     x.size,
+				     0,
+				     x.size,
+				     NULL));
+	g_assert_true(fu_memcpy_safe(self->pk_device,
+				     sizeof(self->pk_device),
+				     1 + 64 - y.size,
+				     y.data,
+				     y.size,
+				     0,
+				     y.size,
+				     NULL));
+	g_assert_cmpint(gnutls_pubkey_init(&peer_key), ==, 0);
+	g_assert_cmpint(
+	    gnutls_pubkey_import_ecc_raw(peer_key, GNUTLS_ECC_CURVE_SECP256R1, &peer_x, &peer_y),
+	    ==,
+	    0);
+	g_assert_cmpint(gnutls_privkey_derive_secret(private_key, peer_key, NULL, &secret, 0),
+			==,
+			0);
+	g_assert_cmpuint(secret.size, >, 0);
+	g_assert_cmpuint(secret.size, <=, sizeof(shared_secret));
+	g_assert_true(fu_memcpy_safe(shared_secret,
+				     sizeof(shared_secret),
+				     sizeof(shared_secret) - secret.size,
+				     secret.data,
+				     secret.size,
+				     0,
+				     secret.size,
+				     NULL));
+	fu_focal_moc_test_device_derive_keys(self, shared_secret);
+	self->d2m_sequence = 0;
+	self->m2d_sequence = 0;
+	self->tx_message_id = 0;
+	response = fu_focal_moc_packet_new(FU_FOCAL_MOC_STATUS_OK,
+					   self->pk_device,
+					   sizeof(self->pk_device),
+					   &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(response);
+	g_ptr_array_add(self->rx_queue, g_steal_pointer(&response));
+	gnutls_free(secret.data);
+	gnutls_free(x.data);
+	gnutls_free(y.data);
+	gnutls_pubkey_deinit(peer_key);
+	gnutls_pubkey_deinit(public_key);
+	gnutls_privkey_deinit(private_key);
+}
+
+static void
+fu_focal_moc_test_device_handle_cipher(FuFocalMocTestDevice *self, GByteArray *frame)
+{
+	const guint8 *buf;
+	gsize bufsz;
+	g_autoptr(FuSecureBytes) plaintext = NULL;
+	g_autoptr(GError) error = NULL;
+
+	plaintext = fu_focal_moc_transport_cipher_frame_parse(self->key_aes_d2m,
+							      self->key_mac_d2m,
+							      self->key_iv_d2m,
+							      self->d2m_sequence,
+							      frame,
+							      &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(plaintext);
+	buf = fu_secure_bytes_get_data(plaintext);
+	bufsz = fu_secure_bytes_get_size(plaintext);
+	if (self->d2m_sequence == 0) {
+		guint8 reply[17] = {0};
+		guint8 tag[16] = {0};
+		g_autoptr(GByteArray) response = NULL;
+
+		g_assert_cmpuint(bufsz, ==, 17);
+		g_assert_cmphex(buf[0], ==, FU_FOCAL_MOC_CMD_TRANSPORT_KEY_CONFIRM);
+		fu_focal_moc_test_device_kc_tag(self, "kc_driver", self->key_mac_d2m, tag);
+		g_assert_cmpmem(buf + 1, 16, tag, sizeof(tag));
+		reply[0] = FU_FOCAL_MOC_STATUS_OK;
+		fu_focal_moc_test_device_kc_tag(self, "kc_mcu", self->key_mac_m2d, reply + 1);
+		response = fu_focal_moc_transport_cipher_frame_new(self->key_aes_m2d,
+								   self->key_mac_m2d,
+								   self->key_iv_m2d,
+								   self->m2d_sequence++,
+								   reply,
+								   sizeof(reply),
+								   &error);
+		g_assert_no_error(error);
+		g_assert_nonnull(response);
+		g_ptr_array_add(self->rx_queue, g_steal_pointer(&response));
+	} else if (self->fault == FU_FOCAL_MOC_TEST_FAULT_SHORT) {
+		const guint8 short_reply[3] = {0};
+		g_autoptr(GByteArray) response = NULL;
+
+		response = fu_focal_moc_transport_cipher_frame_new(self->key_aes_m2d,
+								   self->key_mac_m2d,
+								   self->key_iv_m2d,
+								   self->m2d_sequence++,
+								   short_reply,
+								   sizeof(short_reply),
+								   &error);
+		g_assert_no_error(error);
+		g_assert_nonnull(response);
+		g_ptr_array_add(self->rx_queue, g_steal_pointer(&response));
+		self->tx_message_id++;
+	} else {
+		gsize offset = 0;
+		guint total;
+
+		g_assert_cmpuint(bufsz, >=, 5);
+		g_byte_array_set_size(self->last_request, 0);
+		g_byte_array_append(self->last_request, buf, bufsz);
+		/* the firmware slices response data into 1013-byte fragments */
+		total = MAX(1u, (guint)((self->response_payload->len + 1012) / 1013));
+		for (guint i = 0; i < total; i++) {
+			gsize chunk_sz = MIN((gsize)1013, self->response_payload->len - offset);
+			guint8 header[5] = {i + 1 < total ? 1 : 0,
+					    self->tx_message_id,
+					    (guint8)i,
+					    (guint8)total,
+					    self->response_status};
+			g_autoptr(GByteArray) reply = g_byte_array_new();
+			g_autoptr(GByteArray) response = NULL;
+
+			if (self->fault == FU_FOCAL_MOC_TEST_FAULT_TRUNCATED && i == 1)
+				break;
+			if (self->fault == FU_FOCAL_MOC_TEST_FAULT_FIRST_INDEX && i == 0)
+				header[2] = 1;
+			if (self->fault == FU_FOCAL_MOC_TEST_FAULT_FIRST_TOTAL_ZERO && i == 0)
+				header[3] = 0;
+			if (self->fault == FU_FOCAL_MOC_TEST_FAULT_FIRST_MORE && i == 0)
+				header[0] ^= 1;
+			/* every fragment carries the same wrong ID, so only the
+			 * expected-ID check can reject it */
+			if (self->fault == FU_FOCAL_MOC_TEST_FAULT_FIRST_MESSAGE_ID)
+				header[1]++;
+			if (self->fault == FU_FOCAL_MOC_TEST_FAULT_MESSAGE_ID && i == 1)
+				header[1]++;
+			if (self->fault == FU_FOCAL_MOC_TEST_FAULT_TOTAL && i == 1)
+				header[3]++;
+			if (self->fault == FU_FOCAL_MOC_TEST_FAULT_INDEX && i == 1)
+				header[2]++;
+			if (self->fault == FU_FOCAL_MOC_TEST_FAULT_MORE && i == 1)
+				header[0] ^= 1;
+			if (self->fault == FU_FOCAL_MOC_TEST_FAULT_STATUS && i == 1)
+				header[4] ^= 1;
+			g_byte_array_append(reply, header, sizeof(header));
+			g_byte_array_append(reply, self->response_payload->data + offset, chunk_sz);
+			offset += chunk_sz;
+			response = fu_focal_moc_transport_cipher_frame_new(self->key_aes_m2d,
+									   self->key_mac_m2d,
+									   self->key_iv_m2d,
+									   self->m2d_sequence++,
+									   reply->data,
+									   reply->len,
+									   &error);
+			g_assert_no_error(error);
+			g_assert_nonnull(response);
+			if (self->fault == FU_FOCAL_MOC_TEST_FAULT_CIPHER_BCC && i == 1)
+				response->data[response->len - 1] ^= 1;
+			g_ptr_array_add(self->rx_queue, g_steal_pointer(&response));
+		}
+		self->tx_message_id++;
+	}
+	self->d2m_sequence++;
+}
+
+static gboolean
+fu_focal_moc_test_device_write(FuFocalMocTransportImpl *impl,
+			       const guint8 *buf,
+			       gsize bufsz,
+			       guint timeout_ms,
+			       GError **error)
+{
+	FuFocalMocTestDevice *self = FU_FOCAL_MOC_TEST_DEVICE(impl);
+	guint8 command = 0;
+	g_autoptr(GByteArray) data = NULL;
+	g_autoptr(GByteArray) frame = g_byte_array_new();
+
+	g_assert_cmpuint(bufsz, >, 0);
+	if (self->fault == FU_FOCAL_MOC_TEST_FAULT_SEND) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_WRITE, "send fault");
+		return FALSE;
+	}
+	if (buf[0] == 0x02) {
+		data = fu_focal_moc_packet_parse(buf, bufsz, FALSE, &command, error);
+		g_assert_nonnull(data);
+		g_assert_cmphex(command, ==, FU_FOCAL_MOC_CMD_TRANSPORT_KEY_EXCHANGE);
+		fu_focal_moc_test_device_handle_key_exchange(self, data);
+		return TRUE;
+	}
+	g_byte_array_append(frame, buf, bufsz);
+	fu_focal_moc_test_device_handle_cipher(self, frame);
+	return TRUE;
+}
+
+static GByteArray *
+fu_focal_moc_test_device_read(FuFocalMocTransportImpl *impl, guint timeout_ms, GError **error)
+{
+	FuFocalMocTestDevice *self = FU_FOCAL_MOC_TEST_DEVICE(impl);
+	GByteArray *frame;
+	g_autoptr(GByteArray) buf = g_byte_array_new();
+
+	if (self->rx_queue->len == 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_TIMED_OUT,
+				    "no response queued");
+		return NULL;
+	}
+	frame = g_ptr_array_index(self->rx_queue, 0);
+	g_byte_array_append(buf, frame->data, frame->len);
+	g_ptr_array_remove_index(self->rx_queue, 0);
+	return g_steal_pointer(&buf);
+}
+
+static void
+fu_focal_moc_test_device_transport_impl_iface_init(FuFocalMocTransportImplInterface *iface)
+{
+	iface->write = fu_focal_moc_test_device_write;
+	iface->read = fu_focal_moc_test_device_read;
+}
+
+G_DEFINE_TYPE_WITH_CODE(FuFocalMocTestDevice,
+			fu_focal_moc_test_device,
+			G_TYPE_OBJECT,
+			G_IMPLEMENT_INTERFACE(FU_TYPE_FOCAL_MOC_TRANSPORT_IMPL,
+					      fu_focal_moc_test_device_transport_impl_iface_init))
+
+static void
+fu_focal_moc_test_device_init(FuFocalMocTestDevice *self)
+{
+	self->rx_queue = g_ptr_array_new_with_free_func((GDestroyNotify)g_byte_array_unref);
+	self->last_request = g_byte_array_new();
+	self->response_payload = g_byte_array_new();
+}
+
+static void
+fu_focal_moc_test_device_finalize(GObject *object)
+{
+	FuFocalMocTestDevice *self = FU_FOCAL_MOC_TEST_DEVICE(object);
+
+	g_ptr_array_unref(self->rx_queue);
+	g_byte_array_unref(self->last_request);
+	g_byte_array_unref(self->response_payload);
+	G_OBJECT_CLASS(fu_focal_moc_test_device_parent_class)->finalize(object);
+}
+
+static void
+fu_focal_moc_test_device_class_init(FuFocalMocTestDeviceClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+
+	object_class->finalize = fu_focal_moc_test_device_finalize;
+}
+#endif

--- a/plugins/focal-moc/fu-focal-moc-test-device.h
+++ b/plugins/focal-moc/fu-focal-moc-test-device.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 FocalTech Systems Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#ifdef HAVE_GNUTLS
+#include <gnutls/abstract.h>
+#endif
+
+#include "fu-focal-moc-transport.h"
+
+#if defined(HAVE_GNUTLS) && GNUTLS_VERSION_NUMBER >= 0x030802
+#define FU_FOCAL_MOC_TEST_HAVE_ECDH
+#endif
+
+#ifdef FU_FOCAL_MOC_TEST_HAVE_ECDH
+typedef enum {
+	FU_FOCAL_MOC_TEST_FAULT_NONE,
+	FU_FOCAL_MOC_TEST_FAULT_FIRST_INDEX,
+	FU_FOCAL_MOC_TEST_FAULT_FIRST_TOTAL_ZERO,
+	FU_FOCAL_MOC_TEST_FAULT_FIRST_MORE,
+	FU_FOCAL_MOC_TEST_FAULT_FIRST_MESSAGE_ID,
+	FU_FOCAL_MOC_TEST_FAULT_MESSAGE_ID,
+	FU_FOCAL_MOC_TEST_FAULT_TOTAL,
+	FU_FOCAL_MOC_TEST_FAULT_INDEX,
+	FU_FOCAL_MOC_TEST_FAULT_MORE,
+	FU_FOCAL_MOC_TEST_FAULT_STATUS,
+	FU_FOCAL_MOC_TEST_FAULT_SHORT,
+	FU_FOCAL_MOC_TEST_FAULT_TRUNCATED,
+	FU_FOCAL_MOC_TEST_FAULT_CIPHER_BCC,
+	FU_FOCAL_MOC_TEST_FAULT_SEND,
+} FuFocalMocTestFault;
+
+#define FU_TYPE_FOCAL_MOC_TEST_DEVICE (fu_focal_moc_test_device_get_type())
+G_DECLARE_FINAL_TYPE(FuFocalMocTestDevice,
+		     fu_focal_moc_test_device,
+		     FU,
+		     FOCAL_MOC_TEST_DEVICE,
+		     GObject)
+
+/* a software peer for the TransportSec handshake, with injectable faults */
+struct _FuFocalMocTestDevice {
+	GObject parent_instance;
+	GPtrArray *rx_queue;
+	GByteArray *last_request;
+	guint8 pk_host[65];
+	guint8 pk_device[65];
+	guint8 key_aes_d2m[32];
+	guint8 key_mac_d2m[32];
+	guint8 key_iv_d2m[32];
+	guint8 key_aes_m2d[32];
+	guint8 key_mac_m2d[32];
+	guint8 key_iv_m2d[32];
+	guint32 d2m_sequence;
+	guint32 m2d_sequence;
+	guint8 tx_message_id;
+	guint8 response_status;
+	FuFocalMocTestFault fault;
+	GByteArray *response_payload;
+};
+#endif

--- a/plugins/focal-moc/fu-focal-moc-transport-impl.c
+++ b/plugins/focal-moc/fu-focal-moc-transport-impl.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 FocalTech Systems Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-focal-moc-transport-impl.h"
+
+G_DEFINE_INTERFACE(FuFocalMocTransportImpl, fu_focal_moc_transport_impl, G_TYPE_OBJECT)
+
+static void
+fu_focal_moc_transport_impl_default_init(FuFocalMocTransportImplInterface *iface)
+{
+}
+
+gboolean
+fu_focal_moc_transport_impl_write(FuFocalMocTransportImpl *self,
+				  const guint8 *buf,
+				  gsize bufsz,
+				  guint timeout_ms,
+				  GError **error)
+{
+	FuFocalMocTransportImplInterface *iface;
+
+	g_return_val_if_fail(FU_IS_FOCAL_MOC_TRANSPORT_IMPL(self), FALSE);
+
+	iface = FU_FOCAL_MOC_TRANSPORT_IMPL_GET_IFACE(self);
+	if (iface->write == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "iface->write not implemented");
+		return FALSE;
+	}
+	return (*iface->write)(self, buf, bufsz, timeout_ms, error);
+}
+
+GByteArray *
+fu_focal_moc_transport_impl_read(FuFocalMocTransportImpl *self, guint timeout_ms, GError **error)
+{
+	FuFocalMocTransportImplInterface *iface;
+
+	g_return_val_if_fail(FU_IS_FOCAL_MOC_TRANSPORT_IMPL(self), NULL);
+
+	iface = FU_FOCAL_MOC_TRANSPORT_IMPL_GET_IFACE(self);
+	if (iface->read == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "iface->read not implemented");
+		return NULL;
+	}
+	return (*iface->read)(self, timeout_ms, error);
+}

--- a/plugins/focal-moc/fu-focal-moc-transport-impl.h
+++ b/plugins/focal-moc/fu-focal-moc-transport-impl.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 FocalTech Systems Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_FOCAL_MOC_TRANSPORT_IMPL (fu_focal_moc_transport_impl_get_type())
+G_DECLARE_INTERFACE(FuFocalMocTransportImpl,
+		    fu_focal_moc_transport_impl,
+		    FU,
+		    FOCAL_MOC_TRANSPORT_IMPL,
+		    GObject)
+
+struct _FuFocalMocTransportImplInterface {
+	GTypeInterface g_iface;
+	gboolean (*write)(FuFocalMocTransportImpl *self,
+			  const guint8 *buf,
+			  gsize bufsz,
+			  guint timeout_ms,
+			  GError **error) G_GNUC_NON_NULL(1);
+	GByteArray *(*read)(FuFocalMocTransportImpl *self,
+			    guint timeout_ms,
+			    GError **error)G_GNUC_NON_NULL(1);
+};
+
+gboolean
+fu_focal_moc_transport_impl_write(FuFocalMocTransportImpl *self,
+				  const guint8 *buf,
+				  gsize bufsz,
+				  guint timeout_ms,
+				  GError **error) G_GNUC_NON_NULL(1);
+GByteArray *
+fu_focal_moc_transport_impl_read(FuFocalMocTransportImpl *self, guint timeout_ms, GError **error)
+    G_GNUC_NON_NULL(1) G_GNUC_WARN_UNUSED_RESULT;

--- a/plugins/focal-moc/fu-focal-moc-transport.c
+++ b/plugins/focal-moc/fu-focal-moc-transport.c
@@ -1,0 +1,1175 @@
+/*
+ * Copyright 2026 FocalTech Systems Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#ifdef HAVE_GNUTLS
+#include <gnutls/abstract.h>
+#include <gnutls/crypto.h>
+#endif
+
+#include "fu-focal-moc-common.h"
+#include "fu-focal-moc-struct.h"
+#include "fu-focal-moc-transport.h"
+
+#if defined(HAVE_GNUTLS) && GNUTLS_VERSION_NUMBER >= 0x030802
+#define FU_FOCAL_MOC_TRANSPORT_HAVE_ECDH
+#endif
+
+#define FU_FOCAL_MOC_TRANSPORT_PUBLIC_KEY_SIZE	 65
+#define FU_FOCAL_MOC_TRANSPORT_COORDINATE_SIZE	 32
+#define FU_FOCAL_MOC_TRANSPORT_KEY_SIZE		 32
+#define FU_FOCAL_MOC_TRANSPORT_MAC_SIZE		 16
+#define FU_FOCAL_MOC_TRANSPORT_KC_SIZE		 16
+#define FU_FOCAL_MOC_TRANSPORT_MAX_DATA_SIZE	 1013
+#define FU_FOCAL_MOC_TRANSPORT_REKEY_THRESHOLD	 0xFFFF0000
+#define FU_FOCAL_MOC_TRANSPORT_MAC_FAILURE_LIMIT 16
+#define FU_FOCAL_MOC_TRANSPORT_KEX_TIMEOUT_MS	 2000
+#define FU_FOCAL_MOC_TRANSPORT_KC_TIMEOUT_MS	 3000
+#define FU_FOCAL_MOC_TRANSPORT_DRAIN_TIMEOUT_MS	 50
+#define FU_FOCAL_MOC_TRANSPORT_DRAIN_LIMIT	 8
+
+#define FU_FOCAL_MOC_TRANSPORT_EXTRACT_INFO "SDCPv4-Transport-v1"
+
+struct _FuFocalMocTransport {
+	FuFocalMocTransportImpl *impl; /* no ref; the impl owns the transport */
+	FuFocalMocTransportState state;
+	FuSecureBytes *fixed_host_key;
+	guint32 tx_sequence;
+	guint32 rx_sequence;
+	guint8 tx_message_id;
+	guint8 mac_failures;
+	guint8 public_key_host[FU_FOCAL_MOC_TRANSPORT_PUBLIC_KEY_SIZE];
+	guint8 public_key_device[FU_FOCAL_MOC_TRANSPORT_PUBLIC_KEY_SIZE];
+	FuSecureBytes *key_aes_d2m;
+	FuSecureBytes *key_mac_d2m;
+	FuSecureBytes *key_iv_d2m;
+	FuSecureBytes *key_aes_m2d;
+	FuSecureBytes *key_mac_m2d;
+	FuSecureBytes *key_iv_m2d;
+};
+
+static gboolean
+fu_focal_moc_transport_hmac(const guint8 *key,
+			    gsize key_sz,
+			    const guint8 *buf,
+			    gsize bufsz,
+			    guint8 *digest,
+			    gsize digest_sz,
+			    GError **error)
+{
+	gsize actual_sz = 32;
+	guint8 actual[32] = {0};
+	g_autoptr(FuSecureBytes) actual_secure = NULL;
+	g_autoptr(GHmac) hmac = NULL;
+
+	if (digest_sz > sizeof(actual)) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "HMAC output too large: 0x%zx",
+			    digest_sz);
+		return FALSE;
+	}
+	hmac = g_hmac_new(G_CHECKSUM_SHA256, key, key_sz);
+	g_hmac_update(hmac, buf, bufsz);
+	g_hmac_get_digest(hmac, actual, &actual_sz);
+	actual_secure = fu_secure_bytes_new(actual, sizeof(actual), NULL);
+	if (actual_sz != sizeof(actual)) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "HMAC output invalid: 0x%zx",
+			    actual_sz);
+		return FALSE;
+	}
+	return fu_memcpy_safe(digest, digest_sz, 0, actual, sizeof(actual), 0, digest_sz, error);
+}
+
+gboolean
+fu_focal_moc_transport_kdf_expand(const guint8 *prk,
+				  gsize prk_sz,
+				  const gchar *label,
+				  const guint8 *context,
+				  gsize context_sz,
+				  guint8 *key,
+				  gsize key_sz,
+				  GError **error)
+{
+	const guint8 counter = 0x01;
+	const guint8 separator = 0x00;
+	const guint8 output_bits[] = {0x00, 0x00, 0x01, 0x00};
+	g_autoptr(GByteArray) input = g_byte_array_new();
+
+	g_return_val_if_fail(prk != NULL, FALSE);
+	g_return_val_if_fail(label != NULL, FALSE);
+	g_return_val_if_fail(context != NULL, FALSE);
+	g_return_val_if_fail(key != NULL, FALSE);
+
+	if (key_sz != FU_FOCAL_MOC_TRANSPORT_KEY_SIZE) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "KDF output size invalid: 0x%zx",
+			    key_sz);
+		return FALSE;
+	}
+	g_byte_array_append(input, &counter, sizeof(counter));
+	g_byte_array_append(input, (const guint8 *)label, strlen(label));
+	g_byte_array_append(input, &separator, sizeof(separator));
+	g_byte_array_append(input, context, context_sz);
+	g_byte_array_append(input, output_bits, sizeof(output_bits));
+	return fu_focal_moc_transport_hmac(prk,
+					   prk_sz,
+					   input->data,
+					   input->len,
+					   key,
+					   key_sz,
+					   error);
+}
+
+#ifdef FU_FOCAL_MOC_TRANSPORT_HAVE_ECDH
+static gboolean
+fu_focal_moc_transport_gnutls_error(gint rc, const gchar *context, GError **error)
+{
+	if (rc >= GNUTLS_E_SUCCESS)
+		return TRUE;
+	g_set_error(error,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_AUTH_FAILED,
+		    "%s: %s [%i]",
+		    context,
+		    gnutls_strerror(rc),
+		    rc);
+	return FALSE;
+}
+
+static void
+fu_focal_moc_transport_datum_free(gnutls_datum_t *datum)
+{
+	gnutls_free(datum->data);
+}
+
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(gnutls_datum_t, fu_focal_moc_transport_datum_free)
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC(gnutls_privkey_t, gnutls_privkey_deinit, NULL)
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC(gnutls_pubkey_t, gnutls_pubkey_deinit, NULL)
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC(gnutls_cipher_hd_t, gnutls_cipher_deinit, NULL)
+
+static FuSecureBytes *
+fu_focal_moc_transport_aes_ecb(const guint8 *key, const guint8 *input, GError **error)
+{
+	gint rc;
+	guint8 iv_buf[16] = {0};
+	g_autofree guint8 *output = g_malloc0(16);
+	g_auto(gnutls_cipher_hd_t) cipher = NULL;
+	g_autoptr(FuSecureBytes) block = NULL;
+	gnutls_datum_t iv = {.data = iv_buf, .size = sizeof(iv_buf)};
+	gnutls_datum_t key_datum = {
+	    .data = (guint8 *)key,
+	    .size = FU_FOCAL_MOC_TRANSPORT_KEY_SIZE,
+	};
+
+	rc = gnutls_cipher_init(&cipher, GNUTLS_CIPHER_AES_256_CBC, &key_datum, &iv);
+	if (!fu_focal_moc_transport_gnutls_error(rc, "failed to initialize AES", error))
+		return NULL;
+	rc = gnutls_cipher_encrypt2(cipher, input, 16, output, 16);
+	block = fu_secure_bytes_new(g_steal_pointer(&output), 16, g_free);
+	if (!fu_focal_moc_transport_gnutls_error(rc, "failed to encrypt AES block", error))
+		return NULL;
+	return g_steal_pointer(&block);
+}
+
+static FuSecureBytes *
+fu_focal_moc_transport_derive_iv_internal(const guint8 *key, guint32 sequence, GError **error)
+{
+	guint8 input[16] = {0};
+
+	fu_memwrite_uint32(input, sequence, G_BIG_ENDIAN);
+	return fu_focal_moc_transport_aes_ecb(key, input, error);
+}
+
+static void
+fu_focal_moc_transport_counter_increment(guint8 *counter)
+{
+	for (gint i = 15; i >= 0; i--) {
+		counter[i]++;
+		if (counter[i] != 0)
+			break;
+	}
+}
+
+static gboolean
+fu_focal_moc_transport_aes_ctr_internal(const guint8 *key,
+					const guint8 *iv,
+					const guint8 *input,
+					gsize input_sz,
+					guint8 *output,
+					GError **error)
+{
+	guint8 counter[16] = {0};
+
+	/* the counter is a nonce, not a secret */
+	if (!fu_memcpy_safe(counter,
+			    sizeof(counter),
+			    0,
+			    iv,
+			    sizeof(counter),
+			    0,
+			    sizeof(counter),
+			    error))
+		return FALSE;
+	for (gsize offset = 0; offset < input_sz; offset += 16) {
+		gsize block_sz = MIN((gsize)16, input_sz - offset);
+		const guint8 *stream_buf;
+		g_autoptr(FuSecureBytes) stream = NULL;
+
+		stream = fu_focal_moc_transport_aes_ecb(key, counter, error);
+		if (stream == NULL)
+			return FALSE;
+		stream_buf = fu_secure_bytes_get_data(stream);
+		for (gsize i = 0; i < block_sz; i++)
+			output[offset + i] = input[offset + i] ^ stream_buf[i];
+		fu_focal_moc_transport_counter_increment(counter);
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_focal_moc_transport_derive_keys(FuFocalMocTransport *self,
+				   FuSecureBytes *shared_secret,
+				   GError **error)
+{
+	const gchar *labels[] = {
+	    "AES_KEY_D2M",
+	    "MAC_KEY_D2M",
+	    "IV__KEY_D2M",
+	    "AES_KEY_M2D",
+	    "MAC_KEY_M2D",
+	    "IV__KEY_M2D",
+	};
+	FuSecureBytes **keys[] = {
+	    &self->key_aes_d2m,
+	    &self->key_mac_d2m,
+	    &self->key_iv_d2m,
+	    &self->key_aes_m2d,
+	    &self->key_mac_m2d,
+	    &self->key_iv_m2d,
+	};
+	guint8 transcript_secret[32] = {0};
+	g_autoptr(FuSecureBytes) transcript_secure = NULL;
+	g_autoptr(GByteArray) context = g_byte_array_new();
+
+	g_byte_array_append(context, self->public_key_host, sizeof(self->public_key_host));
+	g_byte_array_append(context, self->public_key_device, sizeof(self->public_key_device));
+	if (!fu_focal_moc_transport_hmac(fu_secure_bytes_get_data(shared_secret),
+					 fu_secure_bytes_get_size(shared_secret),
+					 (const guint8 *)FU_FOCAL_MOC_TRANSPORT_EXTRACT_INFO,
+					 strlen(FU_FOCAL_MOC_TRANSPORT_EXTRACT_INFO),
+					 transcript_secret,
+					 sizeof(transcript_secret),
+					 error))
+		return FALSE;
+	transcript_secure = fu_secure_bytes_new(transcript_secret, sizeof(transcript_secret), NULL);
+	for (guint i = 0; i < G_N_ELEMENTS(labels); i++) {
+		g_autofree guint8 *key = g_malloc0(FU_FOCAL_MOC_TRANSPORT_KEY_SIZE);
+
+		if (!fu_focal_moc_transport_kdf_expand(transcript_secret,
+						       sizeof(transcript_secret),
+						       labels[i],
+						       context->data,
+						       context->len,
+						       key,
+						       FU_FOCAL_MOC_TRANSPORT_KEY_SIZE,
+						       error))
+			return FALSE;
+		*keys[i] = fu_secure_bytes_new(g_steal_pointer(&key),
+					       FU_FOCAL_MOC_TRANSPORT_KEY_SIZE,
+					       g_free);
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static GByteArray *
+fu_focal_moc_transport_cipher_frame_new_internal(const guint8 *key_aes,
+						 const guint8 *key_mac,
+						 const guint8 *key_iv,
+						 guint32 sequence,
+						 const guint8 *plaintext,
+						 gsize plaintext_sz,
+						 GError **error)
+{
+	guint16 length;
+	guint8 bcc;
+	guint8 mac[FU_FOCAL_MOC_TRANSPORT_MAC_SIZE] = {0};
+	g_autofree guint8 *encrypted = NULL;
+	g_autoptr(FuSecureBytes) iv = NULL;
+	g_autoptr(FuStructFocalMocCipherHeader) st = NULL;
+
+	if (plaintext_sz == 0 ||
+	    plaintext_sz > G_MAXUINT16 - 4 - FU_FOCAL_MOC_TRANSPORT_MAC_SIZE - 1) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "cipher plaintext size invalid: 0x%zx",
+			    plaintext_sz);
+		return NULL;
+	}
+	iv = fu_focal_moc_transport_derive_iv_internal(key_iv, sequence, error);
+	if (iv == NULL)
+		return NULL;
+	encrypted = g_malloc0(plaintext_sz);
+	if (!fu_focal_moc_transport_aes_ctr_internal(key_aes,
+						     fu_secure_bytes_get_data(iv),
+						     plaintext,
+						     plaintext_sz,
+						     encrypted,
+						     error))
+		return NULL;
+	length = 4 + plaintext_sz + FU_FOCAL_MOC_TRANSPORT_MAC_SIZE + 1;
+	st = fu_struct_focal_moc_cipher_header_new();
+	fu_struct_focal_moc_cipher_header_set_length(st, length);
+	fu_struct_focal_moc_cipher_header_set_sequence(st, sequence);
+	g_byte_array_append(st->buf, encrypted, plaintext_sz);
+	if (!fu_focal_moc_transport_hmac(key_mac,
+					 FU_FOCAL_MOC_TRANSPORT_KEY_SIZE,
+					 st->buf->data,
+					 st->buf->len,
+					 mac,
+					 sizeof(mac),
+					 error))
+		return NULL;
+	g_byte_array_append(st->buf, mac, sizeof(mac));
+	bcc = fu_xor8(st->buf->data + 1, st->buf->len - 1);
+	g_byte_array_append(st->buf, &bcc, sizeof(bcc));
+
+	/* success */
+	return g_byte_array_ref(st->buf);
+}
+
+typedef enum {
+	FU_FOCAL_MOC_TRANSPORT_CIPHER_FAULT_NONE,
+	FU_FOCAL_MOC_TRANSPORT_CIPHER_FAULT_AUTH,
+	FU_FOCAL_MOC_TRANSPORT_CIPHER_FAULT_REKEY,
+} FuFocalMocTransportCipherFault;
+
+static FuSecureBytes *
+fu_focal_moc_transport_cipher_frame_decode(const guint8 *key_aes,
+					   const guint8 *key_mac,
+					   const guint8 *key_iv,
+					   guint32 expected_sequence,
+					   GByteArray *frame,
+					   FuFocalMocTransportCipherFault *fault,
+					   GError **error)
+{
+	gsize encrypted_sz;
+	gsize mac_offset;
+	guint16 length;
+	guint32 sequence;
+	gboolean ret;
+	guint8 bcc = 0;
+	guint8 bcc_actual = 0;
+	guint8 mac[FU_FOCAL_MOC_TRANSPORT_MAC_SIZE] = {0};
+	g_autofree guint8 *decrypted = NULL;
+	g_autoptr(FuSecureBytes) iv = NULL;
+	g_autoptr(FuSecureBytes) plaintext = NULL;
+	g_autoptr(FuStructFocalMocCipherHeader) st = NULL;
+
+	if (fault != NULL)
+		*fault = FU_FOCAL_MOC_TRANSPORT_CIPHER_FAULT_NONE;
+	st = fu_struct_focal_moc_cipher_header_parse(frame->data, frame->len, 0, error);
+	if (st == NULL)
+		return NULL;
+	length = fu_struct_focal_moc_cipher_header_get_length(st);
+	if (length < 4 + 1 + FU_FOCAL_MOC_TRANSPORT_MAC_SIZE + 1 ||
+	    frame->len != (gsize)length + 3) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "cipher frame size invalid: got=0x%x length=0x%x",
+			    frame->len,
+			    length);
+		return NULL;
+	}
+	if (!fu_xor8_safe(frame->data, frame->len, 0x1, frame->len - 2, &bcc, error))
+		return NULL;
+	if (!fu_memread_uint8_safe(frame->data, frame->len, frame->len - 1, &bcc_actual, error))
+		return NULL;
+	if (bcc != bcc_actual) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "cipher BCC mismatch: got=0x%02x expected=0x%02x",
+			    bcc_actual,
+			    bcc);
+		return NULL;
+	}
+	encrypted_sz = length - 4 - FU_FOCAL_MOC_TRANSPORT_MAC_SIZE - 1;
+	mac_offset = FU_STRUCT_FOCAL_MOC_CIPHER_HEADER_SIZE + encrypted_sz;
+	if (!fu_focal_moc_transport_hmac(key_mac,
+					 FU_FOCAL_MOC_TRANSPORT_KEY_SIZE,
+					 frame->data,
+					 mac_offset,
+					 mac,
+					 sizeof(mac),
+					 error))
+		return NULL;
+	if (gnutls_memcmp(mac, frame->data + mac_offset, sizeof(mac)) != 0) {
+		if (fault != NULL)
+			*fault = FU_FOCAL_MOC_TRANSPORT_CIPHER_FAULT_AUTH;
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_AUTH_FAILED,
+				    "cipher MAC mismatch");
+		return NULL;
+	}
+	sequence = fu_struct_focal_moc_cipher_header_get_sequence(st);
+	if (sequence != expected_sequence) {
+		if (fault != NULL)
+			*fault = FU_FOCAL_MOC_TRANSPORT_CIPHER_FAULT_AUTH;
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_AUTH_FAILED,
+			    "cipher sequence invalid: got=%u expected=%u",
+			    sequence,
+			    expected_sequence);
+		return NULL;
+	}
+	if (sequence >= FU_FOCAL_MOC_TRANSPORT_REKEY_THRESHOLD) {
+		if (fault != NULL)
+			*fault = FU_FOCAL_MOC_TRANSPORT_CIPHER_FAULT_REKEY;
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_AUTH_FAILED,
+			    "transport receive sequence reached rekey threshold: %u",
+			    sequence);
+		return NULL;
+	}
+	iv = fu_focal_moc_transport_derive_iv_internal(key_iv, sequence, error);
+	if (iv == NULL)
+		return NULL;
+	decrypted = g_malloc0(encrypted_sz);
+	ret = fu_focal_moc_transport_aes_ctr_internal(key_aes,
+						      fu_secure_bytes_get_data(iv),
+						      frame->data +
+							  FU_STRUCT_FOCAL_MOC_CIPHER_HEADER_SIZE,
+						      encrypted_sz,
+						      decrypted,
+						      error);
+	/* wrapped even on failure so a partial decrypt is still wiped */
+	plaintext = fu_secure_bytes_new(g_steal_pointer(&decrypted), encrypted_sz, g_free);
+	if (!ret)
+		return NULL;
+
+	/* success */
+	return g_steal_pointer(&plaintext);
+}
+
+static FuSecureBytes *
+fu_focal_moc_transport_cipher_frame_parse_internal(FuFocalMocTransport *self,
+						   GByteArray *frame,
+						   GError **error)
+{
+	FuFocalMocTransportCipherFault fault = FU_FOCAL_MOC_TRANSPORT_CIPHER_FAULT_NONE;
+	g_autoptr(FuSecureBytes) plaintext = NULL;
+
+	plaintext =
+	    fu_focal_moc_transport_cipher_frame_decode(fu_secure_bytes_get_data(self->key_aes_m2d),
+						       fu_secure_bytes_get_data(self->key_mac_m2d),
+						       fu_secure_bytes_get_data(self->key_iv_m2d),
+						       self->rx_sequence,
+						       frame,
+						       &fault,
+						       error);
+	if (plaintext == NULL) {
+		if (fault == FU_FOCAL_MOC_TRANSPORT_CIPHER_FAULT_AUTH) {
+			self->mac_failures = MIN((guint)self->mac_failures + 1,
+						 FU_FOCAL_MOC_TRANSPORT_MAC_FAILURE_LIMIT);
+			if (self->mac_failures == FU_FOCAL_MOC_TRANSPORT_MAC_FAILURE_LIMIT)
+				fu_focal_moc_transport_teardown(self);
+		} else if (fault == FU_FOCAL_MOC_TRANSPORT_CIPHER_FAULT_REKEY) {
+			fu_focal_moc_transport_teardown(self);
+		}
+		return NULL;
+	}
+	self->rx_sequence++;
+
+	/* success */
+	return g_steal_pointer(&plaintext);
+}
+
+static gboolean
+fu_focal_moc_transport_key_exchange(FuFocalMocTransport *self, GError **error)
+{
+	gint rc;
+	guint8 status = 0;
+	guint8 shared_secret[FU_FOCAL_MOC_TRANSPORT_KEY_SIZE] = {0};
+	gnutls_datum_t secret = {0};
+	g_auto(gnutls_datum_t) x = {0};
+	g_auto(gnutls_datum_t) y = {0};
+	gnutls_datum_t peer_x = {
+	    .data = self->public_key_device + 1,
+	    .size = FU_FOCAL_MOC_TRANSPORT_COORDINATE_SIZE,
+	};
+	gnutls_datum_t peer_y = {
+	    .data = self->public_key_device + 1 + FU_FOCAL_MOC_TRANSPORT_COORDINATE_SIZE,
+	    .size = FU_FOCAL_MOC_TRANSPORT_COORDINATE_SIZE,
+	};
+	gnutls_ecc_curve_t curve = GNUTLS_ECC_CURVE_INVALID;
+	g_auto(gnutls_privkey_t) private_key = NULL;
+	g_auto(gnutls_pubkey_t) public_key = NULL;
+	g_auto(gnutls_pubkey_t) peer_key = NULL;
+	g_autoptr(FuSecureBytes) secret_secure = NULL;
+	g_autoptr(FuSecureBytes) shared_secret_secure = NULL;
+	g_autoptr(GByteArray) data = NULL;
+	g_autoptr(GByteArray) request = NULL;
+	g_autoptr(GByteArray) response = NULL;
+
+	rc = gnutls_privkey_init(&private_key);
+	if (!fu_focal_moc_transport_gnutls_error(rc, "failed to initialize private key", error))
+		return FALSE;
+	/* an emulation reuses a well-known key; a live device gets a fresh one */
+	if (self->fixed_host_key != NULL) {
+		const guint coord = FU_FOCAL_MOC_TRANSPORT_COORDINATE_SIZE;
+		guint8 *host_key = (guint8 *)fu_secure_bytes_get_data(self->fixed_host_key);
+		gnutls_datum_t datum_x = {.data = host_key, .size = coord};
+		gnutls_datum_t datum_y = {.data = host_key + coord, .size = coord};
+		gnutls_datum_t datum_k = {.data = host_key + (2 * coord), .size = coord};
+
+		rc = gnutls_privkey_import_ecc_raw(private_key,
+						   GNUTLS_ECC_CURVE_SECP256R1,
+						   &datum_x,
+						   &datum_y,
+						   &datum_k);
+		if (!fu_focal_moc_transport_gnutls_error(rc,
+							 "failed to import fixed host key",
+							 error))
+			return FALSE;
+	} else {
+		rc = gnutls_privkey_generate(private_key,
+					     GNUTLS_PK_ECDSA,
+					     GNUTLS_CURVE_TO_BITS(GNUTLS_ECC_CURVE_SECP256R1),
+					     0);
+		if (!fu_focal_moc_transport_gnutls_error(rc, "failed to generate P-256 key", error))
+			return FALSE;
+	}
+	rc = gnutls_pubkey_init(&public_key);
+	if (!fu_focal_moc_transport_gnutls_error(rc, "failed to initialize public key", error))
+		return FALSE;
+	rc = gnutls_pubkey_import_privkey(public_key, private_key, 0, 0);
+	if (!fu_focal_moc_transport_gnutls_error(rc, "failed to import host public key", error))
+		return FALSE;
+	rc = gnutls_pubkey_export_ecc_raw2(public_key, &curve, &x, &y, GNUTLS_EXPORT_FLAG_NO_LZ);
+	if (!fu_focal_moc_transport_gnutls_error(rc, "failed to export host public key", error))
+		return FALSE;
+	if (curve != GNUTLS_ECC_CURVE_SECP256R1 || x.size == 0 || y.size == 0 ||
+	    x.size > FU_FOCAL_MOC_TRANSPORT_COORDINATE_SIZE ||
+	    y.size > FU_FOCAL_MOC_TRANSPORT_COORDINATE_SIZE) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_AUTH_FAILED,
+				    "host public key format invalid");
+		return FALSE;
+	}
+	/* a coordinate with leading zeros exports short, so the padding must start clean */
+	memset(self->public_key_host, 0, sizeof(self->public_key_host));
+	self->public_key_host[0] = 0x04;
+	if (!fu_memcpy_safe(self->public_key_host,
+			    sizeof(self->public_key_host),
+			    1 + FU_FOCAL_MOC_TRANSPORT_COORDINATE_SIZE - x.size,
+			    x.data,
+			    x.size,
+			    0,
+			    x.size,
+			    error) ||
+	    !fu_memcpy_safe(self->public_key_host,
+			    sizeof(self->public_key_host),
+			    1 + (2 * FU_FOCAL_MOC_TRANSPORT_COORDINATE_SIZE) - y.size,
+			    y.data,
+			    y.size,
+			    0,
+			    y.size,
+			    error))
+		return FALSE;
+	request = fu_focal_moc_packet_new(FU_FOCAL_MOC_CMD_TRANSPORT_KEY_EXCHANGE,
+					  self->public_key_host,
+					  sizeof(self->public_key_host),
+					  error);
+	if (request == NULL ||
+	    !fu_focal_moc_transport_impl_write(self->impl,
+					       request->data,
+					       request->len,
+					       FU_FOCAL_MOC_TRANSPORT_KEX_TIMEOUT_MS,
+					       error))
+		return FALSE;
+	response = fu_focal_moc_transport_impl_read(self->impl,
+						    FU_FOCAL_MOC_TRANSPORT_KEX_TIMEOUT_MS,
+						    error);
+	if (response == NULL)
+		return FALSE;
+	/* the key exchange reply is plaintext, so it carries the same one byte of
+	 * stale buffer past the declared frame that the runtime always appends */
+	data = fu_focal_moc_packet_parse(response->data, response->len, TRUE, &status, error);
+	if (data == NULL)
+		return FALSE;
+	if (status != FU_FOCAL_MOC_STATUS_OK ||
+	    data->len != FU_FOCAL_MOC_TRANSPORT_PUBLIC_KEY_SIZE || data->data[0] != 0x04) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_AUTH_FAILED,
+			    "key exchange response invalid: status=0x%02x size=0x%x",
+			    status,
+			    data->len);
+		return FALSE;
+	}
+	if (!fu_memcpy_safe(self->public_key_device,
+			    sizeof(self->public_key_device),
+			    0,
+			    data->data,
+			    data->len,
+			    0,
+			    data->len,
+			    error))
+		return FALSE;
+	rc = gnutls_pubkey_init(&peer_key);
+	if (!fu_focal_moc_transport_gnutls_error(rc, "failed to initialize peer key", error))
+		return FALSE;
+	rc = gnutls_pubkey_import_ecc_raw(peer_key, GNUTLS_ECC_CURVE_SECP256R1, &peer_x, &peer_y);
+	if (!fu_focal_moc_transport_gnutls_error(rc, "device public key invalid", error))
+		return FALSE;
+	rc = gnutls_privkey_derive_secret(private_key, peer_key, NULL, &secret, 0);
+	if (!fu_focal_moc_transport_gnutls_error(rc, "ECDH failed", error))
+		return FALSE;
+	secret_secure = fu_secure_bytes_new(secret.data, secret.size, gnutls_free);
+	if (secret.size == 0 || secret.size > sizeof(shared_secret)) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_AUTH_FAILED,
+			    "ECDH secret size invalid: 0x%x",
+			    secret.size);
+		return FALSE;
+	}
+	if (!fu_memcpy_safe(shared_secret,
+			    sizeof(shared_secret),
+			    sizeof(shared_secret) - secret.size,
+			    secret.data,
+			    secret.size,
+			    0,
+			    secret.size,
+			    error))
+		return FALSE;
+	shared_secret_secure = fu_secure_bytes_new(shared_secret, sizeof(shared_secret), NULL);
+	if (!fu_focal_moc_transport_derive_keys(self, shared_secret_secure, error))
+		return FALSE;
+	self->tx_sequence = 0;
+	self->rx_sequence = 0;
+	self->tx_message_id = 0;
+	self->state = FU_FOCAL_MOC_TRANSPORT_STATE_KC_PENDING;
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_focal_moc_transport_key_confirm(FuFocalMocTransport *self, GError **error)
+{
+	const guint8 label_driver[] = "kc_driver";
+	const guint8 label_device[] = "kc_mcu";
+	const guint8 *response_buf;
+	guint8 expected[FU_FOCAL_MOC_TRANSPORT_KC_SIZE] = {0};
+	guint8 plaintext[1 + FU_FOCAL_MOC_TRANSPORT_KC_SIZE] = {0};
+	g_autoptr(FuSecureBytes) expected_secure = NULL;
+	g_autoptr(FuSecureBytes) plaintext_secure = NULL;
+	g_autoptr(FuSecureBytes) response_plaintext = NULL;
+	g_autoptr(GByteArray) input = g_byte_array_new();
+	g_autoptr(GByteArray) frame = NULL;
+	g_autoptr(GByteArray) response = NULL;
+
+	g_byte_array_append(input, label_driver, sizeof(label_driver) - 1);
+	g_byte_array_append(input, self->public_key_host, sizeof(self->public_key_host));
+	g_byte_array_append(input, self->public_key_device, sizeof(self->public_key_device));
+	plaintext[0] = FU_FOCAL_MOC_CMD_TRANSPORT_KEY_CONFIRM;
+	if (!fu_focal_moc_transport_hmac(fu_secure_bytes_get_data(self->key_mac_d2m),
+					 FU_FOCAL_MOC_TRANSPORT_KEY_SIZE,
+					 input->data,
+					 input->len,
+					 plaintext + 1,
+					 FU_FOCAL_MOC_TRANSPORT_KC_SIZE,
+					 error))
+		return FALSE;
+	plaintext_secure = fu_secure_bytes_new(plaintext, sizeof(plaintext), NULL);
+	frame = fu_focal_moc_transport_cipher_frame_new_internal(
+	    fu_secure_bytes_get_data(self->key_aes_d2m),
+	    fu_secure_bytes_get_data(self->key_mac_d2m),
+	    fu_secure_bytes_get_data(self->key_iv_d2m),
+	    self->tx_sequence,
+	    plaintext,
+	    sizeof(plaintext),
+	    error);
+	if (frame == NULL)
+		return FALSE;
+	if (!fu_focal_moc_transport_impl_write(self->impl,
+					       frame->data,
+					       frame->len,
+					       FU_FOCAL_MOC_TRANSPORT_KC_TIMEOUT_MS,
+					       error))
+		return FALSE;
+	self->tx_sequence++;
+	response = fu_focal_moc_transport_impl_read(self->impl,
+						    FU_FOCAL_MOC_TRANSPORT_KC_TIMEOUT_MS,
+						    error);
+	if (response == NULL)
+		return FALSE;
+	response_plaintext =
+	    fu_focal_moc_transport_cipher_frame_parse_internal(self, response, error);
+	if (response_plaintext == NULL)
+		return FALSE;
+	response_buf = fu_secure_bytes_get_data(response_plaintext);
+	if (fu_secure_bytes_get_size(response_plaintext) != sizeof(plaintext) ||
+	    response_buf[0] != FU_FOCAL_MOC_STATUS_OK) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_AUTH_FAILED,
+			    "key confirmation response invalid: size=0x%zx",
+			    fu_secure_bytes_get_size(response_plaintext));
+		return FALSE;
+	}
+	g_byte_array_set_size(input, 0);
+	g_byte_array_append(input, label_device, sizeof(label_device) - 1);
+	g_byte_array_append(input, self->public_key_host, sizeof(self->public_key_host));
+	g_byte_array_append(input, self->public_key_device, sizeof(self->public_key_device));
+	if (!fu_focal_moc_transport_hmac(fu_secure_bytes_get_data(self->key_mac_m2d),
+					 FU_FOCAL_MOC_TRANSPORT_KEY_SIZE,
+					 input->data,
+					 input->len,
+					 expected,
+					 sizeof(expected),
+					 error))
+		return FALSE;
+	expected_secure = fu_secure_bytes_new(expected, sizeof(expected), NULL);
+	if (gnutls_memcmp(expected, response_buf + 1, sizeof(expected)) != 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_AUTH_FAILED,
+				    "device key confirmation mismatch");
+		return FALSE;
+	}
+	self->state = FU_FOCAL_MOC_TRANSPORT_STATE_ACTIVE;
+
+	/* success */
+	return TRUE;
+}
+
+static GByteArray *
+fu_focal_moc_transport_receive_message(FuFocalMocTransport *self,
+				       guint8 expected_message_id,
+				       guint timeout_ms,
+				       guint8 *status,
+				       GError **error)
+{
+	guint8 message_id = 0;
+	guint8 total = 0;
+	g_autoptr(GByteArray) data = g_byte_array_new();
+
+	for (guint chunk = 0;; chunk++) {
+		const guint8 *buf;
+		gsize bufsz;
+		guint8 more;
+		g_autoptr(FuStructFocalMocFragmentHeader) st_fragment = NULL;
+		g_autoptr(GByteArray) frame = NULL;
+		g_autoptr(FuSecureBytes) plaintext = NULL;
+
+		frame = fu_focal_moc_transport_impl_read(self->impl, timeout_ms, error);
+		if (frame == NULL)
+			return NULL;
+		plaintext = fu_focal_moc_transport_cipher_frame_parse_internal(self, frame, error);
+		if (plaintext == NULL)
+			return NULL;
+		buf = fu_secure_bytes_get_data(plaintext);
+		bufsz = fu_secure_bytes_get_size(plaintext);
+		if (bufsz < FU_STRUCT_FOCAL_MOC_FRAGMENT_HEADER_SIZE + 1) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "cipher response payload too short: 0x%zx",
+				    bufsz);
+			return NULL;
+		}
+		st_fragment = fu_struct_focal_moc_fragment_header_parse(buf, bufsz, 0, error);
+		if (st_fragment == NULL)
+			return NULL;
+		more = fu_struct_focal_moc_fragment_header_get_more(st_fragment);
+		if (chunk == 0) {
+			message_id =
+			    fu_struct_focal_moc_fragment_header_get_message_id(st_fragment);
+			total = fu_struct_focal_moc_fragment_header_get_total(st_fragment);
+			*status = buf[FU_STRUCT_FOCAL_MOC_FRAGMENT_HEADER_SIZE];
+			/* a late response to an earlier command must not be accepted as
+			 * the reply to this one */
+			if (message_id != expected_message_id || total == 0 ||
+			    fu_struct_focal_moc_fragment_header_get_index(st_fragment) != 0 ||
+			    more != (total > 1 ? 1 : 0)) {
+				g_set_error(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
+					    "first cipher fragment metadata invalid: "
+					    "message-id=%u expected=%u",
+					    message_id,
+					    expected_message_id);
+				return NULL;
+			}
+		} else if (fu_struct_focal_moc_fragment_header_get_message_id(st_fragment) !=
+			       message_id ||
+			   fu_struct_focal_moc_fragment_header_get_total(st_fragment) != total ||
+			   fu_struct_focal_moc_fragment_header_get_index(st_fragment) != chunk ||
+			   more != (chunk + 1 < total ? 1 : 0) ||
+			   buf[FU_STRUCT_FOCAL_MOC_FRAGMENT_HEADER_SIZE] != *status) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "cipher fragment metadata invalid: chunk=%u",
+				    chunk);
+			return NULL;
+		}
+		g_byte_array_append(data,
+				    buf + FU_STRUCT_FOCAL_MOC_FRAGMENT_HEADER_SIZE + 1,
+				    bufsz - FU_STRUCT_FOCAL_MOC_FRAGMENT_HEADER_SIZE - 1);
+		if (chunk + 1 == total)
+			return g_steal_pointer(&data);
+	}
+}
+#endif
+
+gboolean
+fu_focal_moc_transport_is_supported(void)
+{
+#ifdef FU_FOCAL_MOC_TRANSPORT_HAVE_ECDH
+	return TRUE;
+#else
+	return FALSE;
+#endif
+}
+
+gboolean
+fu_focal_moc_transport_derive_iv(const guint8 *key, guint32 sequence, guint8 *iv, GError **error)
+{
+#ifdef FU_FOCAL_MOC_TRANSPORT_HAVE_ECDH
+	g_autoptr(FuSecureBytes) iv_secure = NULL;
+#endif
+
+	g_return_val_if_fail(key != NULL, FALSE);
+	g_return_val_if_fail(iv != NULL, FALSE);
+
+#ifdef FU_FOCAL_MOC_TRANSPORT_HAVE_ECDH
+	iv_secure = fu_focal_moc_transport_derive_iv_internal(key, sequence, error);
+	if (iv_secure == NULL)
+		return FALSE;
+	return fu_memcpy_safe(iv,
+			      16,
+			      0,
+			      fu_secure_bytes_get_data(iv_secure),
+			      fu_secure_bytes_get_size(iv_secure),
+			      0,
+			      16,
+			      error);
+#else
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "TransportSec requires GnuTLS 3.8.2 or later");
+	return FALSE;
+#endif
+}
+
+gboolean
+fu_focal_moc_transport_aes_ctr(const guint8 *key,
+			       const guint8 *iv,
+			       const guint8 *input,
+			       gsize input_sz,
+			       guint8 *output,
+			       GError **error)
+{
+	g_return_val_if_fail(key != NULL, FALSE);
+	g_return_val_if_fail(iv != NULL, FALSE);
+	g_return_val_if_fail(input != NULL || input_sz == 0, FALSE);
+	g_return_val_if_fail(output != NULL || input_sz == 0, FALSE);
+
+#ifdef FU_FOCAL_MOC_TRANSPORT_HAVE_ECDH
+	return fu_focal_moc_transport_aes_ctr_internal(key, iv, input, input_sz, output, error);
+#else
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "TransportSec requires GnuTLS 3.8.2 or later");
+	return FALSE;
+#endif
+}
+
+GByteArray *
+fu_focal_moc_transport_cipher_frame_new(const guint8 *key_aes,
+					const guint8 *key_mac,
+					const guint8 *key_iv,
+					guint32 sequence,
+					const guint8 *plaintext,
+					gsize plaintext_sz,
+					GError **error)
+{
+	g_return_val_if_fail(key_aes != NULL, NULL);
+	g_return_val_if_fail(key_mac != NULL, NULL);
+	g_return_val_if_fail(key_iv != NULL, NULL);
+	g_return_val_if_fail(plaintext != NULL || plaintext_sz == 0, NULL);
+
+#ifdef FU_FOCAL_MOC_TRANSPORT_HAVE_ECDH
+	return fu_focal_moc_transport_cipher_frame_new_internal(key_aes,
+								key_mac,
+								key_iv,
+								sequence,
+								plaintext,
+								plaintext_sz,
+								error);
+#else
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "TransportSec requires GnuTLS 3.8.2 or later");
+	return NULL;
+#endif
+}
+
+FuSecureBytes *
+fu_focal_moc_transport_cipher_frame_parse(const guint8 *key_aes,
+					  const guint8 *key_mac,
+					  const guint8 *key_iv,
+					  guint32 expected_sequence,
+					  GByteArray *frame,
+					  GError **error)
+{
+#ifdef FU_FOCAL_MOC_TRANSPORT_HAVE_ECDH
+	g_return_val_if_fail(key_aes != NULL, NULL);
+	g_return_val_if_fail(key_mac != NULL, NULL);
+	g_return_val_if_fail(key_iv != NULL, NULL);
+	g_return_val_if_fail(frame != NULL, NULL);
+
+	return fu_focal_moc_transport_cipher_frame_decode(key_aes,
+							  key_mac,
+							  key_iv,
+							  expected_sequence,
+							  frame,
+							  NULL,
+							  error);
+#else
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "TransportSec requires GnuTLS 3.8.2 or later");
+	return NULL;
+#endif
+}
+
+FuFocalMocTransport *
+fu_focal_moc_transport_new(FuFocalMocTransportImpl *impl)
+{
+	FuFocalMocTransport *self;
+
+	g_return_val_if_fail(FU_IS_FOCAL_MOC_TRANSPORT_IMPL(impl), NULL);
+
+	self = g_new0(FuFocalMocTransport, 1);
+	self->impl = impl;
+	return self;
+}
+
+void
+fu_focal_moc_transport_set_fixed_host_key(FuFocalMocTransport *self,
+					  const guint8 *host_key,
+					  gsize host_keysz)
+{
+	g_return_if_fail(self != NULL);
+	g_return_if_fail(host_key != NULL);
+	g_return_if_fail(host_keysz == FU_FOCAL_MOC_TRANSPORT_HOST_KEY_SIZE);
+
+	fu_focal_moc_transport_clear_fixed_host_key(self);
+	self->fixed_host_key =
+	    fu_secure_bytes_new(g_memdup2(host_key, host_keysz), host_keysz, g_free);
+}
+
+void
+fu_focal_moc_transport_clear_fixed_host_key(FuFocalMocTransport *self)
+{
+	g_return_if_fail(self != NULL);
+	g_clear_pointer(&self->fixed_host_key, fu_secure_bytes_free);
+}
+
+void
+fu_focal_moc_transport_teardown(FuFocalMocTransport *self)
+{
+	g_return_if_fail(self != NULL);
+
+	g_clear_pointer(&self->key_aes_d2m, fu_secure_bytes_free);
+	g_clear_pointer(&self->key_mac_d2m, fu_secure_bytes_free);
+	g_clear_pointer(&self->key_iv_d2m, fu_secure_bytes_free);
+	g_clear_pointer(&self->key_aes_m2d, fu_secure_bytes_free);
+	g_clear_pointer(&self->key_mac_m2d, fu_secure_bytes_free);
+	g_clear_pointer(&self->key_iv_m2d, fu_secure_bytes_free);
+	self->tx_sequence = 0;
+	self->rx_sequence = 0;
+	self->tx_message_id = 0;
+	self->mac_failures = 0;
+	self->state = FU_FOCAL_MOC_TRANSPORT_STATE_IDLE;
+}
+
+void
+fu_focal_moc_transport_free(FuFocalMocTransport *self)
+{
+	if (self == NULL)
+		return;
+	fu_focal_moc_transport_teardown(self);
+	fu_focal_moc_transport_clear_fixed_host_key(self);
+	g_free(self);
+}
+
+gboolean
+fu_focal_moc_transport_is_active(FuFocalMocTransport *self)
+{
+	g_return_val_if_fail(self != NULL, FALSE);
+	return self->state == FU_FOCAL_MOC_TRANSPORT_STATE_ACTIVE;
+}
+
+gboolean
+fu_focal_moc_transport_handshake(FuFocalMocTransport *self, GError **error)
+{
+	g_return_val_if_fail(self != NULL, FALSE);
+
+#ifdef FU_FOCAL_MOC_TRANSPORT_HAVE_ECDH
+	if (fu_focal_moc_transport_is_active(self))
+		return TRUE;
+	if (self->state != FU_FOCAL_MOC_TRANSPORT_STATE_IDLE) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "transport handshake requires idle state");
+		return FALSE;
+	}
+	for (guint i = 0; i < FU_FOCAL_MOC_TRANSPORT_DRAIN_LIMIT; i++) {
+		g_autoptr(GByteArray) stale = NULL;
+		g_autoptr(GError) error_local = NULL;
+
+		stale = fu_focal_moc_transport_impl_read(self->impl,
+							 FU_FOCAL_MOC_TRANSPORT_DRAIN_TIMEOUT_MS,
+							 &error_local);
+		if (stale == NULL)
+			break;
+	}
+	if (!fu_focal_moc_transport_key_exchange(self, error) ||
+	    !fu_focal_moc_transport_key_confirm(self, error)) {
+		fu_focal_moc_transport_teardown(self);
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+#else
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "TransportSec requires GnuTLS 3.8.2 or later");
+	return FALSE;
+#endif
+}
+
+GByteArray *
+fu_focal_moc_transport_command(FuFocalMocTransport *self,
+			       guint8 command,
+			       const guint8 *payload,
+			       gsize payload_sz,
+			       guint timeout_ms,
+			       guint8 *status,
+			       GError **error)
+{
+#ifdef FU_FOCAL_MOC_TRANSPORT_HAVE_ECDH
+	guint8 message_id = 0;
+	GByteArray *response;
+	g_autoptr(FuStructFocalMocFragmentHeader) st_fragment = NULL;
+	g_autoptr(GByteArray) plaintext = g_byte_array_new();
+	g_autoptr(GByteArray) frame = NULL;
+#endif
+
+	g_return_val_if_fail(self != NULL, NULL);
+	g_return_val_if_fail(status != NULL, NULL);
+
+#ifdef FU_FOCAL_MOC_TRANSPORT_HAVE_ECDH
+	message_id = self->tx_message_id;
+	st_fragment = fu_struct_focal_moc_fragment_header_new();
+	fu_struct_focal_moc_fragment_header_set_message_id(st_fragment, message_id);
+	fu_struct_focal_moc_fragment_header_set_total(st_fragment, 1);
+	if (!fu_focal_moc_transport_is_active(self)) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "encrypted command requires active transport");
+		return NULL;
+	}
+	if ((payload_sz > 0 && payload == NULL) ||
+	    payload_sz > FU_FOCAL_MOC_TRANSPORT_MAX_DATA_SIZE) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "encrypted command payload invalid: 0x%zx",
+			    payload_sz);
+		return NULL;
+	}
+	if (self->tx_sequence >= FU_FOCAL_MOC_TRANSPORT_REKEY_THRESHOLD) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_AUTH_FAILED,
+			    "transport sequence reached rekey threshold: %u",
+			    self->tx_sequence);
+		fu_focal_moc_transport_teardown(self);
+		return NULL;
+	}
+	g_byte_array_append(plaintext, st_fragment->buf->data, st_fragment->buf->len);
+	g_byte_array_append(plaintext, &command, sizeof(command));
+	if (payload_sz > 0)
+		g_byte_array_append(plaintext, payload, payload_sz);
+	frame = fu_focal_moc_transport_cipher_frame_new_internal(
+	    fu_secure_bytes_get_data(self->key_aes_d2m),
+	    fu_secure_bytes_get_data(self->key_mac_d2m),
+	    fu_secure_bytes_get_data(self->key_iv_d2m),
+	    self->tx_sequence,
+	    plaintext->data,
+	    plaintext->len,
+	    error);
+	if (frame == NULL)
+		return NULL;
+	/* once the frame may have reached the wire the sequence is burned:
+	 * reusing it would repeat the AES-CTR keystream, and a partial response
+	 * leaves rx desynchronized -- on any failure below require a fresh
+	 * handshake with new keys */
+	if (!fu_focal_moc_transport_impl_write(self->impl,
+					       frame->data,
+					       frame->len,
+					       timeout_ms,
+					       error)) {
+		fu_focal_moc_transport_teardown(self);
+		return NULL;
+	}
+	self->tx_sequence++;
+	self->tx_message_id++;
+	response =
+	    fu_focal_moc_transport_receive_message(self, message_id, timeout_ms, status, error);
+	if (response == NULL)
+		fu_focal_moc_transport_teardown(self);
+	return response;
+#else
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "TransportSec requires GnuTLS 3.8.2 or later");
+	return NULL;
+#endif
+}

--- a/plugins/focal-moc/fu-focal-moc-transport.h
+++ b/plugins/focal-moc/fu-focal-moc-transport.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 FocalTech Systems Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#include "fu-focal-moc-transport-impl.h"
+
+/* an ephemeral P-256 key packed as x||y||scalar, 32 bytes each */
+#define FU_FOCAL_MOC_TRANSPORT_HOST_KEY_SIZE 96
+
+typedef struct _FuFocalMocTransport FuFocalMocTransport;
+
+gboolean
+fu_focal_moc_transport_is_supported(void);
+
+FuFocalMocTransport *
+fu_focal_moc_transport_new(FuFocalMocTransportImpl *impl);
+
+void
+fu_focal_moc_transport_set_fixed_host_key(FuFocalMocTransport *self,
+					  const guint8 *host_key,
+					  gsize host_keysz);
+
+void
+fu_focal_moc_transport_clear_fixed_host_key(FuFocalMocTransport *self);
+
+void
+fu_focal_moc_transport_free(FuFocalMocTransport *self);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuFocalMocTransport, fu_focal_moc_transport_free)
+
+gboolean
+fu_focal_moc_transport_is_active(FuFocalMocTransport *self);
+
+gboolean
+fu_focal_moc_transport_handshake(FuFocalMocTransport *self, GError **error);
+
+GByteArray *
+fu_focal_moc_transport_command(FuFocalMocTransport *self,
+			       guint8 command,
+			       const guint8 *payload,
+			       gsize payload_sz,
+			       guint timeout_ms,
+			       guint8 *status,
+			       GError **error) G_GNUC_WARN_UNUSED_RESULT;
+
+void
+fu_focal_moc_transport_teardown(FuFocalMocTransport *self);
+
+gboolean
+fu_focal_moc_transport_kdf_expand(const guint8 *prk,
+				  gsize prk_sz,
+				  const gchar *label,
+				  const guint8 *context,
+				  gsize context_sz,
+				  guint8 *key,
+				  gsize key_sz,
+				  GError **error);
+
+gboolean
+fu_focal_moc_transport_derive_iv(const guint8 *key, guint32 sequence, guint8 *iv, GError **error);
+
+gboolean
+fu_focal_moc_transport_aes_ctr(const guint8 *key,
+			       const guint8 *iv,
+			       const guint8 *input,
+			       gsize input_sz,
+			       guint8 *output,
+			       GError **error);
+
+GByteArray *
+fu_focal_moc_transport_cipher_frame_new(const guint8 *key_aes,
+					const guint8 *key_mac,
+					const guint8 *key_iv,
+					guint32 sequence,
+					const guint8 *plaintext,
+					gsize plaintext_sz,
+					GError **error);
+
+FuSecureBytes *
+fu_focal_moc_transport_cipher_frame_parse(const guint8 *key_aes,
+					  const guint8 *key_mac,
+					  const guint8 *key_iv,
+					  guint32 expected_sequence,
+					  GByteArray *frame,
+					  GError **error) G_GNUC_WARN_UNUSED_RESULT;

--- a/plugins/focal-moc/fu-focal-moc.rs
+++ b/plugins/focal-moc/fu-focal-moc.rs
@@ -35,6 +35,11 @@ enum FuFocalMocIapStatusLayout {
     Aligned,
 }
 
+#[repr(u32le)]
+enum FuFocalMocFirmwareKind {
+    App = 0x02,
+}
+
 #[repr(u8)]
 enum FuFocalMocBootMode {
     App = 0x00,
@@ -80,4 +85,18 @@ struct FuStructFocalMocDataV1 {
     kind: FuFocalMocFrame,
     sequence: u8,
     data: [u8; 1024],
+}
+
+#[derive(New, ParseStream, ValidateStream, Default)]
+#[repr(C, packed)]
+struct FuStructFocalMocFirmwareHeader {
+    magic: u32le == 0x46574844,
+    kind: u32le,
+    version: u32le,
+    size: u32le,
+    entry_offset: u32le,
+    _reserved1: [u8; 28],
+    digest: [u8; 32],
+    signature: [u8; 64],
+    _reserved2: [u8; 112],
 }

--- a/plugins/focal-moc/fu-focal-moc.rs
+++ b/plugins/focal-moc/fu-focal-moc.rs
@@ -8,6 +8,8 @@ enum FuFocalMocCmd {
     SetBootMode = 0x32,
     SendFirmware = 0x33,
     WakeUp = 0x34,
+    TransportKeyExchange = 0xB0,
+    TransportKeyConfirm = 0xB1,
 }
 
 #[repr(u8)]
@@ -54,6 +56,12 @@ enum FuFocalMocFrame {
     Eot = 0x04,
 }
 
+enum FuFocalMocTransportState {
+    Idle,
+    KcPending,
+    Active,
+}
+
 #[derive(New, Parse, Default)]
 #[repr(C, packed)]
 struct FuStructFocalMocPacketHeader {
@@ -66,6 +74,23 @@ struct FuStructFocalMocPacketHeader {
 #[repr(C, packed)]
 struct FuStructFocalMocWakeUp {
     magic: u16be == 0x55AA,
+}
+
+#[derive(New, Parse, Default)]
+#[repr(C, packed)]
+struct FuStructFocalMocCipherHeader {
+    magic: u8 == 0x03,
+    length: u16be,
+    sequence: u32be,
+}
+
+#[derive(New, Parse, Default)]
+#[repr(C, packed)]
+struct FuStructFocalMocFragmentHeader {
+    more: u8,
+    message_id: u8,
+    index: u8,
+    total: u8,
 }
 
 #[derive(New, Default)]

--- a/plugins/focal-moc/fu-focal-moc.rs
+++ b/plugins/focal-moc/fu-focal-moc.rs
@@ -112,6 +112,26 @@ struct FuStructFocalMocDataV1 {
     data: [u8; 1024],
 }
 
+#[derive(New, Default)]
+#[repr(C, packed)]
+struct FuStructFocalMocSohV2 {
+    kind: FuFocalMocFrame == Soh,
+    sequence: u16be,
+    filename: [char; 64],
+    firmware_size: u32be,
+    crc32: u32be,
+    frame_size: u16be == 1024,
+    _reserved: [u8; 54],
+}
+
+#[derive(New, Default)]
+#[repr(C, packed)]
+struct FuStructFocalMocDataV2 {
+    kind: FuFocalMocFrame,
+    sequence: u16be,
+    data: [u8; 1024],
+}
+
 #[derive(New, ParseStream, ValidateStream, Default)]
 #[repr(C, packed)]
 struct FuStructFocalMocFirmwareHeader {

--- a/plugins/focal-moc/fu-focal-moc.rs
+++ b/plugins/focal-moc/fu-focal-moc.rs
@@ -1,66 +1,83 @@
 // Copyright 2024 FocalTech Systems Co., Ltd.
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-// Command codes
 #[repr(u8)]
 enum FuFocalMocCmd {
-    GetFwVersion = 0x30,  // request firmware version string
-    SetBootMode  = 0x32,  // switch device mode; data[0] = FuFocalMocBootMode
-    FwDownload   = 0x33,  // firmware download (3-phase: SHO → STX×N → EOT)
-    Ack          = 0x04,  // device acknowledgment (response to all commands)
+    GetFwVersion = 0x30,
+    GetFpVersion = 0x31,
+    SetBootMode = 0x32,
+    SendFirmware = 0x33,
+    WakeUp = 0x34,
 }
 
-// Boot mode argument for SetBootMode
+#[repr(u8)]
+enum FuFocalMocStatus {
+    Ok = 0x04,
+    InvalidParameter = 0x05,
+    Timeout = 0x06,
+    NoMemory = 0x07,
+    CheckError = 0x08,
+    InvalidCommand = 0x09,
+    ExecutionFailure = 0x0A,
+    CommandMasterKeyInvalid = 0x20,
+    MasterKeyInvalid = 0x21,
+    FirmwareSequence = 0x40,
+    FirmwareFlash = 0x41,
+    FirmwareNoSession = 0x42,
+    FirmwareVerify = 0x43,
+    FirmwareRecover = 0x44,
+}
+
+#[derive(ToString)]
+enum FuFocalMocIapStatusLayout {
+    Unknown,
+    Legacy,
+    Aligned,
+}
+
 #[repr(u8)]
 enum FuFocalMocBootMode {
-    EnterApp     = 0x00,  // return to normal application mode
-    EnterBoot    = 0x01,  // enter bootloader (IAP) mode for firmware update
-    EnterRomBoot = 0x02,  // enter ROM bootloader mode
+    App = 0x00,
+    Iap = 0x01,
 }
 
-// Magic byte in the firmware-download packet
+#[derive(ToString)]
 #[repr(u8)]
-enum FuFocalMocMagic {
-    Sho = 0x01,  // Start-of-Header: first packet, carries filename + size + CRC32
-    Stx = 0x02,  // Start-of-Text: middle data block (1024 bytes each)
-    Eot = 0x04,  // End-of-Text: last (possibly partial) data block
+enum FuFocalMocFrame {
+    Soh = 0x01,
+    Stx = 0x02,
+    Eot = 0x04,
 }
 
-// Standard command request header
-#[derive(New, Default)]
+#[derive(New, Parse, Default)]
 #[repr(C, packed)]
-struct FuStructFocalMocCmdReq {
-    head: u8 == 0x02,
-    ln: u16be,             // payload length (data bytes + 1 for BCC)
-    cmd: FuFocalMocCmd,
+struct FuStructFocalMocPacketHeader {
+    magic: u8 == 0x02,
+    length: u16be,
+    command: FuFocalMocCmd,
 }
 
-// Device response header
 #[derive(Parse, Default)]
 #[repr(C, packed)]
-struct FuStructFocalMocCmdRsp {
-    head: u8 == 0x02,
-    ln: u16be,
-    st: FuFocalMocCmd == Ack,
+struct FuStructFocalMocWakeUp {
+    magic: u16be == 0x55AA,
 }
 
-// Firmware-download packet header
 #[derive(New, Default)]
 #[repr(C, packed)]
-struct FuStructFocalMocDlHdr {
-    head: u8 == 0x02,
-    ln: u16be,
-    cmd: FuFocalMocCmd = FwDownload,
-    magic: FuFocalMocMagic,
-    seq: u8,                   // incrementing sequence number
+struct FuStructFocalMocSohV1 {
+    kind: FuFocalMocFrame == Soh,
+    sequence: u8,
+    filename: [char; 64],
+    firmware_size: u32be,
+    crc32: u32be,
+    _reserved: [u8; 56],
 }
 
-// SHO packet data payload
-#[derive(New, Setters)]
+#[derive(New, Default)]
 #[repr(C, packed)]
-struct FuStructFocalMocShoData {
-    filename: [char; 64],
-    filesize: u32be,
-    crc32: u32be,
-    _padding: [u8; 56],
+struct FuStructFocalMocDataV1 {
+    kind: FuFocalMocFrame,
+    sequence: u8,
+    data: [u8; 1024],
 }

--- a/plugins/focal-moc/fu-self-test.c
+++ b/plugins/focal-moc/fu-self-test.c
@@ -10,6 +10,486 @@
 #include "fu-focal-moc-common.h"
 #include "fu-focal-moc-firmware.h"
 #include "fu-focal-moc-struct.h"
+#include "fu-focal-moc-test-device.h"
+#include "fu-focal-moc-transport.h"
+
+static void
+fu_focal_moc_transport_kdf_func(void)
+{
+	const guint8 expected[] = {
+	    0x6E, 0x3C, 0xBE, 0xB6, 0x45, 0xF7, 0xD2, 0x68, 0xF1, 0x5F, 0x5B,
+	    0xE5, 0xBE, 0xA2, 0x5D, 0x35, 0x63, 0xD0, 0xA7, 0xC7, 0x66, 0x27,
+	    0x50, 0x13, 0xF9, 0x9B, 0x3D, 0xCF, 0xB8, 0xE3, 0x53, 0x89,
+	};
+	guint8 context[130] = {0};
+	guint8 key[32] = {0};
+	guint8 prk[32] = {0};
+	g_autoptr(GError) error = NULL;
+
+	for (guint i = 0; i < sizeof(prk); i++)
+		prk[i] = i;
+	for (guint i = 0; i < sizeof(context); i++)
+		context[i] = i;
+	g_assert_true(fu_focal_moc_transport_kdf_expand(prk,
+							sizeof(prk),
+							"AES_KEY_D2M",
+							context,
+							sizeof(context),
+							key,
+							sizeof(key),
+							&error));
+	g_assert_no_error(error);
+	g_assert_cmpmem(key, sizeof(key), expected, sizeof(expected));
+}
+
+static void
+fu_focal_moc_transport_aes_func(void)
+{
+	const guint8 expected_iv[] = {
+	    0x9D,
+	    0xBA,
+	    0x41,
+	    0xA7,
+	    0x77,
+	    0xF3,
+	    0xB4,
+	    0x6A,
+	    0x37,
+	    0xB7,
+	    0xAA,
+	    0xAE,
+	    0x49,
+	    0xD6,
+	    0xDF,
+	    0x8D,
+	};
+	const guint8 expected_ciphertext[] = {
+	    0xD4, 0x28, 0x15, 0x45, 0x00, 0x4F, 0xBE, 0xCB, 0x52, 0x0C, 0xA8, 0xA5, 0x35,
+	    0xC2, 0x10, 0x7A, 0xD1, 0xEF, 0x8A, 0xFB, 0xA3, 0xC3, 0xC7, 0xE4, 0x73, 0x68,
+	    0xE0, 0x47, 0xDB, 0x45, 0x5C, 0x93, 0x07, 0xA5, 0x04, 0xF9, 0x72,
+	};
+	guint8 ciphertext[37] = {0};
+	guint8 iv[16] = {0};
+	guint8 key[32] = {0};
+	guint8 plaintext[37] = {0};
+	g_autoptr(GError) error = NULL;
+
+	if (!fu_focal_moc_transport_is_supported()) {
+		g_test_skip("GnuTLS 3.8.2 is unavailable");
+		return;
+	}
+	for (guint i = 0; i < sizeof(key); i++)
+		key[i] = i;
+	for (guint i = 0; i < sizeof(plaintext); i++)
+		plaintext[i] = i;
+	g_assert_true(fu_focal_moc_transport_derive_iv(key, 1, iv, &error));
+	g_assert_no_error(error);
+	g_assert_cmpmem(iv, sizeof(iv), expected_iv, sizeof(expected_iv));
+	g_assert_true(fu_focal_moc_transport_aes_ctr(key,
+						     iv,
+						     plaintext,
+						     sizeof(plaintext),
+						     ciphertext,
+						     &error));
+	g_assert_no_error(error);
+	g_assert_cmpmem(ciphertext,
+			sizeof(ciphertext),
+			expected_ciphertext,
+			sizeof(expected_ciphertext));
+}
+
+static void
+fu_focal_moc_transport_cipher_frame_func(void)
+{
+	const guint8 expected[] = {
+	    0x03, 0x00, 0x1A, 0x00, 0x00, 0x00, 0x01, 0xF0, 0xD6, 0xE3,
+	    0xDB, 0x44, 0x20, 0xFA, 0x86, 0xB3, 0x2C, 0x02, 0xC1, 0x85,
+	    0x26, 0x5D, 0x8E, 0x80, 0x78, 0xB6, 0x4A, 0xC6, 0xF3,
+	};
+	const guint8 plaintext[] = {0x00, 0x00, 0x00, 0x01, 0x30};
+	guint8 key_aes[32] = {0};
+	guint8 key_iv[32] = {0};
+	guint8 key_mac[32] = {0};
+	g_autoptr(FuSecureBytes) plaintext_parsed = NULL;
+	g_autoptr(GByteArray) frame = NULL;
+	g_autoptr(GError) error = NULL;
+
+	if (!fu_focal_moc_transport_is_supported()) {
+		g_test_skip("GnuTLS 3.8.2 is unavailable");
+		return;
+	}
+	for (guint i = 0; i < sizeof(key_aes); i++) {
+		key_aes[i] = i;
+		key_mac[i] = i + 32;
+		key_iv[i] = i + 64;
+	}
+	frame = fu_focal_moc_transport_cipher_frame_new(key_aes,
+							key_mac,
+							key_iv,
+							1,
+							plaintext,
+							sizeof(plaintext),
+							&error);
+	g_assert_no_error(error);
+	g_assert_nonnull(frame);
+	g_assert_cmpmem(frame->data, frame->len, expected, sizeof(expected));
+	plaintext_parsed =
+	    fu_focal_moc_transport_cipher_frame_parse(key_aes, key_mac, key_iv, 1, frame, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(plaintext_parsed);
+	g_assert_cmpmem(fu_secure_bytes_get_data(plaintext_parsed),
+			fu_secure_bytes_get_size(plaintext_parsed),
+			plaintext,
+			sizeof(plaintext));
+
+	frame->data[frame->len - 1] ^= 0x01;
+	g_assert_null(
+	    fu_focal_moc_transport_cipher_frame_parse(key_aes, key_mac, key_iv, 1, frame, &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
+	g_clear_error(&error);
+	frame->data[frame->len - 1] ^= 0x01;
+
+	frame->data[frame->len - 2] ^= 0x01;
+	frame->data[frame->len - 1] ^= 0x01;
+	g_assert_null(
+	    fu_focal_moc_transport_cipher_frame_parse(key_aes, key_mac, key_iv, 1, frame, &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_AUTH_FAILED);
+	g_clear_error(&error);
+	frame->data[frame->len - 2] ^= 0x01;
+	frame->data[frame->len - 1] ^= 0x01;
+
+	g_assert_null(
+	    fu_focal_moc_transport_cipher_frame_parse(key_aes, key_mac, key_iv, 2, frame, &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_AUTH_FAILED);
+	g_clear_error(&error);
+
+	g_clear_pointer(&frame, g_byte_array_unref);
+	frame = fu_focal_moc_transport_cipher_frame_new(key_aes,
+							key_mac,
+							key_iv,
+							0xFFFF0000,
+							plaintext,
+							sizeof(plaintext),
+							&error);
+	g_assert_no_error(error);
+	g_assert_nonnull(frame);
+	g_assert_null(fu_focal_moc_transport_cipher_frame_parse(key_aes,
+								key_mac,
+								key_iv,
+								0xFFFF0000,
+								frame,
+								&error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_AUTH_FAILED);
+}
+
+#ifdef FU_FOCAL_MOC_TEST_HAVE_ECDH
+#define FU_TYPE_FOCAL_MOC_TEST_STUB (fu_focal_moc_test_stub_get_type())
+G_DECLARE_FINAL_TYPE(FuFocalMocTestStub, fu_focal_moc_test_stub, FU, FOCAL_MOC_TEST_STUB, GObject)
+
+struct _FuFocalMocTestStub {
+	GObject parent_instance;
+};
+
+static void
+fu_focal_moc_test_stub_transport_impl_iface_init(FuFocalMocTransportImplInterface *iface)
+{
+}
+
+G_DEFINE_TYPE_WITH_CODE(FuFocalMocTestStub,
+			fu_focal_moc_test_stub,
+			G_TYPE_OBJECT,
+			G_IMPLEMENT_INTERFACE(FU_TYPE_FOCAL_MOC_TRANSPORT_IMPL,
+					      fu_focal_moc_test_stub_transport_impl_iface_init))
+
+static void
+fu_focal_moc_test_stub_init(FuFocalMocTestStub *self)
+{
+}
+
+static void
+fu_focal_moc_test_stub_class_init(FuFocalMocTestStubClass *klass)
+{
+}
+#endif
+
+static void
+fu_focal_moc_transport_handshake_func(void)
+{
+#ifdef FU_FOCAL_MOC_TEST_HAVE_ECDH
+	const guint8 payload_alive[] = {0x55, 0xAA};
+	const guint8 payload_version[] = "FT9349_APP_FT9001_AA7A_USB_DEC_SV0.1_0104";
+	const guint8 request_alive[] = {0x00, 0x00, 0x00, 0x01, FU_FOCAL_MOC_CMD_WAKE_UP};
+	const guint8 request_version[] = {0x00, 0x01, 0x00, 0x01, FU_FOCAL_MOC_CMD_GET_FW_VERSION};
+	const guint8 request_sensor[] = {0x00, 0x02, 0x00, 0x01, FU_FOCAL_MOC_CMD_GET_FP_VERSION};
+	gboolean ret;
+	guint8 status = 0;
+	g_autoptr(FuFocalMocTestDevice) device = g_object_new(FU_TYPE_FOCAL_MOC_TEST_DEVICE, NULL);
+	g_autoptr(FuFocalMocTransport) transport = NULL;
+	g_autoptr(GByteArray) data = NULL;
+	g_autoptr(GError) error = NULL;
+
+	transport = fu_focal_moc_transport_new(FU_FOCAL_MOC_TRANSPORT_IMPL(device));
+
+	/* encrypted commands require a confirmed session */
+	g_assert_null(fu_focal_moc_transport_command(transport,
+						     FU_FOCAL_MOC_CMD_WAKE_UP,
+						     NULL,
+						     0,
+						     100,
+						     &status,
+						     &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL);
+	g_clear_error(&error);
+
+	ret = fu_focal_moc_transport_handshake(transport, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_true(fu_focal_moc_transport_is_active(transport));
+
+	/* single-fragment response with the first message ID */
+	device->response_status = FU_FOCAL_MOC_STATUS_OK;
+	g_byte_array_append(device->response_payload, payload_alive, sizeof(payload_alive));
+	g_clear_pointer(&data, g_byte_array_unref);
+	data = fu_focal_moc_transport_command(transport,
+					      FU_FOCAL_MOC_CMD_WAKE_UP,
+					      NULL,
+					      0,
+					      100,
+					      &status,
+					      &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(data);
+	g_assert_cmphex(status, ==, FU_FOCAL_MOC_STATUS_OK);
+	g_assert_cmpmem(data->data, data->len, payload_alive, sizeof(payload_alive));
+	g_assert_cmpmem(device->last_request->data,
+			device->last_request->len,
+			request_alive,
+			sizeof(request_alive));
+
+	/* still a single fragment, with the next message ID */
+	g_byte_array_set_size(device->response_payload, 0);
+	g_byte_array_append(device->response_payload, payload_version, sizeof(payload_version) - 1);
+	g_clear_pointer(&data, g_byte_array_unref);
+	data = fu_focal_moc_transport_command(transport,
+					      FU_FOCAL_MOC_CMD_GET_FW_VERSION,
+					      NULL,
+					      0,
+					      100,
+					      &status,
+					      &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(data);
+	g_assert_cmphex(status, ==, FU_FOCAL_MOC_STATUS_OK);
+	g_assert_cmpmem(data->data, data->len, payload_version, sizeof(payload_version) - 1);
+	g_assert_cmpmem(device->last_request->data,
+			device->last_request->len,
+			request_version,
+			sizeof(request_version));
+
+	/* 2100-byte response reassembled from 1013+1013+74-byte fragments */
+	g_byte_array_set_size(device->response_payload, 0);
+	for (guint i = 0; i < 2100; i++)
+		fu_byte_array_append_uint8(device->response_payload, (guint8)i);
+	g_clear_pointer(&data, g_byte_array_unref);
+	data = fu_focal_moc_transport_command(transport,
+					      FU_FOCAL_MOC_CMD_GET_FP_VERSION,
+					      NULL,
+					      0,
+					      100,
+					      &status,
+					      &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(data);
+	g_assert_cmphex(status, ==, FU_FOCAL_MOC_STATUS_OK);
+	g_assert_cmpmem(data->data,
+			data->len,
+			device->response_payload->data,
+			device->response_payload->len);
+	g_assert_cmpmem(device->last_request->data,
+			device->last_request->len,
+			request_sensor,
+			sizeof(request_sensor));
+
+	/* one KC exchange plus three commands, three reply messages in six frames */
+	g_assert_cmpuint(device->d2m_sequence, ==, 4);
+	g_assert_cmpuint(device->m2d_sequence, ==, 6);
+	g_assert_cmpuint(device->tx_message_id, ==, 3);
+
+	/* teardown ends the session and rejects further commands */
+	fu_focal_moc_transport_teardown(transport);
+	g_assert_false(fu_focal_moc_transport_is_active(transport));
+	g_assert_null(fu_focal_moc_transport_command(transport,
+						     FU_FOCAL_MOC_CMD_WAKE_UP,
+						     NULL,
+						     0,
+						     100,
+						     &status,
+						     &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL);
+#else
+	g_test_skip("GnuTLS 3.8.2 is unavailable");
+#endif
+}
+
+static void
+fu_focal_moc_transport_fragment_invalid_func(void)
+{
+#ifdef FU_FOCAL_MOC_TEST_HAVE_ECDH
+	const struct {
+		FuFocalMocTestFault fault;
+		FwupdError code;
+	} faults[] = {
+	    {FU_FOCAL_MOC_TEST_FAULT_FIRST_INDEX, FWUPD_ERROR_INVALID_DATA},
+	    {FU_FOCAL_MOC_TEST_FAULT_FIRST_TOTAL_ZERO, FWUPD_ERROR_INVALID_DATA},
+	    {FU_FOCAL_MOC_TEST_FAULT_FIRST_MORE, FWUPD_ERROR_INVALID_DATA},
+	    {FU_FOCAL_MOC_TEST_FAULT_FIRST_MESSAGE_ID, FWUPD_ERROR_INVALID_DATA},
+	    {FU_FOCAL_MOC_TEST_FAULT_MESSAGE_ID, FWUPD_ERROR_INVALID_DATA},
+	    {FU_FOCAL_MOC_TEST_FAULT_TOTAL, FWUPD_ERROR_INVALID_DATA},
+	    {FU_FOCAL_MOC_TEST_FAULT_INDEX, FWUPD_ERROR_INVALID_DATA},
+	    {FU_FOCAL_MOC_TEST_FAULT_MORE, FWUPD_ERROR_INVALID_DATA},
+	    {FU_FOCAL_MOC_TEST_FAULT_STATUS, FWUPD_ERROR_INVALID_DATA},
+	    {FU_FOCAL_MOC_TEST_FAULT_SHORT, FWUPD_ERROR_INVALID_DATA},
+	    {FU_FOCAL_MOC_TEST_FAULT_TRUNCATED, FWUPD_ERROR_TIMED_OUT},
+	    {FU_FOCAL_MOC_TEST_FAULT_CIPHER_BCC, FWUPD_ERROR_INVALID_DATA},
+	    {FU_FOCAL_MOC_TEST_FAULT_SEND, FWUPD_ERROR_WRITE},
+	};
+	g_autoptr(FuFocalMocTestDevice) device = g_object_new(FU_TYPE_FOCAL_MOC_TEST_DEVICE, NULL);
+	g_autoptr(FuFocalMocTransport) transport = NULL;
+
+	device->response_status = FU_FOCAL_MOC_STATUS_OK;
+	/* two 1013-byte-rule fragments so both first and follow-up checks trigger */
+	for (guint i = 0; i < 1200; i++)
+		fu_byte_array_append_uint8(device->response_payload, (guint8)i);
+	transport = fu_focal_moc_transport_new(FU_FOCAL_MOC_TRANSPORT_IMPL(device));
+
+	for (guint i = 0; i < G_N_ELEMENTS(faults); i++) {
+		gboolean ret;
+		guint8 status = 0;
+		g_autoptr(GError) error = NULL;
+
+		/* a fresh session per fault; the handshake drains stale fragments */
+		fu_focal_moc_transport_teardown(transport);
+		device->fault = FU_FOCAL_MOC_TEST_FAULT_NONE;
+		ret = fu_focal_moc_transport_handshake(transport, &error);
+		g_assert_no_error(error);
+		g_assert_true(ret);
+		device->fault = faults[i].fault;
+		g_assert_null(fu_focal_moc_transport_command(transport,
+							     FU_FOCAL_MOC_CMD_GET_FP_VERSION,
+							     NULL,
+							     0,
+							     100,
+							     &status,
+							     &error));
+		g_assert_error(error, FWUPD_ERROR, (gint)faults[i].code);
+		/* a burned sequence must never be reused: any post-send failure
+		 * has to end the session and force a fresh handshake */
+		g_assert_false(fu_focal_moc_transport_is_active(transport));
+	}
+#else
+	g_test_skip("GnuTLS 3.8.2 is unavailable");
+#endif
+}
+
+static void
+fu_focal_moc_transport_impl_vfuncs_func(void)
+{
+#ifdef FU_FOCAL_MOC_TEST_HAVE_ECDH
+	g_autoptr(FuFocalMocTestStub) stub = g_object_new(FU_TYPE_FOCAL_MOC_TEST_STUB, NULL);
+	g_autoptr(FuFocalMocTransport) transport = NULL;
+	g_autoptr(GError) error = NULL;
+
+	/* missing mandatory I/O vfuncs must fail cleanly rather than crash */
+	transport = fu_focal_moc_transport_new(FU_FOCAL_MOC_TRANSPORT_IMPL(stub));
+	g_assert_false(fu_focal_moc_transport_handshake(transport, &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL);
+	g_assert_nonnull(g_strstr_len(error->message, -1, "not implemented"));
+	g_assert_false(fu_focal_moc_transport_is_active(transport));
+#else
+	g_test_skip("GnuTLS 3.8.2 is unavailable");
+#endif
+}
+
+static void
+fu_focal_moc_transport_fixed_host_key_func(void)
+{
+#ifdef FU_FOCAL_MOC_TEST_HAVE_ECDH
+	gboolean ret;
+	g_autoptr(FuFocalMocTestDevice) device = g_object_new(FU_TYPE_FOCAL_MOC_TEST_DEVICE, NULL);
+	g_autoptr(FuFocalMocTransport) transport = NULL;
+	g_autoptr(GBytes) host_key = NULL;
+	g_autoptr(GBytes) host_key_short = NULL;
+	g_autoptr(GBytes) pk_expected = NULL;
+	g_autoptr(GBytes) pk_expected_short = NULL;
+	g_autoptr(GError) error = NULL;
+
+	host_key =
+	    fu_bytes_from_string("509507d9afe7885875ec3e82f27f3f26b101438117aa843f827b3cc8ff3a9cbb"
+				 "1376086829ab873a45e968a030485bdf98f2766b35fda2496c43e9606392e337"
+				 "59567a7e2a43194bdef67291ed1273a5d677258d48662f282467a710f37923f2",
+				 &error);
+	g_assert_no_error(error);
+	pk_expected =
+	    fu_bytes_from_string("04"
+				 "509507d9afe7885875ec3e82f27f3f26b101438117aa843f827b3cc8ff3a9cbb"
+				 "1376086829ab873a45e968a030485bdf98f2766b35fda2496c43e9606392e337",
+				 &error);
+	g_assert_no_error(error);
+	host_key_short =
+	    fu_bytes_from_string("0040313eb178c9c0997113a59a2448cad7b861b025a19bcbdaa89e2d0b66d26d"
+				 "3616a7daa1a7ef1ccd193bba07128882ff9f982ffaee491947047153e176f9ff"
+				 "61bda3307be4f4c75daed2fc8a5c28d21f1d51db41efb8530ad3366ca5248466",
+				 &error);
+	g_assert_no_error(error);
+	pk_expected_short =
+	    fu_bytes_from_string("04"
+				 "0040313eb178c9c0997113a59a2448cad7b861b025a19bcbdaa89e2d0b66d26d"
+				 "3616a7daa1a7ef1ccd193bba07128882ff9f982ffaee491947047153e176f9ff",
+				 &error);
+	g_assert_no_error(error);
+
+	/* the well-known key must appear on the wire byte-identically */
+	transport = fu_focal_moc_transport_new(FU_FOCAL_MOC_TRANSPORT_IMPL(device));
+	fu_focal_moc_transport_set_fixed_host_key(transport,
+						  g_bytes_get_data(host_key, NULL),
+						  g_bytes_get_size(host_key));
+	ret = fu_focal_moc_transport_handshake(transport, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_true(fu_focal_moc_transport_is_active(transport));
+	g_assert_cmpmem(device->pk_host,
+			sizeof(device->pk_host),
+			g_bytes_get_data(pk_expected, NULL),
+			g_bytes_get_size(pk_expected));
+
+	/* a leading zero byte exports as a 31-byte coordinate, and the previous
+	 * key must not show through the padding */
+	fu_focal_moc_transport_teardown(transport);
+	fu_focal_moc_transport_set_fixed_host_key(transport,
+						  g_bytes_get_data(host_key_short, NULL),
+						  g_bytes_get_size(host_key_short));
+	ret = fu_focal_moc_transport_handshake(transport, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_cmpmem(device->pk_host,
+			sizeof(device->pk_host),
+			g_bytes_get_data(pk_expected_short, NULL),
+			g_bytes_get_size(pk_expected_short));
+
+	/* clearing must fall back to a fresh random key */
+	fu_focal_moc_transport_teardown(transport);
+	fu_focal_moc_transport_clear_fixed_host_key(transport);
+	ret = fu_focal_moc_transport_handshake(transport, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_true(fu_focal_moc_transport_is_active(transport));
+	g_assert_false(memcmp(device->pk_host,
+			      g_bytes_get_data(pk_expected_short, NULL),
+			      g_bytes_get_size(pk_expected_short)) == 0);
+#else
+	g_test_skip("GnuTLS 3.8.2 is unavailable");
+#endif
+}
 
 static void
 fu_focal_moc_packet_build_func(void)
@@ -926,6 +1406,17 @@ main(int argc, char **argv)
 	g_test_init(&argc, &argv, NULL);
 	g_type_ensure(FU_TYPE_FOCAL_MOC_FIRMWARE);
 	g_test_add_func("/focal-moc/packet/build", fu_focal_moc_packet_build_func);
+	g_test_add_func("/focal-moc/transport/kdf", fu_focal_moc_transport_kdf_func);
+	g_test_add_func("/focal-moc/transport/aes", fu_focal_moc_transport_aes_func);
+	g_test_add_func("/focal-moc/transport/cipher-frame",
+			fu_focal_moc_transport_cipher_frame_func);
+	g_test_add_func("/focal-moc/transport/handshake", fu_focal_moc_transport_handshake_func);
+	g_test_add_func("/focal-moc/transport/fragment-invalid",
+			fu_focal_moc_transport_fragment_invalid_func);
+	g_test_add_func("/focal-moc/transport/impl-vfuncs",
+			fu_focal_moc_transport_impl_vfuncs_func);
+	g_test_add_func("/focal-moc/transport/fixed-host-key",
+			fu_focal_moc_transport_fixed_host_key_func);
 	g_test_add_func("/focal-moc/packet/parse", fu_focal_moc_packet_parse_func);
 	g_test_add_func("/focal-moc/packet/status-only", fu_focal_moc_packet_status_only_func);
 	g_test_add_func("/focal-moc/packet/bad-bcc", fu_focal_moc_packet_bad_bcc_func);

--- a/plugins/focal-moc/fu-self-test.c
+++ b/plugins/focal-moc/fu-self-test.c
@@ -2,7 +2,7 @@
  * Copyright 2026 FocalTech Systems Co., Ltd.
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
- * nocheck:magic-inlines=230
+ * nocheck:magic-inlines=235
  */
 
 #include "config.h"
@@ -743,6 +743,51 @@ fu_focal_moc_ymodem_frame_func(void)
 					       payload,
 					       sizeof(payload),
 					       &error);
+	g_assert_null(frame);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
+	g_clear_error(&error);
+
+	frame = fu_focal_moc_ymodem_build_soh_v2(0x1234, 0x89ABCDEF, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(frame);
+	g_assert_cmpuint(frame->len, ==, FU_STRUCT_FOCAL_MOC_SOH_V2_SIZE);
+	g_assert_cmphex(frame->data[0], ==, FU_FOCAL_MOC_FRAME_SOH);
+	g_assert_cmphex(frame->data[1], ==, 0x00);
+	g_assert_cmphex(frame->data[2], ==, 0x00);
+	g_assert_cmpmem(frame->data + 3, 7, "app.bin", 7);
+	g_assert_true(
+	    fu_memread_uint32_safe(frame->data, frame->len, 67, &value, G_BIG_ENDIAN, &error));
+	g_assert_no_error(error);
+	g_assert_cmphex(value, ==, 0x1234);
+	g_assert_true(
+	    fu_memread_uint32_safe(frame->data, frame->len, 71, &value, G_BIG_ENDIAN, &error));
+	g_assert_no_error(error);
+	g_assert_cmphex(value, ==, 0x89ABCDEF);
+	/* the fixed frame size is 1024 big-endian */
+	g_assert_cmphex(frame->data[75], ==, 0x04);
+	g_assert_cmphex(frame->data[76], ==, 0x00);
+
+	g_clear_pointer(&frame, g_byte_array_unref);
+	frame = fu_focal_moc_ymodem_build_data_v2(FU_FOCAL_MOC_FRAME_STX,
+						  0x1234,
+						  payload,
+						  sizeof(payload),
+						  &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(frame);
+	g_assert_cmpuint(frame->len, ==, FU_STRUCT_FOCAL_MOC_DATA_V2_SIZE);
+	g_assert_cmphex(frame->data[0], ==, FU_FOCAL_MOC_FRAME_STX);
+	g_assert_cmphex(frame->data[1], ==, 0x12);
+	g_assert_cmphex(frame->data[2], ==, 0x34);
+	g_assert_cmpmem(frame->data + 3, sizeof(payload), payload, sizeof(payload));
+	g_assert_cmphex(frame->data[3 + sizeof(payload)], ==, 0x00);
+
+	g_clear_pointer(&frame, g_byte_array_unref);
+	frame = fu_focal_moc_ymodem_build_data_v2(FU_FOCAL_MOC_FRAME_SOH,
+						  0x1234,
+						  payload,
+						  sizeof(payload),
+						  &error);
 	g_assert_null(frame);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
 }

--- a/plugins/focal-moc/fu-self-test.c
+++ b/plugins/focal-moc/fu-self-test.c
@@ -2,159 +2,203 @@
  * Copyright 2026 FocalTech Systems Co., Ltd.
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
+ * nocheck:magic-inlines=230
  */
 
 #include "config.h"
 
 #include "fu-focal-moc-common.h"
+#include "fu-focal-moc-struct.h"
 
 static void
 fu_focal_moc_packet_build_func(void)
 {
-	const guint8 payload[] = {0x01};
-	const guint8 expected[] = {0x02, 0x00, 0x02, 0x32, 0x01, 0x31};
-	g_autoptr(GByteArray) pkt = NULL;
+	const guint8 expected_version[] = {0x02, 0x00, 0x01, 0x30, 0x31};
+	const guint8 expected_probe[] = {0x02, 0x00, 0x01, 0x31, 0x30};
+	const guint8 expected_detach[] = {0x02, 0x00, 0x02, 0x32, 0x01, 0x31};
+	const guint8 mode = 0x01;
+	g_autoptr(GByteArray) packet = NULL;
 	g_autoptr(GError) error = NULL;
 
-	pkt = fu_focal_moc_packet_new(0x32, payload, sizeof(payload), &error);
-	g_assert_no_error(error);
-	g_assert_nonnull(pkt);
-	g_assert_cmpmem(pkt->data, pkt->len, expected, sizeof(expected));
-}
+	/* the BCC inside each captured frame is fu_xor8() over [LN..payload] */
+	g_assert_cmphex(fu_xor8(expected_version + 1, sizeof(expected_version) - 2),
+			==,
+			expected_version[sizeof(expected_version) - 1]);
+	g_assert_cmphex(fu_xor8(expected_probe + 1, sizeof(expected_probe) - 2),
+			==,
+			expected_probe[sizeof(expected_probe) - 1]);
+	g_assert_cmphex(fu_xor8(expected_detach + 1, sizeof(expected_detach) - 2),
+			==,
+			expected_detach[sizeof(expected_detach) - 1]);
 
-static void
-fu_focal_moc_packet_build_empty_func(void)
-{
-	const guint8 expected[] = {0x02, 0x00, 0x01, 0x30, 0x31};
-	g_autoptr(GByteArray) pkt = NULL;
-	g_autoptr(GError) error = NULL;
-
-	pkt = fu_focal_moc_packet_new(0x30, NULL, 0, &error);
+	packet = fu_focal_moc_packet_new(0x30, NULL, 0, &error);
 	g_assert_no_error(error);
-	g_assert_nonnull(pkt);
-	g_assert_cmpmem(pkt->data, pkt->len, expected, sizeof(expected));
+	g_assert_nonnull(packet);
+	g_assert_cmpmem(packet->data, packet->len, expected_version, sizeof(expected_version));
+
+	g_clear_pointer(&packet, g_byte_array_unref);
+	packet = fu_focal_moc_packet_new(FU_FOCAL_MOC_CMD_GET_FP_VERSION, NULL, 0, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(packet);
+	g_assert_cmpmem(packet->data, packet->len, expected_probe, sizeof(expected_probe));
+
+	g_clear_pointer(&packet, g_byte_array_unref);
+	packet = fu_focal_moc_packet_new(0x32, &mode, sizeof(mode), &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(packet);
+	g_assert_cmpmem(packet->data, packet->len, expected_detach, sizeof(expected_detach));
 }
 
 static void
 fu_focal_moc_packet_parse_func(void)
 {
-	const guint8 buf[] = {0x02, 0x00, 0x03, 0x04, 0xAA, 0xBB, 0x16};
-	const guint8 expected[] = {0xAA, 0xBB};
+	const guint8 response[] = {0x02, 0x00, 0x05, 0x04, 0x37, 0x32, 0x32, 0x35, 0x03, 0x00};
+	guint8 status = 0;
 	g_autoptr(GByteArray) data = NULL;
 	g_autoptr(GError) error = NULL;
 
-	data = fu_focal_moc_packet_parse(buf, sizeof(buf), &error);
+	/* the BCC inside the captured frame is fu_xor8() over [LN..payload] */
+	g_assert_cmphex(fu_xor8(response + 1, 7), ==, response[8]);
+
+	data = fu_focal_moc_packet_parse(response, sizeof(response), TRUE, &status, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(data);
-	g_assert_cmpmem(data->data, data->len, expected, sizeof(expected));
+	g_assert_cmphex(status, ==, 0x04);
+	g_assert_cmpmem(data->data, data->len, "7225", 4);
+
+	/* a zero-length USB read must set an error, not a GLib critical */
+	g_assert_null(fu_focal_moc_packet_parse(NULL, 0, TRUE, &status, &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
 }
 
 static void
-fu_focal_moc_packet_parse_padded_func(void)
+fu_focal_moc_packet_status_only_func(void)
 {
-	/* trailing padding must not be treated as payload */
-	const guint8 buf[] = {0x02, 0x00, 0x03, 0x04, 0xAA, 0xBB, 0x16, 0x00, 0x00, 0x00};
-	const guint8 expected[] = {0xAA, 0xBB};
+	/* an error status carries no payload: the parse must return an empty
+	 * array rather than NULL so the caller can decode the status */
+	const guint8 response[] = {0x02, 0x00, 0x01, 0x09, 0x08};
+	const guint8 response_zero_len[] = {0x02, 0x00, 0x00, 0x04, 0x04};
+	guint8 status = 0;
 	g_autoptr(GByteArray) data = NULL;
 	g_autoptr(GError) error = NULL;
 
-	data = fu_focal_moc_packet_parse(buf, sizeof(buf), &error);
+	g_assert_cmphex(fu_xor8(response + 1, 3), ==, response[4]);
+
+	data = fu_focal_moc_packet_parse(response, sizeof(response), FALSE, &status, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(data);
-	g_assert_cmpmem(data->data, data->len, expected, sizeof(expected));
-}
+	g_assert_cmpuint(data->len, ==, 0);
+	g_assert_cmphex(status, ==, FU_FOCAL_MOC_STATUS_INVALID_COMMAND);
 
-static void
-fu_focal_moc_packet_parse_bad_bcc_func(void)
-{
-	const guint8 buf[] = {0x02, 0x00, 0x03, 0x04, 0xAA, 0xBB, 0x17};
-	g_autoptr(GByteArray) data = NULL;
-	g_autoptr(GError) error = NULL;
-
-	data = fu_focal_moc_packet_parse(buf, sizeof(buf), &error);
+	/* a declared length of zero cannot even carry the status byte */
+	g_assert_null(fu_focal_moc_packet_parse(response_zero_len,
+						sizeof(response_zero_len),
+						FALSE,
+						&status,
+						&error));
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
-	g_assert_null(data);
 }
 
 static void
-fu_focal_moc_packet_parse_truncated_func(void)
+fu_focal_moc_packet_bad_bcc_func(void)
 {
-	const guint8 buf[] = {0x02, 0x00, 0x09, 0x04, 0xAA};
-	g_autoptr(GByteArray) data = NULL;
+	const guint8 response[] = {0x02, 0x00, 0x01, 0x04, 0x00};
+	guint8 status = 0;
 	g_autoptr(GError) error = NULL;
 
-	data = fu_focal_moc_packet_parse(buf, sizeof(buf), &error);
+	/* the trailing byte deliberately disagrees with the computed BCC */
+	g_assert_cmphex(fu_xor8(response + 1, 3), !=, response[4]);
+
+	g_assert_null(
+	    fu_focal_moc_packet_parse(response, sizeof(response), FALSE, &status, &error));
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
-	g_assert_null(data);
 }
 
 static void
-fu_focal_moc_packet_parse_nak_func(void)
+fu_focal_moc_packet_length_func(void)
 {
-	const guint8 buf[] = {0x02, 0x00, 0x01, 0x09, 0x08};
-	g_autoptr(GByteArray) data = NULL;
-	g_autoptr(GError) error = NULL;
-
-	data = fu_focal_moc_packet_parse(buf, sizeof(buf), &error);
-	g_assert_nonnull(error);
-	g_assert_null(data);
-}
-
-static void
-fu_focal_moc_packet_parse_zero_len_func(void)
-{
-	const guint8 buf[] = {0x02, 0x00, 0x00, 0x04, 0x04};
-	g_autoptr(GByteArray) data = NULL;
-	g_autoptr(GError) error = NULL;
-
-	data = fu_focal_moc_packet_parse(buf, sizeof(buf), &error);
-	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
-	g_assert_null(data);
-}
-
-static void
-fu_focal_moc_version_func(void)
-{
-	const struct {
-		const gchar *payload;
-		const gchar *version;
-		gboolean is_bootloader;
-	} tests[] = {
-	    {"FT9769DL_APP_FT9001_USB_DEC_SV0.1_7396", "7396", FALSE},
-	    {"FT9365_APP_FT9001_A27A_USB_DEC_SV0.1_7004", "7004", FALSE},
-	    {"FT9349_IAP_FT9001_A97A_USB_DEC_SV0.1_6704", "6704", TRUE},
-	    {"FT9349_APP_FT9001_A97A_USB_DEC_SV0.1_f132", "f132", FALSE},
+	const guint8 response[] = {0x02, 0x00, 0x05, 0x04, 0x37, 0x32, 0x32, 0x35, 0x03};
+	const guint8 response_trailing[] = {
+	    0x02,
+	    0x00,
+	    0x05,
+	    0x04,
+	    0x37,
+	    0x32,
+	    0x32,
+	    0x35,
+	    0x03,
+	    0x00,
 	};
+	const guint8 response_extra[] = {
+	    0x02,
+	    0x00,
+	    0x05,
+	    0x04,
+	    0x37,
+	    0x32,
+	    0x32,
+	    0x35,
+	    0x03,
+	    0x00,
+	    0x00,
+	};
+	guint8 status = 0;
+	g_autoptr(GByteArray) data = NULL;
+	g_autoptr(GError) error = NULL;
 
-	for (guint i = 0; i < G_N_ELEMENTS(tests); i++) {
-		gboolean is_bootloader = FALSE;
-		g_autofree gchar *version = NULL;
-		g_autoptr(GError) error = NULL;
+	g_assert_cmphex(fu_xor8(response + 1, 7), ==, response[8]);
 
-		version = fu_focal_moc_version_parse((const guint8 *)tests[i].payload,
-						     strlen(tests[i].payload),
-						     &is_bootloader,
-						     &error);
-		g_assert_no_error(error);
-		g_assert_cmpstr(version, ==, tests[i].version);
-		g_assert_cmpint(is_bootloader, ==, tests[i].is_bootloader);
-	}
+	data = fu_focal_moc_packet_parse(response, sizeof(response), FALSE, &status, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(data);
+
+	g_assert_null(fu_focal_moc_packet_parse(response_trailing,
+						sizeof(response_trailing),
+						FALSE,
+						&status,
+						&error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
+	g_clear_error(&error);
+
+	g_clear_pointer(&data, g_byte_array_unref);
+	data = fu_focal_moc_packet_parse(response_trailing,
+					 sizeof(response_trailing),
+					 TRUE,
+					 &status,
+					 &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(data);
+
+	g_assert_null(fu_focal_moc_packet_parse(response_extra,
+						sizeof(response_extra),
+						TRUE,
+						&status,
+						&error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
+	g_clear_error(&error);
+
+	g_assert_null(
+	    fu_focal_moc_packet_parse(response, sizeof(response) - 1, TRUE, &status, &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
 }
 
 static void
 fu_focal_moc_version_frame_func(void)
 {
 	/* the firmware writes the string by length, so the checksum sits hard
-	 * against the last character and only the padding after it would ever
-	 * act as a terminator */
+	 * against the last character, and one byte of stale buffer follows the
+	 * declared frame on protocol v1 */
 	const gchar *str = "FT9365_APP_FT9001_A27A_USB_DEC_SV0.1_7004";
 	gsize strsz = strlen(str);
 	gboolean is_bootloader = TRUE;
-	guint8 buf[64] = {0x02, 0x00, 0x00, 0x04};
+	guint8 buf[47] = {0x02, 0x00, 0x00, 0x04};
+	guint8 status = 0;
 	g_autofree gchar *version = NULL;
 	g_autoptr(GByteArray) data = NULL;
 	g_autoptr(GError) error = NULL;
 
+	g_assert_cmpuint(sizeof(buf), ==, 0x4 + strsz + 1 + 1);
 	fu_memwrite_uint16(buf + 0x1, strsz + 1, G_BIG_ENDIAN);
 	g_assert_true(
 	    fu_memcpy_safe(buf, sizeof(buf), 0x4, (const guint8 *)str, strsz, 0x0, strsz, &error));
@@ -163,9 +207,10 @@ fu_focal_moc_version_frame_func(void)
 	/* matches the checksum captured from real hardware */
 	g_assert_cmpuint(buf[0x4 + strsz], ==, 0x1b);
 
-	data = fu_focal_moc_packet_parse(buf, sizeof(buf), &error);
+	data = fu_focal_moc_packet_parse(buf, sizeof(buf), TRUE, &status, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(data);
+	g_assert_cmphex(status, ==, FU_FOCAL_MOC_STATUS_OK);
 	version = fu_focal_moc_version_parse(data->data, data->len, &is_bootloader, &error);
 	g_assert_no_error(error);
 	g_assert_cmpstr(version, ==, "7004");
@@ -173,28 +218,452 @@ fu_focal_moc_version_frame_func(void)
 }
 
 static void
-fu_focal_moc_version_invalid_func(void)
+fu_focal_moc_ymodem_frame_func(void)
 {
-	const gchar *tests[] = {
-	    "",						/* empty */
-	    "FT9349_FT9001_A97A_USB_DEC_SV0.1_6704",	/* no mode marker */
-	    "FT9349_APP_IAP_FT9001_USB_DEC_SV0.1_6704", /* both mode markers */
-	    "FT9349_APP_FT9001_A97A_USB_DEC_SV0.1_",	/* no build number */
-	    "FT9349_APP_FT9001_\xff\xff_SV0.1_6704",	/* not utf-8 */
+	const guint8 payload[] = {0xAA, 0xBB, 0xCC};
+	guint32 value = 0;
+	g_autoptr(GByteArray) frame = NULL;
+	g_autoptr(GError) error = NULL;
+
+	frame = fu_focal_moc_ymodem_build_soh(0x1234, 0x89ABCDEF, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(frame);
+	g_assert_cmpuint(frame->len, ==, FU_STRUCT_FOCAL_MOC_SOH_V1_SIZE);
+	g_assert_cmphex(frame->data[0], ==, FU_FOCAL_MOC_FRAME_SOH);
+	g_assert_cmphex(frame->data[1], ==, 0x00);
+	g_assert_cmpmem(frame->data + 2, 7, "app.bin", 7);
+	g_assert_true(
+	    fu_memread_uint32_safe(frame->data, frame->len, 66, &value, G_BIG_ENDIAN, &error));
+	g_assert_no_error(error);
+	g_assert_cmphex(value, ==, 0x1234);
+	g_assert_true(
+	    fu_memread_uint32_safe(frame->data, frame->len, 70, &value, G_BIG_ENDIAN, &error));
+	g_assert_no_error(error);
+	g_assert_cmphex(value, ==, 0x89ABCDEF);
+
+	g_clear_pointer(&frame, g_byte_array_unref);
+	frame = fu_focal_moc_ymodem_build_data(FU_FOCAL_MOC_FRAME_EOT,
+					       0xFF,
+					       payload,
+					       sizeof(payload),
+					       &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(frame);
+	g_assert_cmpuint(frame->len, ==, FU_STRUCT_FOCAL_MOC_DATA_V1_SIZE);
+	g_assert_cmphex(frame->data[0], ==, FU_FOCAL_MOC_FRAME_EOT);
+	g_assert_cmphex(frame->data[1], ==, 0xFF);
+	g_assert_cmpmem(frame->data + 2, sizeof(payload), payload, sizeof(payload));
+	g_assert_cmphex(frame->data[2 + sizeof(payload)], ==, 0x00);
+	g_assert_cmphex(frame->data[frame->len - 1], ==, 0x00);
+
+	g_clear_pointer(&frame, g_byte_array_unref);
+	frame = fu_focal_moc_ymodem_build_data(FU_FOCAL_MOC_FRAME_STX,
+					       0x100,
+					       payload,
+					       sizeof(payload),
+					       &error);
+	g_assert_null(frame);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
+}
+
+static void
+fu_focal_moc_ymodem_frame_plan_func(void)
+{
+	const struct {
+		gsize firmware_sz;
+		guint n_frames;
+		gsize last_sz;
+	} plans[] = {
+	    /* the sizes that bracket the decision: short, exact multiple, one
+	     * past a multiple, two exact frames, and the largest protocol v1
+	     * payload, whose last frame number must still fit its 8-bit field */
+	    {500, 1, 500},
+	    {FU_FOCAL_MOC_YMODEM_DATA_SIZE, 1, FU_FOCAL_MOC_YMODEM_DATA_SIZE},
+	    {FU_FOCAL_MOC_YMODEM_DATA_SIZE + 1, 2, 1},
+	    {FU_FOCAL_MOC_YMODEM_DATA_SIZE * 2, 2, FU_FOCAL_MOC_YMODEM_DATA_SIZE},
+	    {FU_FOCAL_MOC_YMODEM_DATA_SIZE * G_MAXUINT8, G_MAXUINT8, FU_FOCAL_MOC_YMODEM_DATA_SIZE},
 	};
 
-	for (guint i = 0; i < G_N_ELEMENTS(tests); i++) {
-		gboolean is_bootloader = FALSE;
-		g_autofree gchar *version = NULL;
+	for (guint i = 0; i < G_N_ELEMENTS(plans); i++) {
+		guint32 crc32 = G_MAXUINT32;
+		g_autofree guint8 *buf = g_malloc(plans[i].firmware_sz);
+		g_autoptr(FuChunk) chk = NULL;
+		g_autoptr(FuChunkArray) chunks = NULL;
+		g_autoptr(FuInputStream) stream = NULL;
+		g_autoptr(GByteArray) frame = NULL;
+		g_autoptr(GBytes) blob = NULL;
 		g_autoptr(GError) error = NULL;
 
-		version = fu_focal_moc_version_parse((const guint8 *)tests[i],
-						     strlen(tests[i]),
-						     &is_bootloader,
-						     &error);
-		g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
-		g_assert_null(version);
+		for (gsize j = 0; j < plans[i].firmware_sz; j++)
+			buf[j] = (guint8)(j * 7);
+		blob = g_bytes_new_take(g_steal_pointer(&buf), plans[i].firmware_sz);
+		stream = fu_memory_input_stream_new_from_bytes(blob);
+
+		/* the SOH advertises the same CRC the device computes over the image,
+		 * and the stream helper only matches fu_crc32() for this seed */
+		g_assert_true(fu_input_stream_compute_crc32(stream,
+							    FU_CRC_KIND_B32_STANDARD,
+							    &crc32,
+							    &error));
+		g_assert_no_error(error);
+		g_assert_cmphex(crc32,
+				==,
+				fu_crc32(FU_CRC_KIND_B32_STANDARD,
+					 g_bytes_get_data(blob, NULL),
+					 plans[i].firmware_sz));
+
+		/* the last chunk is sent as EOT, so an exact multiple of the frame
+		 * size must not gain an empty trailing frame */
+		chunks = fu_chunk_array_new_from_stream(stream,
+							FU_CHUNK_ADDR_OFFSET_NONE,
+							FU_CHUNK_PAGESZ_NONE,
+							FU_FOCAL_MOC_YMODEM_DATA_SIZE,
+							&error);
+		g_assert_no_error(error);
+		g_assert_nonnull(chunks);
+		g_assert_cmpuint(fu_chunk_array_length(chunks), ==, plans[i].n_frames);
+		chk = fu_chunk_array_index(chunks, plans[i].n_frames - 1, &error);
+		g_assert_no_error(error);
+		g_assert_nonnull(chk);
+		g_assert_cmpuint(fu_chunk_get_data_sz(chk), ==, plans[i].last_sz);
+
+		/* the write loop numbers frames from one, so the last frame of the
+		 * largest payload must still be a frame the protocol can address */
+		g_clear_pointer(&frame, g_byte_array_unref);
+		frame = fu_focal_moc_ymodem_build_data(FU_FOCAL_MOC_FRAME_EOT,
+						       plans[i].n_frames,
+						       fu_chunk_get_data(chk),
+						       fu_chunk_get_data_sz(chk),
+						       &error);
+		g_assert_no_error(error);
+		g_assert_nonnull(frame);
 	}
+}
+
+static void
+fu_focal_moc_version_func(void)
+{
+	const guint8 version_app[] = "FT9349_APP_FT9001_A97A_USB_ENC_SV0.1_7225";
+	const guint8 version_iap[] = "FT9349_IAP_FT9001_A97A_USB_ENC_SV1.0_7049";
+	const guint8 version_debug[] = "FT9349_APP_FT9001_A97A_USB_ENC_SV0.1_f132";
+	const gchar *version_invalid[] = {
+	    "",						/* empty */
+	    "FT9349_FT9001_A97A_USB_ENC_SV0.1_7225",	/* no mode marker */
+	    "FT9349_APP_IAP_FT9001_USB_ENC_SV0.1_7225", /* both mode markers */
+	    "FT9349_APP_FT9001_A97A_USB_ENC_SV0.1_",	/* no build number */
+	    "FT9349_APP_FT9001_\xff\xff_SV0.1_7225",	/* not utf-8 */
+	};
+	gboolean is_bootloader = FALSE;
+	g_autofree gchar *version = NULL;
+	g_autoptr(GError) error = NULL;
+
+	/* is_bootloader gates the IAP capability probe: a runtime device must
+	 * never be probed as its firmware always implements the command */
+	version = fu_focal_moc_version_parse(version_app,
+					     sizeof(version_app) - 1,
+					     &is_bootloader,
+					     &error);
+	g_assert_no_error(error);
+	g_assert_cmpstr(version, ==, "7225");
+	g_assert_false(is_bootloader);
+
+	g_clear_pointer(&version, g_free);
+	version = fu_focal_moc_version_parse(version_iap,
+					     sizeof(version_iap) - 1,
+					     &is_bootloader,
+					     &error);
+	g_assert_no_error(error);
+	g_assert_cmpstr(version, ==, "7049");
+	g_assert_true(is_bootloader);
+
+	/* internal debug builds prefix the build number with a letter */
+	g_clear_pointer(&version, g_free);
+	version = fu_focal_moc_version_parse(version_debug,
+					     sizeof(version_debug) - 1,
+					     &is_bootloader,
+					     &error);
+	g_assert_no_error(error);
+	g_assert_cmpstr(version, ==, "f132");
+	g_assert_false(is_bootloader);
+
+	for (guint i = 0; i < G_N_ELEMENTS(version_invalid); i++) {
+		gboolean is_bootloader_tmp = FALSE;
+		g_autofree gchar *version_tmp = NULL;
+		g_autoptr(GError) error_tmp = NULL;
+
+		version_tmp = fu_focal_moc_version_parse((const guint8 *)version_invalid[i],
+							 strlen(version_invalid[i]),
+							 &is_bootloader_tmp,
+							 &error_tmp);
+		g_assert_error(error_tmp, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
+		g_assert_null(version_tmp);
+	}
+
+	/* a zero-length USB read hands over a NULL buffer */
+	g_assert_null(fu_focal_moc_version_parse(NULL, 0, &is_bootloader, &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
+}
+
+static void
+fu_focal_moc_iap_status_layout_func(void)
+{
+	const guint8 payload_valid[] = "FT9349_Coating_V1.0";
+	const guint8 payload_binary[] = {0x46, 0x54, 0x01, 0x02};
+	guint8 payload_long[65] = {0};
+	FuFocalMocIapStatusLayout layout = FU_FOCAL_MOC_IAP_STATUS_LAYOUT_UNKNOWN;
+	g_autoptr(GError) error = NULL;
+
+	/* 0x04 with a valid sensor version: the unified status layout is confirmed */
+	g_assert_true(fu_focal_moc_iap_status_layout_from_probe(FU_FOCAL_MOC_STATUS_OK,
+								payload_valid,
+								sizeof(payload_valid) - 1,
+								&layout,
+								&error));
+	g_assert_no_error(error);
+	g_assert_cmpint(layout, ==, FU_FOCAL_MOC_IAP_STATUS_LAYOUT_ALIGNED);
+
+	/* 0x09: the command is not registered on older bootloaders, which stay
+	 * updatable using the legacy layout */
+	layout = FU_FOCAL_MOC_IAP_STATUS_LAYOUT_UNKNOWN;
+	g_assert_true(fu_focal_moc_iap_status_layout_from_probe(FU_FOCAL_MOC_STATUS_INVALID_COMMAND,
+								NULL,
+								0,
+								&layout,
+								&error));
+	g_assert_no_error(error);
+	g_assert_cmpint(layout, ==, FU_FOCAL_MOC_IAP_STATUS_LAYOUT_LEGACY);
+
+	/* 0x04 with an empty payload must not count as the new capability */
+	layout = FU_FOCAL_MOC_IAP_STATUS_LAYOUT_UNKNOWN;
+	g_assert_false(fu_focal_moc_iap_status_layout_from_probe(FU_FOCAL_MOC_STATUS_OK,
+								 NULL,
+								 0,
+								 &layout,
+								 &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
+	g_assert_cmpint(layout, ==, FU_FOCAL_MOC_IAP_STATUS_LAYOUT_UNKNOWN);
+	g_clear_error(&error);
+
+	/* 0x04 with a non-text payload must not count as the new capability */
+	g_assert_false(fu_focal_moc_iap_status_layout_from_probe(FU_FOCAL_MOC_STATUS_OK,
+								 payload_binary,
+								 sizeof(payload_binary),
+								 &layout,
+								 &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
+	g_assert_cmpint(layout, ==, FU_FOCAL_MOC_IAP_STATUS_LAYOUT_UNKNOWN);
+	g_clear_error(&error);
+
+	/* 0x04 with an oversized payload must not count as the new capability */
+	memset(payload_long, 'A', sizeof(payload_long));
+	g_assert_false(fu_focal_moc_iap_status_layout_from_probe(FU_FOCAL_MOC_STATUS_OK,
+								 payload_long,
+								 sizeof(payload_long),
+								 &layout,
+								 &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
+	g_assert_cmpint(layout, ==, FU_FOCAL_MOC_IAP_STATUS_LAYOUT_UNKNOWN);
+	g_clear_error(&error);
+
+	/* any other status leaves the capability unknown: fail closed */
+	g_assert_false(fu_focal_moc_iap_status_layout_from_probe(FU_FOCAL_MOC_STATUS_TIMEOUT,
+								 NULL,
+								 0,
+								 &layout,
+								 &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
+	g_assert_cmpint(layout, ==, FU_FOCAL_MOC_IAP_STATUS_LAYOUT_UNKNOWN);
+}
+
+static void
+fu_focal_moc_fp_version_func(void)
+{
+	const guint8 payload_dotted[] = "SV0.1_0104";
+	const guint8 payload_lead_space[] = "  7225";
+	const guint8 payload_trail_space[] = "7225  ";
+	const guint8 payload_space[] = "   ";
+	const guint8 payload_nul[] = "72\0garbage";
+	const guint8 payload_binary[] = "FT\x01\x02";
+	const guint8 payload_binary_first[] = "\x01"
+					      "7225";
+	const guint8 payload_junk[] = "\x01\x02\x03";
+	guint8 payload_max[64] = {0};
+	guint8 payload_over[sizeof(payload_max) + 1] = {0};
+	struct {
+		const gchar *name;
+		const guint8 *buf;
+		gsize bufsz;
+		const gchar *error_substr;
+	} cases[] = {
+	    {"dotted", payload_dotted, sizeof(payload_dotted) - 1, NULL},
+	    {"leading space", payload_lead_space, sizeof(payload_lead_space) - 1, NULL},
+	    {"trailing space", payload_trail_space, sizeof(payload_trail_space) - 1, NULL},
+	    {"embedded NUL", payload_nul, sizeof(payload_nul) - 1, NULL},
+	    {"maximum length", payload_max, sizeof(payload_max), NULL},
+	    {"whitespace only", payload_space, sizeof(payload_space) - 1, "empty"},
+	    {"all binary", payload_junk, sizeof(payload_junk) - 1, "empty"},
+	    {"no payload", NULL, 0, "empty"},
+	    {"too long", payload_over, sizeof(payload_over), "too long"},
+	    {"binary tail", payload_binary, sizeof(payload_binary) - 1, "not printable"},
+	    {"binary head",
+	     payload_binary_first,
+	     sizeof(payload_binary_first) - 1,
+	     "not printable"},
+	};
+
+	memset(payload_max, 'A', sizeof(payload_max));
+	memset(payload_over, 'A', sizeof(payload_over));
+	for (guint i = 0; i < G_N_ELEMENTS(cases); i++) {
+		gboolean ret;
+		g_autoptr(GError) error = NULL;
+
+		g_test_message("checking '%s'", cases[i].name);
+		ret = fu_focal_moc_fp_version_validate(cases[i].buf, cases[i].bufsz, &error);
+		if (cases[i].error_substr == NULL) {
+			g_assert_no_error(error);
+			g_assert_true(ret);
+			continue;
+		}
+		g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
+		g_assert_false(ret);
+		g_assert_nonnull(g_strstr_len(error->message, -1, cases[i].error_substr));
+	}
+}
+
+static void
+fu_focal_moc_iap_probe_required_func(void)
+{
+	/* only a bootloader is probed */
+	g_assert_true(fu_focal_moc_iap_probe_required(TRUE));
+
+	/* the runtime firmware always implements the command: never probe */
+	g_assert_false(fu_focal_moc_iap_probe_required(FALSE));
+}
+
+static void
+fu_focal_moc_status_error_func(void)
+{
+	g_autoptr(GByteArray) data = g_byte_array_new();
+	g_autoptr(GError) error = NULL;
+
+	/* unified layout: 0x07 is out-of-memory */
+	g_assert_false(fu_focal_moc_status_to_error(FU_FOCAL_MOC_STATUS_NO_MEMORY,
+						    "ctx",
+						    FWUPD_ERROR_NOT_SUPPORTED,
+						    TRUE,
+						    data,
+						    &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL);
+	g_assert_nonnull(g_strstr_len(error->message, -1, "out of memory"));
+	g_clear_error(&error);
+
+	/* unified layout: 0x08 is a command check failure */
+	g_assert_false(fu_focal_moc_status_to_error(FU_FOCAL_MOC_STATUS_CHECK_ERROR,
+						    "ctx",
+						    FWUPD_ERROR_NOT_SUPPORTED,
+						    TRUE,
+						    data,
+						    &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
+	g_assert_nonnull(g_strstr_len(error->message, -1, "check failed"));
+	g_clear_error(&error);
+
+	/* unified layout: 0x0a is an execution failure */
+	g_assert_false(fu_focal_moc_status_to_error(FU_FOCAL_MOC_STATUS_EXECUTION_FAILURE,
+						    "ctx",
+						    FWUPD_ERROR_NOT_SUPPORTED,
+						    TRUE,
+						    data,
+						    &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL);
+	g_assert_nonnull(g_strstr_len(error->message, -1, "execution failed"));
+	g_clear_error(&error);
+
+	/* legacy layout: 0x07/0x08/0x0a keep their raw code and context */
+	g_assert_false(fu_focal_moc_status_to_error(FU_FOCAL_MOC_STATUS_NO_MEMORY,
+						    "STX rejected",
+						    FWUPD_ERROR_NOT_SUPPORTED,
+						    FALSE,
+						    data,
+						    &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL);
+	g_assert_nonnull(g_strstr_len(error->message, -1, "STX rejected"));
+	g_assert_nonnull(g_strstr_len(error->message, -1, "status=0x07"));
+	g_assert_nonnull(g_strstr_len(error->message, -1, "legacy IAP status"));
+	g_assert_null(g_strstr_len(error->message, -1, "memory"));
+	g_clear_error(&error);
+
+	g_assert_false(fu_focal_moc_status_to_error(FU_FOCAL_MOC_STATUS_CHECK_ERROR,
+						    "ctx",
+						    FWUPD_ERROR_NOT_SUPPORTED,
+						    FALSE,
+						    data,
+						    &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL);
+	g_assert_nonnull(g_strstr_len(error->message, -1, "status=0x08"));
+	g_assert_null(g_strstr_len(error->message, -1, "check failed"));
+	g_clear_error(&error);
+
+	g_assert_false(fu_focal_moc_status_to_error(FU_FOCAL_MOC_STATUS_EXECUTION_FAILURE,
+						    "ctx",
+						    FWUPD_ERROR_NOT_SUPPORTED,
+						    FALSE,
+						    data,
+						    &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL);
+	g_assert_nonnull(g_strstr_len(error->message, -1, "status=0x0a"));
+	g_assert_nonnull(g_strstr_len(error->message, -1, "legacy IAP status"));
+	g_assert_null(g_strstr_len(error->message, -1, "execution"));
+	g_clear_error(&error);
+
+	/* unambiguous codes stay mapped even on the legacy layout */
+	g_assert_false(fu_focal_moc_status_to_error(FU_FOCAL_MOC_STATUS_INVALID_PARAMETER,
+						    "ctx",
+						    FWUPD_ERROR_NOT_SUPPORTED,
+						    FALSE,
+						    data,
+						    &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
+	g_assert_nonnull(g_strstr_len(error->message, -1, "invalid parameter"));
+	g_clear_error(&error);
+
+	g_assert_false(fu_focal_moc_status_to_error(FU_FOCAL_MOC_STATUS_TIMEOUT,
+						    "ctx",
+						    FWUPD_ERROR_NOT_SUPPORTED,
+						    FALSE,
+						    data,
+						    &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT);
+	g_clear_error(&error);
+
+	g_assert_false(fu_focal_moc_status_to_error(FU_FOCAL_MOC_STATUS_INVALID_COMMAND,
+						    "ctx",
+						    FWUPD_ERROR_NOT_SUPPORTED,
+						    FALSE,
+						    data,
+						    &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
+	g_assert_nonnull(g_strstr_len(error->message, -1, "invalid command"));
+	g_clear_error(&error);
+
+	/* firmware-transfer statuses keep their existing mapping in both layouts */
+	g_assert_false(fu_focal_moc_status_to_error(FU_FOCAL_MOC_STATUS_FIRMWARE_VERIFY,
+						    "ctx",
+						    FWUPD_ERROR_NOT_SUPPORTED,
+						    FALSE,
+						    data,
+						    &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_SIGNATURE_INVALID);
+	g_clear_error(&error);
+
+	g_assert_false(fu_focal_moc_status_to_error(FU_FOCAL_MOC_STATUS_FIRMWARE_FLASH,
+						    "ctx",
+						    FWUPD_ERROR_NOT_SUPPORTED,
+						    TRUE,
+						    data,
+						    &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_WRITE);
+	g_clear_error(&error);
 }
 
 int
@@ -202,15 +671,17 @@ main(int argc, char **argv)
 {
 	g_test_init(&argc, &argv, NULL);
 	g_test_add_func("/focal-moc/packet/build", fu_focal_moc_packet_build_func);
-	g_test_add_func("/focal-moc/packet/build-empty", fu_focal_moc_packet_build_empty_func);
 	g_test_add_func("/focal-moc/packet/parse", fu_focal_moc_packet_parse_func);
-	g_test_add_func("/focal-moc/packet/parse-padded", fu_focal_moc_packet_parse_padded_func);
-	g_test_add_func("/focal-moc/packet/bad-bcc", fu_focal_moc_packet_parse_bad_bcc_func);
-	g_test_add_func("/focal-moc/packet/truncated", fu_focal_moc_packet_parse_truncated_func);
-	g_test_add_func("/focal-moc/packet/nak", fu_focal_moc_packet_parse_nak_func);
-	g_test_add_func("/focal-moc/packet/zero-len", fu_focal_moc_packet_parse_zero_len_func);
+	g_test_add_func("/focal-moc/packet/status-only", fu_focal_moc_packet_status_only_func);
+	g_test_add_func("/focal-moc/packet/bad-bcc", fu_focal_moc_packet_bad_bcc_func);
+	g_test_add_func("/focal-moc/packet/length", fu_focal_moc_packet_length_func);
+	g_test_add_func("/focal-moc/ymodem/frame", fu_focal_moc_ymodem_frame_func);
+	g_test_add_func("/focal-moc/ymodem/frame-plan", fu_focal_moc_ymodem_frame_plan_func);
 	g_test_add_func("/focal-moc/version", fu_focal_moc_version_func);
 	g_test_add_func("/focal-moc/version/frame", fu_focal_moc_version_frame_func);
-	g_test_add_func("/focal-moc/version/invalid", fu_focal_moc_version_invalid_func);
+	g_test_add_func("/focal-moc/fp-version", fu_focal_moc_fp_version_func);
+	g_test_add_func("/focal-moc/iap-probe-required", fu_focal_moc_iap_probe_required_func);
+	g_test_add_func("/focal-moc/iap-status-layout", fu_focal_moc_iap_status_layout_func);
+	g_test_add_func("/focal-moc/status-error", fu_focal_moc_status_error_func);
 	return g_test_run();
 }

--- a/plugins/focal-moc/fu-self-test.c
+++ b/plugins/focal-moc/fu-self-test.c
@@ -8,6 +8,7 @@
 #include "config.h"
 
 #include "fu-focal-moc-common.h"
+#include "fu-focal-moc-firmware.h"
 #include "fu-focal-moc-struct.h"
 
 static void
@@ -666,10 +667,264 @@ fu_focal_moc_status_error_func(void)
 	g_clear_error(&error);
 }
 
+static GBytes *
+fu_focal_moc_build_firmware_sized(guint32 kind, guint32 body_sz)
+{
+	guint8 reserved1[28] = {0};
+	guint8 digest[32] = {0};
+	guint8 signature[64] = {0};
+	guint8 reserved2[112] = {0};
+	g_autoptr(GByteArray) buf = g_byte_array_new();
+
+	/* nonzero patterns prove the writer carries the fields, not the raw copy */
+	for (guint i = 0; i < sizeof(digest); i++)
+		digest[i] = (guint8)i;
+	for (guint i = 0; i < sizeof(signature); i++)
+		signature[i] = (guint8)(0x80 + i);
+	fu_byte_array_append_uint32(buf, 0x46574844, G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint32(buf, kind, G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint32(buf, 0x0104, G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint32(buf, body_sz, G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint32(buf, 0, G_LITTLE_ENDIAN);
+	g_byte_array_append(buf, reserved1, sizeof(reserved1));
+	g_byte_array_append(buf, digest, sizeof(digest));
+	g_byte_array_append(buf, signature, sizeof(signature));
+	g_byte_array_append(buf, reserved2, sizeof(reserved2));
+	fu_byte_array_set_size(buf, FU_STRUCT_FOCAL_MOC_FIRMWARE_HEADER_SIZE + body_sz, 0x0);
+	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+}
+
+static GBytes *
+fu_focal_moc_build_firmware(guint32 kind)
+{
+	return fu_focal_moc_build_firmware_sized(kind, 4);
+}
+
+static void
+fu_focal_moc_firmware_func(void)
+{
+	g_autoptr(FuFirmware) firmware = fu_focal_moc_firmware_new();
+	g_autoptr(GBytes) bytes = fu_focal_moc_build_firmware(FU_FOCAL_MOC_FIRMWARE_KIND_APP);
+	g_autoptr(GBytes) bytes_body = NULL;
+	g_autoptr(GBytes) bytes_written = NULL;
+	g_autoptr(FuInputStream) stream = fu_memory_input_stream_new_from_bytes(bytes);
+	g_autoptr(GError) error = NULL;
+
+	g_assert_true(
+	    fu_firmware_parse_stream(firmware, stream, 0, FU_FIRMWARE_PARSE_FLAG_NONE, &error));
+	g_assert_no_error(error);
+	g_assert_cmpstr(fu_firmware_get_version(firmware), ==, "0104");
+
+	/* the payload is the body without the header */
+	bytes_body = fu_firmware_get_bytes(firmware, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(bytes_body);
+	g_assert_cmpuint(g_bytes_get_size(bytes_body), ==, 4);
+
+	/* the writer rebuilds the header from the parsed fields */
+	bytes_written = fu_firmware_write(firmware, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(bytes_written);
+	g_assert_cmpmem(g_bytes_get_data(bytes_written, NULL),
+			g_bytes_get_size(bytes_written),
+			g_bytes_get_data(bytes, NULL),
+			g_bytes_get_size(bytes));
+}
+
+static void
+fu_focal_moc_firmware_xml_func(void)
+{
+	g_autofree gchar *filename = NULL;
+	g_autoptr(GError) error = NULL;
+
+	filename = g_test_build_filename(G_TEST_DIST, "tests", "focal-moc.builder.xml", NULL);
+	g_assert_true(
+	    fu_firmware_roundtrip_from_filename(filename,
+						"82d74338dcf189114871f15666e96b7471db3e82",
+						FU_FIRMWARE_BUILDER_FLAG_NONE,
+						&error));
+	g_assert_no_error(error);
+}
+
+static void
+fu_focal_moc_firmware_wrong_type_func(void)
+{
+	g_autoptr(FuFirmware) firmware = fu_focal_moc_firmware_new();
+	g_autoptr(GBytes) bytes = fu_focal_moc_build_firmware(0x01);
+	g_autoptr(FuInputStream) stream = fu_memory_input_stream_new_from_bytes(bytes);
+	g_autoptr(GError) error = NULL;
+
+	g_assert_false(
+	    fu_firmware_parse_stream(firmware, stream, 0, FU_FIRMWARE_PARSE_FLAG_NONE, &error));
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
+}
+
+static void
+fu_focal_moc_firmware_invalid_func(void)
+{
+	const struct {
+		gsize offset;
+		guint32 value;
+		FwupdError code;
+	} tests[] = {
+	    /* a bad magic is rejected by the struct parser, the rest by the field checks */
+	    {0, 0x00000000, FWUPD_ERROR_INVALID_DATA},
+	    {8, 0x00010000, FWUPD_ERROR_INVALID_FILE},
+	    {12, 0x00000005, FWUPD_ERROR_INVALID_FILE},
+	    {16, 0x00000004, FWUPD_ERROR_INVALID_FILE},
+	};
+
+	for (guint i = 0; i < G_N_ELEMENTS(tests); i++) {
+		g_autoptr(FuFirmware) firmware = fu_focal_moc_firmware_new();
+		g_autoptr(GBytes) bytes =
+		    fu_focal_moc_build_firmware(FU_FOCAL_MOC_FIRMWARE_KIND_APP);
+		g_autoptr(GByteArray) buf = g_bytes_unref_to_array(g_steal_pointer(&bytes));
+		g_autoptr(FuInputStream) stream = NULL;
+		g_autoptr(GError) error = NULL;
+
+		fu_memwrite_uint32(buf->data + tests[i].offset, tests[i].value, G_LITTLE_ENDIAN);
+		stream = fu_memory_input_stream_new_from_data(buf->data, buf->len, NULL);
+		g_assert_false(fu_firmware_parse_stream(firmware,
+							stream,
+							0,
+							FU_FIRMWARE_PARSE_FLAG_NONE,
+							&error));
+		g_assert_error(error, FWUPD_ERROR, (gint)tests[i].code);
+	}
+}
+
+static void
+fu_focal_moc_firmware_size_max_func(void)
+{
+	const gsize size_max = FU_FOCAL_MOC_FIRMWARE_SIZE_MAX;
+	const struct {
+		gsize streamsz;
+		gboolean valid;
+	} tests[] = {
+	    {size_max, TRUE},
+	    {size_max + 1, FALSE},
+	};
+
+	for (guint i = 0; i < G_N_ELEMENTS(tests); i++) {
+		gboolean ret;
+		g_autoptr(FuFirmware) firmware = fu_focal_moc_firmware_new();
+		g_autoptr(GBytes) bytes = fu_focal_moc_build_firmware_sized(
+		    FU_FOCAL_MOC_FIRMWARE_KIND_APP,
+		    (guint32)(tests[i].streamsz - FU_STRUCT_FOCAL_MOC_FIRMWARE_HEADER_SIZE));
+		g_autoptr(FuInputStream) stream = fu_memory_input_stream_new_from_bytes(bytes);
+		g_autoptr(GError) error = NULL;
+
+		ret = fu_firmware_parse_stream(firmware,
+					       stream,
+					       0,
+					       FU_FIRMWARE_PARSE_FLAG_NONE,
+					       &error);
+		g_assert_cmpint(ret, ==, tests[i].valid);
+		if (tests[i].valid)
+			g_assert_no_error(error);
+		else
+			g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
+	}
+}
+
+static void
+fu_focal_moc_firmware_strict_func(void)
+{
+	const struct {
+		gsize offset;
+		guint8 value;
+	} tests[] = {
+	    /* reserved regions must stay zero or a parse-write cycle would not
+	     * reproduce the file */
+	    {0x14, 0xAA},
+	    {0x95, 0x01},
+	};
+
+	for (guint i = 0; i < G_N_ELEMENTS(tests); i++) {
+		g_autoptr(FuFirmware) firmware = fu_focal_moc_firmware_new();
+		g_autoptr(GBytes) bytes =
+		    fu_focal_moc_build_firmware(FU_FOCAL_MOC_FIRMWARE_KIND_APP);
+		g_autoptr(GByteArray) buf = g_bytes_unref_to_array(g_steal_pointer(&bytes));
+		g_autoptr(FuInputStream) stream = NULL;
+		g_autoptr(GError) error = NULL;
+
+		buf->data[tests[i].offset] = tests[i].value;
+		stream = fu_memory_input_stream_new_from_data(buf->data, buf->len, NULL);
+		g_assert_false(fu_firmware_parse_stream(firmware,
+							stream,
+							0,
+							FU_FIRMWARE_PARSE_FLAG_NONE,
+							&error));
+		g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
+	}
+}
+
+static void
+fu_focal_moc_firmware_truncated_func(void)
+{
+	g_autoptr(FuFirmware) firmware = fu_focal_moc_firmware_new();
+	g_autoptr(GBytes) bytes = fu_focal_moc_build_firmware(FU_FOCAL_MOC_FIRMWARE_KIND_APP);
+	g_autoptr(FuInputStream) stream =
+	    fu_memory_input_stream_new_from_data(g_bytes_get_data(bytes, NULL), 128, NULL);
+	g_autoptr(GError) error = NULL;
+
+	g_assert_false(
+	    fu_firmware_parse_stream(firmware, stream, 0, FU_FIRMWARE_PARSE_FLAG_NONE, &error));
+	g_assert_nonnull(error);
+}
+
+static void
+fu_focal_moc_firmware_entry_offset_func(void)
+{
+	g_autoptr(FuFirmware) firmware = fu_focal_moc_firmware_new();
+	g_autoptr(GBytes) bytes = fu_focal_moc_build_firmware(FU_FOCAL_MOC_FIRMWARE_KIND_APP);
+	g_autoptr(GByteArray) buf = g_bytes_unref_to_array(g_steal_pointer(&bytes));
+	g_autoptr(GBytes) bytes_patched = NULL;
+	g_autoptr(GBytes) bytes_written = NULL;
+	g_autoptr(FuInputStream) stream = NULL;
+	g_autoptr(GError) error = NULL;
+
+	/* a nonzero entry offset must survive the parse-write cycle */
+	fu_memwrite_uint32(buf->data + 0x10, 0x2, G_LITTLE_ENDIAN);
+	bytes_patched = g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	stream = fu_memory_input_stream_new_from_bytes(bytes_patched);
+	g_assert_true(
+	    fu_firmware_parse_stream(firmware, stream, 0, FU_FIRMWARE_PARSE_FLAG_NONE, &error));
+	g_assert_no_error(error);
+	bytes_written = fu_firmware_write(firmware, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(bytes_written);
+	g_assert_cmpmem(g_bytes_get_data(bytes_written, NULL),
+			g_bytes_get_size(bytes_written),
+			g_bytes_get_data(bytes_patched, NULL),
+			g_bytes_get_size(bytes_patched));
+}
+
+static void
+fu_focal_moc_firmware_xml_invalid_func(void)
+{
+	const gchar *xmls[] = {
+	    "<firmware gtype=\"FuFocalMocFirmware\"><digest>zz</digest></firmware>",
+	    "<firmware gtype=\"FuFocalMocFirmware\"><digest>aabb</digest></firmware>",
+	    "<firmware gtype=\"FuFocalMocFirmware\"><signature>aabb</signature></firmware>",
+	};
+
+	for (guint i = 0; i < G_N_ELEMENTS(xmls); i++) {
+		g_autoptr(FuFirmware) firmware = NULL;
+		g_autoptr(GError) error = NULL;
+
+		firmware = fu_firmware_new_from_xml(xmls[i], &error);
+		g_assert_null(firmware);
+		g_assert_nonnull(error);
+	}
+}
+
 int
 main(int argc, char **argv)
 {
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
+	g_type_ensure(FU_TYPE_FOCAL_MOC_FIRMWARE);
 	g_test_add_func("/focal-moc/packet/build", fu_focal_moc_packet_build_func);
 	g_test_add_func("/focal-moc/packet/parse", fu_focal_moc_packet_parse_func);
 	g_test_add_func("/focal-moc/packet/status-only", fu_focal_moc_packet_status_only_func);
@@ -683,5 +938,15 @@ main(int argc, char **argv)
 	g_test_add_func("/focal-moc/iap-probe-required", fu_focal_moc_iap_probe_required_func);
 	g_test_add_func("/focal-moc/iap-status-layout", fu_focal_moc_iap_status_layout_func);
 	g_test_add_func("/focal-moc/status-error", fu_focal_moc_status_error_func);
+	g_test_add_func("/focal-moc/firmware/parse", fu_focal_moc_firmware_func);
+	g_test_add_func("/focal-moc/firmware/xml", fu_focal_moc_firmware_xml_func);
+	g_test_add_func("/focal-moc/firmware/wrong-type", fu_focal_moc_firmware_wrong_type_func);
+	g_test_add_func("/focal-moc/firmware/invalid", fu_focal_moc_firmware_invalid_func);
+	g_test_add_func("/focal-moc/firmware/size-max", fu_focal_moc_firmware_size_max_func);
+	g_test_add_func("/focal-moc/firmware/strict", fu_focal_moc_firmware_strict_func);
+	g_test_add_func("/focal-moc/firmware/truncated", fu_focal_moc_firmware_truncated_func);
+	g_test_add_func("/focal-moc/firmware/entry-offset",
+			fu_focal_moc_firmware_entry_offset_func);
+	g_test_add_func("/focal-moc/firmware/xml-invalid", fu_focal_moc_firmware_xml_invalid_func);
 	return g_test_run();
 }

--- a/plugins/focal-moc/meson.build
+++ b/plugins/focal-moc/meson.build
@@ -24,6 +24,7 @@ device_tests += files('tests/focal-moc.json')
 if get_option('tests')
   e = executable(
     'focal-moc-self-test',
+    rustgen.process('fu-focal-moc.rs'),
     sources: [
       'fu-self-test.c',
     ],

--- a/plugins/focal-moc/meson.build
+++ b/plugins/focal-moc/meson.build
@@ -10,6 +10,7 @@ plugin_builtin_focal_moc = static_library(
   sources: [
     'fu-focal-moc-common.c',
     'fu-focal-moc-device.c',
+    'fu-focal-moc-firmware.c',
     'fu-focal-moc-plugin.c',
   ],
   include_directories: plugin_incdirs,
@@ -22,6 +23,8 @@ plugin_builtins += plugin_builtin_focal_moc
 device_tests += files('tests/focal-moc.json')
 
 if get_option('tests')
+  install_data(['tests/focal-moc.builder.xml'],
+    install_dir: join_paths(installed_test_datadir, 'tests'))
   e = executable(
     'focal-moc-self-test',
     rustgen.process('fu-focal-moc.rs'),
@@ -30,7 +33,9 @@ if get_option('tests')
     ],
     include_directories: plugin_incdirs,
     dependencies: plugin_deps,
-    c_args: cargs,
+    c_args: cargs + [
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
     link_with: [
       plugin_libs,
       plugin_builtin_focal_moc,

--- a/plugins/focal-moc/meson.build
+++ b/plugins/focal-moc/meson.build
@@ -12,6 +12,7 @@ plugin_builtin_focal_moc = static_library(
     'fu-focal-moc-device.c',
     'fu-focal-moc-firmware.c',
     'fu-focal-moc-plugin.c',
+    'fu-focal-moc-signed-device.c',
     'fu-focal-moc-transport-impl.c',
     'fu-focal-moc-transport.c',
   ],

--- a/plugins/focal-moc/meson.build
+++ b/plugins/focal-moc/meson.build
@@ -12,6 +12,8 @@ plugin_builtin_focal_moc = static_library(
     'fu-focal-moc-device.c',
     'fu-focal-moc-firmware.c',
     'fu-focal-moc-plugin.c',
+    'fu-focal-moc-transport-impl.c',
+    'fu-focal-moc-transport.c',
   ],
   include_directories: plugin_incdirs,
   link_with: plugin_libs,
@@ -29,6 +31,7 @@ if get_option('tests')
     'focal-moc-self-test',
     rustgen.process('fu-focal-moc.rs'),
     sources: [
+      'fu-focal-moc-test-device.c',
       'fu-self-test.c',
     ],
     include_directories: plugin_incdirs,

--- a/plugins/focal-moc/tests/focal-moc.builder.xml
+++ b/plugins/focal-moc/tests/focal-moc.builder.xml
@@ -1,0 +1,7 @@
+<firmware gtype="FuFocalMocFirmware">
+  <version_raw>0x104</version_raw>
+  <entry_offset>0x0</entry_offset>
+  <digest>000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f</digest>
+  <signature>808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf</signature>
+  <data>aGVsbG8gd29ybGQ=</data>
+</firmware>

--- a/plugins/focal-moc/tests/focal-moc.json
+++ b/plugins/focal-moc/tests/focal-moc.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "url": "de9796f65f2a5c8927d0aea99e0fdf40b71db22d6da9663d3c8c063b2ae5bceb-FT9769DL_APP_FT9001_USB_DEC_SV0.1_7396.cab",
-      "emulation-url": "9c7a37cae5b6942acb3822e28cc74770b5431892aa483137e4d32da68f97ca49-focal-moc-emulation-FT9769-v7396.zip",
+      "emulation-url": "7b798cec687920a8c4bf2df9662682e9004675bdadf9b8a4f8453e1258340ffd-focal-moc-emulation-FT9769-v7396.zip",
       "components": [
         {
           "version": "7396",

--- a/plugins/focal-moc/tests/focal-moc.json
+++ b/plugins/focal-moc/tests/focal-moc.json
@@ -14,6 +14,19 @@
           ]
         }
       ]
+    },
+    {
+      "url": "87b2d06726d05935907061a3ba4dcce1955f6e44730131708d58279942deb7e2-FT9349_APP_FT9001_AA7A_USB_DEC_SV0.1_0104.cab",
+      "emulation-url": "b5b43df56bf5b918925b2e3c9b27dacabf9e012e6e0dcb58ea949425b4bd8331-focal-moc-emulation-AA7A-v0104.zip",
+      "components": [
+        {
+          "version": "0104",
+          "protocol": "com.focal.moc",
+          "guids": [
+            "847bfb91-b443-50a2-afe2-4530c06955b6"
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Reworked as four self-contained commits, each building and passing the
plugin self-tests on its own:

1. `focal-moc: Harden the protocol v1 update flow`
2. `focal-moc: Add the FWHD firmware format`
3. `focal-moc: Add the TransportSec session layer`
4. `focal-moc: Add FuFocalMocSignedDevice for the encrypted update protocol`

All review comments from the previous round are addressed; replies inline.
Both device generations replay their recorded emulations with
`fwupdmgr device-emulate`, and the v1 path also passed a full update on
FT9769 hardware.
