### PR TITLE
trivial: Allow other kinds of build daemon

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -181,7 +181,7 @@ DEBUG=1 fwupdmgr get-devices
 ## Build Options
 
 ### Common Meson Options
-- `-Dbuild=all|standalone|library` - What to build
+- `-Dbuild=dbus|standalone|library` - What to build
 - `-Dtests=true|false` - Enable/disable tests
 - `-Dplugin_*=enabled|disabled|auto` - Individual plugin control
 - `-Dsystemd=enabled|disabled|auto` - systemd integration

--- a/contrib/build-windows.sh
+++ b/contrib/build-windows.sh
@@ -19,7 +19,7 @@ meson setup .. \
     --sysconfdir="etc" \
     --libexecdir="bin" \
     --bindir="bin" \
-    -Dbuild=all \
+    -Dbuild=dbus \
     -Ddbus_socket_address="tcp:host=localhost,port=1341" \
     -Dman=false \
     -Dfish_completion=false \

--- a/contrib/ci/build_macos.sh
+++ b/contrib/ci/build_macos.sh
@@ -6,7 +6,7 @@ export PKG_CONFIG_PATH="/opt/homebrew/Cellar/readline/8.2.13/lib/pkgconfig:$PKG_
 
 mkdir -p build-macos && cd build-macos
 meson setup .. \
-    -Dbuild=all \
+    -Dbuild=dbus \
     -Ddbus_socket_address="unix:path=/var/run/fwupd.socket" \
     -Dman=false \
     -Dlibxmlb:gtkdoc=false \

--- a/contrib/ci/build_windows.sh
+++ b/contrib/ci/build_windows.sh
@@ -39,7 +39,7 @@ xvfb-run meson setup .. \
     --sysconfdir="etc" \
     --libexecdir="bin" \
     --bindir="bin" \
-    -Dbuild=all \
+    -Dbuild=dbus \
     -Dman=false \
     -Dtests=false \
     -Dbuildtype=release \

--- a/contrib/snap/snapcraft.yaml
+++ b/contrib/snap/snapcraft.yaml
@@ -108,7 +108,7 @@ parts:
         --prefix=/,
         -Defi_binary=false,
         -Ddocs=disabled,
-        -Dbuild=all,
+        -Dbuild=dbus,
         -Dintrospection=disabled,
         -Dman=false,
         -Dpython=/usr/bin/python3,

--- a/data/bash-completion/meson.build
+++ b/data/bash-completion/meson.build
@@ -19,7 +19,7 @@ if bashcomp.found()
     install_dir: completions_dir,
   )
 
-  if build_daemon
+  if build_daemon != 'none'
     configure_file(
       input: 'fwupdmgr',
       output: 'fwupdmgr',

--- a/data/meson.build
+++ b/data/meson.build
@@ -15,12 +15,12 @@ if get_option('tests')
   subdir('device-tests')
 endif
 
-if build_daemon
+if build_daemon == 'dbus'
   subdir('motd')
 endif
 
 if get_option('tests')
-  if build_daemon
+  if build_daemon != 'none'
     subdir('tests')
   endif
 endif
@@ -59,7 +59,7 @@ if get_option('metainfo')
   )
 endif
 
