### PR TITLE
Add fwupd_client_add_connect_func() for future use

### DIFF
--- a/libfwupd/fwupd-client-test.c
+++ b/libfwupd/fwupd-client-test.c
@@ -10,6 +10,56 @@
 #include "fwupd-error.h"
 #include "fwupd-test.h"
 
+static gboolean
+fwupd_client_connect_success_cb(FwupdClient *self, gpointer user_data, GError **error)
+{
+	gboolean *run = (gboolean *)user_data;
+	*run = TRUE;
+	return TRUE;
+}
+
+static gboolean
+fwupd_client_connect_failure_cb(FwupdClient *self, gpointer user_data, GError **error)
+{
+	gboolean *run = (gboolean *)user_data;
+	*run = TRUE;
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_AC_POWER_REQUIRED, "ac needed");
+	return FALSE;
+}
+
+static void
+fwupd_client_connect_func(void)
+{
+	gboolean ret;
+	gboolean ran_func1 = FALSE;
+	gboolean ran_func2 = FALSE;
+	gboolean ran_func3 = FALSE;
+	g_autoptr(FwupdClient) client = fwupd_client_new();
+	g_autoptr(GError) error = NULL;
+
+	/* none */
+	ret = fwupd_client_run_connect_funcs(client, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* all success */
+	fwupd_client_add_connect_func(client, fwupd_client_connect_success_cb, &ran_func1, NULL);
+	ret = fwupd_client_run_connect_funcs(client, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_true(ran_func1);
+
+	/* 1 success, 1 failure (then abort) */
+	fwupd_client_add_connect_func(client, fwupd_client_connect_failure_cb, &ran_func2, NULL);
+	fwupd_client_add_connect_func(client, fwupd_client_connect_success_cb, &ran_func3, NULL);
+	ret = fwupd_client_run_connect_funcs(client, &error);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_AC_POWER_REQUIRED);
+	g_assert_false(ret);
+	g_assert_true(ran_func1);
+	g_assert_true(ran_func2);
+	g_assert_false(ran_func3);
+}
+
 static void
 fwupd_client_download_func(void)
 {
@@ -388,5 +438,6 @@ main(int argc, char **argv)
 		g_test_add_func("/fwupd/client/devices", fwupd_client_devices_func);
 	}
 	g_test_add_func("/fwupd/client/download", fwupd_client_download_func);
+	g_test_add_func("/fwupd/client/connect/func", fwupd_client_connect_func);
 	return g_test_run();
 }

--- a/libfwupd/fwupd-client-test.c
+++ b/libfwupd/fwupd-client-test.c
@@ -6,6 +6,7 @@
 
 #include "config.h"
 
+#include "fwupd-client-private.h"
 #include "fwupd-client-sync.h"
 #include "fwupd-error.h"
 #include "fwupd-test.h"
@@ -58,6 +59,68 @@ fwupd_client_connect_func(void)
 	g_assert_true(ran_func1);
 	g_assert_true(ran_func2);
 	g_assert_false(ran_func3);
+}
+
+typedef struct {
+	gboolean done_connect;
+	gboolean done_set_feature_flags;
+	FwupdFeatureFlags feature_flags;
+} FwupdClientImplHelper;
+
+static gboolean
+fwupd_client_impl_connect_cb(FwupdClient *self,
+			     gpointer user_data,
+			     GCancellable *cancellable,
+			     GError **error)
+{
+	FwupdClientImplHelper *helper = (FwupdClientImplHelper *)user_data;
+	helper->done_connect = TRUE;
+	return TRUE;
+}
+
+static gboolean
+fwupd_client_impl_set_feature_flags_cb(FwupdClient *self,
+				       FwupdFeatureFlags feature_flags,
+				       gpointer user_data,
+				       GCancellable *cancellable,
+				       GError **error)
+{
+	FwupdClientImplHelper *helper = (FwupdClientImplHelper *)user_data;
+	helper->done_set_feature_flags = TRUE;
+	helper->feature_flags = feature_flags;
+	return TRUE;
+}
+
+static void
+fwupd_client_sync_impl_func(void)
+{
+	gboolean ret;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(FwupdClient) client = fwupd_client_new();
+	FwupdClientSyncImpl impl = {
+	    .connect = fwupd_client_impl_connect_cb,
+	    .set_feature_flags = fwupd_client_impl_set_feature_flags_cb,
+	};
+	FwupdClientImplHelper helper = {};
+
+	fwupd_client_set_sync_impl(client, &impl, &helper, NULL);
+	ret = fwupd_client_connect(client, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_true(helper.done_connect);
+	g_assert_false(helper.done_set_feature_flags);
+
+	ret =
+	    fwupd_client_set_feature_flags(client, FWUPD_FEATURE_FLAG_SHOW_PROBLEMS, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_cmpint(helper.feature_flags, ==, FWUPD_FEATURE_FLAG_SHOW_PROBLEMS);
+	g_assert_true(helper.done_connect);
+	g_assert_true(helper.done_set_feature_flags);
+
+	ret = fwupd_client_reset_config(client, "daemon", NULL, &error);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
+	g_assert_false(ret);
 }
 
 static void
@@ -439,5 +502,6 @@ main(int argc, char **argv)
 	}
 	g_test_add_func("/fwupd/client/download", fwupd_client_download_func);
 	g_test_add_func("/fwupd/client/connect/func", fwupd_client_connect_func);
+	g_test_add_func("/fwupd/client/sync/impl", fwupd_client_sync_impl_func);
 	return g_test_run();
 }

