### PR TITLE
Limit decompressing LZMA streams to 2GiB

### DIFF
--- a/libfwupdplugin/fu-lzma-common.c
+++ b/libfwupdplugin/fu-lzma-common.c
@@ -8,6 +8,7 @@
 
 #include <lzma.h>
 
+#include "fu-common.h"
 #include "fu-lzma-common.h"
 
 /**
@@ -50,6 +51,10 @@ fu_lzma_decompress_bytes(GBytes *blob, guint64 memlimit, GError **error)
 		rc = lzma_code(&strm, LZMA_RUN);
 		if (rc != LZMA_OK && rc != LZMA_STREAM_END)
 			break;
+		if (buf->len + tmpbufsz > 2 * FU_GB) {
+			rc = LZMA_BUF_ERROR;
+			break;
+		}
 		g_byte_array_append(buf, tmpbuf, tmpbufsz - strm.avail_out);
 	} while (rc == LZMA_OK);
 	lzma_end(&strm);


### PR DESCRIPTION
The fuzzer has found a way to explode 320KiB into more than 2GiB, which exceeds the allowed size of a GByteArray.

Fixes https://issues.oss-fuzz.com/issues/544203407

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