-if build_daemon
+if build_daemon == 'dbus'
   install_data(
     ['org.freedesktop.fwupd.conf'],
     install_tag: 'runtime',

--- a/data/tests/README.md
+++ b/data/tests/README.md
@@ -1,7 +1,7 @@
 # Installed tests
 
 A test suite that can be used to interact with a fake device is installed when
-configured with `-Dbuild=all` and `-Dtests=true`.
+configured with `-Dbuild=dbus` and `-Dtests=true`.
 
 The test files have been signed by the production LVFS instance, and are available here:
 

--- a/meson.build
+++ b/meson.build
@@ -234,15 +234,15 @@ add_project_arguments(
 )
 
 # sanity check
-if get_option('build') == 'all'
+if get_option('build') == 'dbus'
   build_standalone = true
-  build_daemon = true
+  build_daemon = 'dbus'
 elif get_option('build') == 'standalone'
   build_standalone = true
-  build_daemon = false
+  build_daemon = 'none'
 elif get_option('build') == 'library'
   build_standalone = false
-  build_daemon = false
+  build_daemon = 'none'
 endif
 
 prefix = get_option('prefix')
@@ -422,7 +422,7 @@ if polkit.found()
   endif
   conf.set_quoted ('POLKIT_ACTIONDIR', polkit.get_variable(pkgconfig: 'actiondir'))
 endif
-if build_daemon
+if build_daemon != 'none'
   if not polkit.found()
     warning('Polkit is disabled, the daemon will allow ALL client actions')
   endif
@@ -948,7 +948,7 @@ endif
 summary(
   {
     'fwupdtool': build_standalone,
-    'fwupd (daemon)': build_daemon,
+    'fwupd': build_daemon,
   },
   section: 'build targets',
   bool_yn: true,
@@ -976,7 +976,7 @@ summary(
   bool_yn: true,
 )
 
-if build_daemon
+if build_daemon != 'none'
   summary(
     {
       'bluez': bluez.allowed(),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -21,8 +21,8 @@ option(
 option(
   'build',
   type: 'combo',
-  choices: ['all', 'standalone', 'library'],
-  value: 'all',
+  choices: ['dbus', 'standalone', 'library'],
+  value: 'dbus',
   description: 'build type',
 )
 option(

--- a/src/fwupd-dbus.gresource.xml
+++ b/src/fwupd-dbus.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+ <gresource prefix="/org/freedesktop/fwupd">
+  <file preprocess="xml-stripblanks" compressed="true">org.freedesktop.fwupd.xml</file>
+ </gresource>
+</gresources>

--- a/src/fwupd.gresource.xml
+++ b/src/fwupd.gresource.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
- <gresource prefix="/org/freedesktop/fwupd">
-  <file preprocess="xml-stripblanks" compressed="true">org.freedesktop.fwupd.xml</file>
- </gresource>
+ <gresource prefix="/org/freedesktop/fwupd" />
 </gresources>

--- a/src/meson.build
+++ b/src/meson.build
@@ -122,17 +122,19 @@ fwupdcli = library(
   link_with: [fwupd, fwupdplugin],
 )
 
-dbus_interface = custom_target(
-  'fwupd-generate-dbus-interface',
-  input: 'org.freedesktop.fwupd.xml',
-  output: 'org.freedesktop.fwupd.xml',
-  command: [generate_dbus_interface, '@INPUT@', '@OUTPUT@'],
-  install: build_daemon,
-  install_tag: 'runtime',
-  install_dir: join_paths(datadir, 'dbus-1', 'interfaces'),
+if build_daemon == 'dbus'
+  dbus_interface = custom_target(
+    'fwupd-generate-dbus-interface',
+    input: 'org.freedesktop.fwupd.xml',
+    output: 'org.freedesktop.fwupd.xml',
+    command: [generate_dbus_interface, '@INPUT@', '@OUTPUT@'],
+    install: true,
+    install_tag: 'runtime',
+    install_dir: join_paths(datadir, 'dbus-1', 'interfaces'),
 )
+endif
 
-if build_daemon
+if build_daemon == 'dbus'
   executable(
     'fwupdmgr',
     sources: ['fu-dbus-cli.c', client_src],
@@ -145,12 +147,20 @@ if build_daemon
   )
 endif
 
-resources_src = gnome.compile_resources(
-  'fwupd-resources',
-  'fwupd.gresource.xml',
-  c_name: 'fu',
-  dependencies: [dbus_interface],
-)
+if build_daemon == 'dbus'
+  resources_src = gnome.compile_resources(
+    'fwupd-resources',
+    'fwupd-dbus.gresource.xml',
+    c_name: 'fu',
+    dependencies: [dbus_interface],
+  )
+else
+  resources_src = gnome.compile_resources(
+    'fwupd-resources',
+    'fwupd.gresource.xml',
+    c_name: 'fu',
+  )
+endif
 
 # generate a header file that allows us to instantiate the plugins without copy-pasting or
 # duplicating the meson build logic in the engine
@@ -211,7 +221,7 @@ executable(
   install_dir: bindir,
 )
 
-if build_daemon
+if build_daemon != 'none'
   if get_option('man')
     custom_target(
       'fwupdmgr.1',
@@ -290,15 +300,14 @@ if build_standalone
   endif
 endif
 
-if build_daemon
+# the StartServiceCtrlDispatcherA design is so different use a different source file
+if host_machine.system() == 'windows'
+  daemon_loader_src = 'fu-main-windows.c'
+else
+  daemon_loader_src = 'fu-main.c'
+endif
 
-  # the StartServiceCtrlDispatcherA design is so different use a different source file
-  if host_machine.system() == 'windows'
-    daemon_loader_src = 'fu-main-windows.c'
-  else
-    daemon_loader_src = 'fu-main.c'
-  endif
-
+if build_daemon == 'dbus'
   executable(
     'fwupd',
     fwupdengine_rs,


### PR DESCRIPTION
For Android we want to build the binder IPC versions of fwupd and fwupdmgr; it's pointless building the D-Bus versions as they won't work.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