--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -92,6 +92,7 @@ typedef struct {
 	GMutex download_items_mutex; /* for @download_items */
 	GPtrArray *download_items;   /* element-type FwupdClientDownloadItem */
 	FwupdClientSyncImpl impl;
+	GPtrArray *connect_items; /* element-type FwupdClientConnectItem */
 	gpointer impl_userdata;
 	GDestroyNotify impl_userdata_destroy; /* nullable */
 } FwupdClientPrivate;
@@ -107,6 +108,12 @@ typedef struct {
 	gchar *key;
 	gchar *value;
 } FwupdClientHwid;
+
+typedef struct {
+	FwupdClientConnectFunc func;
+	gpointer user_data;
+	GDestroyNotify user_data_destroy;
+} FwupdClientConnectItem;
 
 enum {
 	SIGNAL_CHANGED,
@@ -153,6 +160,16 @@ fwupd_client_hwid_free(FwupdClientHwid *hwid)
 	g_free(hwid->value);
 	g_free(hwid);
 }
+
+static void
+fwupd_client_connect_item_free(FwupdClientConnectItem *item)
+{
+	if (item->user_data_destroy != NULL)
+		item->user_data_destroy(item->user_data);
+	g_free(item);
+}
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(FwupdClientConnectItem, fwupd_client_connect_item_free)
 
 static void
 fwupd_client_curl_helper_free(FwupdCurlHelper *helper)
@@ -1059,12 +1076,41 @@ fwupd_client_curl_new(FwupdClient *self, GError **error)
 	return g_steal_pointer(&helper);
 }
 
+/**
+ * fwupd_client_run_connect_funcs:
+ * @self: a #FwupdClient
+ * @error: (nullable): optional return location for an error
+ *
+ * Manually runs functions to run after the connection has been completed. In the usual case, this
+ * function is called as the last step of fwupd_client_connect_async(), but must be called manually
+ * if the connect action is overridden by fwupd_client_set_sync_impl().
+ *
+ * Returns: %TRUE for success
+ *
+ * Since: 2.1.8
+ **/
+gboolean
+fwupd_client_run_connect_funcs(FwupdClient *self, GError **error)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE(self);
+
+	for (guint i = 0; i < priv->connect_items->len; i++) {
+		FwupdClientConnectItem *item = g_ptr_array_index(priv->connect_items, i);
+		if (!item->func(self, item->user_data, error))
+			return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
 static void
 fwupd_client_set_hints_cb(GObject *source, GAsyncResult *res, gpointer user_data)
 {
 	g_autoptr(GTask) task = G_TASK(user_data);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GVariant) val = NULL;
+	FwupdClient *self = g_task_get_source_object(task);
 
 	val = g_dbus_proxy_call_finish(G_DBUS_PROXY(source), res, &error);
 	if (val == NULL) {
@@ -1075,6 +1121,12 @@ fwupd_client_set_hints_cb(GObject *source, GAsyncResult *res, gpointer user_data
 			return;
 		}
 		fwupd_client_fixup_dbus_error(error);
+		g_task_return_error(task, g_steal_pointer(&error));
+		return;
+	}
+
+	/* any post-connect extra checks */
+	if (!fwupd_client_run_connect_funcs(self, &error)) {
 		g_task_return_error(task, g_steal_pointer(&error));
 		return;
 	}
@@ -7976,6 +8028,37 @@ fwupd_client_build_report_security(FwupdClient *self,
 }
 
 /**
+ * fwupd_client_add_connect_func:
+ * @self: a #FwupdClient
+ * @func: (not nullable) (scope notified) (closure user_data) (destroy user_data_destroy): a
+ * #FwupdClientConnectFunc
+ * @user_data: (nullable): userdata to use with both @func and @user_data_destroy
+ * @user_data_destroy: (nullable): function to destroy @user_data when @self is finalized
+ *
+ * Adds a function to run after the connection has been completed. For example, checking that
+ * the client version matches the daemon version.
+ *
+ * Since: 2.1.8
+ **/
+void
+fwupd_client_add_connect_func(FwupdClient *self,
+			      FwupdClientConnectFunc func,
+			      gpointer user_data,
+			      GDestroyNotify user_data_destroy)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE(self);
+	g_autoptr(FwupdClientConnectItem) item = g_new0(FwupdClientConnectItem, 1);
+
+	g_return_if_fail(FWUPD_IS_CLIENT(self));
+	g_return_if_fail(func != NULL);
+
+	item->func = func;
+	item->user_data = user_data;
+	item->user_data_destroy = user_data_destroy;
+	g_ptr_array_add(priv->connect_items, g_steal_pointer(&item));
+}
+
+/**
  * fwupd_client_set_sync_impl:
  * @self: a #FwupdClient
  * @impl: (not nullable): a #FwupdClientSyncImpl
@@ -8514,7 +8597,8 @@ fwupd_client_init(FwupdClient *self)
 	    g_hash_table_new_full(g_str_hash, g_str_equal, g_free, (GDestroyNotify)g_object_unref);
 	g_mutex_init(&priv->immediate_requests_mutex);
 	priv->hwids = g_ptr_array_new_with_free_func((GDestroyNotify)fwupd_client_hwid_free);
-
+	priv->connect_items =
+	    g_ptr_array_new_with_free_func((GDestroyNotify)fwupd_client_connect_item_free);
 	/* we get this one for free */
 	fwupd_client_add_hint(self, "locale", g_getenv("LANG"));
 }
@@ -8526,6 +8610,7 @@ fwupd_client_finalize(GObject *object)
 	FwupdClientPrivate *priv = GET_PRIVATE(self);
 
 	g_ptr_array_unref(priv->hwids);
+	g_ptr_array_unref(priv->connect_items);
 	g_clear_pointer(&priv->main_ctx, g_main_context_unref);
 	g_free(priv->user_agent);
 	g_free(priv->package_name);

--- a/libfwupd/fwupd-client.h
+++ b/libfwupd/fwupd-client.h
@@ -682,4 +682,28 @@ fwupd_client_set_sync_impl(FwupdClient *self,
 			   gpointer userdata,
 			   GDestroyNotify userdata_destroy) G_GNUC_NON_NULL(1);
 
+/**
+ * FwupdClientConnectFunc:
+ * @self: a #FwupdClient
+ * @user_data: (closure): user data
+ * @error: (nullable): optional return location for an error
+ *
+ * Functions to run when the client has connected. If any function returns with a failure then
+ * the connect method will fail and will need to be started again.
+ *
+ * Returns: %TRUE on success
+ */
+typedef gboolean (*FwupdClientConnectFunc)(FwupdClient *self,
+					   gpointer user_data,
+					   GError **error) G_GNUC_WARN_UNUSED_RESULT;
+
+void
+fwupd_client_add_connect_func(FwupdClient *self,
+			      FwupdClientConnectFunc func,
+			      gpointer user_data,
+			      GDestroyNotify user_data_destroy) G_GNUC_NON_NULL(1, 2);
+gboolean
+fwupd_client_run_connect_funcs(FwupdClient *self, GError **error) G_GNUC_WARN_UNUSED_RESULT
+    G_GNUC_NON_NULL(1);
+
 G_END_DECLS

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -1217,6 +1217,7 @@ LIBFWUPD_2.1.7 {
 
 LIBFWUPD_2.1.8 {
   global:
+    fwupd_client_add_connect_func;
     fwupd_client_download_bytes2;
     fwupd_client_download_bytes2_async;
     fwupd_client_download_bytes2_finish;
@@ -1224,5 +1225,6 @@ LIBFWUPD_2.1.8 {
     fwupd_client_emit_device_changed;
     fwupd_client_emit_device_removed;
     fwupd_client_emit_device_request;
+    fwupd_client_run_connect_funcs;
   local: *;
 } LIBFWUPD_2.1.7;

--- a/src/fu-engine-cli.c
+++ b/src/fu-engine-cli.c
@@ -6296,14 +6296,16 @@ fu_engine_cli_sync_impl_connect(FwupdClient *client,
 				GError **error)
 {
 	FuEngineCli *self = FU_ENGINE_CLI(user_data);
-	return fu_engine_cli_start_engine(
-	    self,
-	    FU_ENGINE_LOAD_FLAG_COLDPLUG | FU_ENGINE_LOAD_FLAG_EXTERNAL_PLUGINS |
-		FU_ENGINE_LOAD_FLAG_BUILTIN_PLUGINS | FU_ENGINE_LOAD_FLAG_PATH_STORE_DEFAULTS |
-		FU_ENGINE_LOAD_FLAG_HWINFO | FU_ENGINE_LOAD_FLAG_REMOTES |
-		FU_ENGINE_LOAD_FLAG_HISTORY,
-	    self->progress,
-	    error);
+	if (!fu_engine_cli_start_engine(
+		self,
+		FU_ENGINE_LOAD_FLAG_COLDPLUG | FU_ENGINE_LOAD_FLAG_EXTERNAL_PLUGINS |
+		    FU_ENGINE_LOAD_FLAG_BUILTIN_PLUGINS | FU_ENGINE_LOAD_FLAG_PATH_STORE_DEFAULTS |
+		    FU_ENGINE_LOAD_FLAG_HWINFO | FU_ENGINE_LOAD_FLAG_REMOTES |
+		    FU_ENGINE_LOAD_FLAG_HISTORY,
+		self->progress,
+		error))
+		return FALSE;
+	return fwupd_client_run_connect_funcs(client, error);
 }
 
 static GPtrArray *


### PR DESCRIPTION
The idea here is that we can add functions to check the client connection, for instance checking that the client version matches the daemon version.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
