### PR TITLE
rust: Fix clippy -Dpedantic warnings

### DIFF
--- a/rust/fwupd-ffi/src/glib/gerror.rs
+++ b/rust/fwupd-ffi/src/glib/gerror.rs
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
-//! Minimal GError FFI helpers for setting errors from Rust.
+//! Minimal `GError` FFI helpers for setting errors from Rust.
 
 use std::ffi::CString;
 use std::os::raw::{c_char, c_int};
 
-/// GError -- must match the GLib GError struct layout
+/// `GError` -- must match the `GLib` `GError` struct layout
 #[repr(C)]
 pub struct GError {
     pub domain: u32,
@@ -18,7 +18,7 @@ pub struct GError {
 }
 
 impl GError {
-    /// Generic setter for a GError from an error code and a message.
+    /// Generic setter for a `GError` from an error code and a message.
     #[allow(dead_code)]
     pub(crate) unsafe fn set(error: *mut *mut GError, error_code: u32, msg: &str) {
         if error.is_null() {
@@ -28,17 +28,15 @@ impl GError {
         let c_msg =
             CString::new(msg).unwrap_or_else(|_| CString::new("(invalid error message)").unwrap());
         unsafe {
-            g_set_error_literal(
-                error,
-                fwupd_error_quark(),
-                error_code as c_int,
-                c_msg.as_ptr(),
-            );
+            // clippy wants error_code.cast_signed() but that requires Rust 1.87.0
+            #[allow(clippy::cast_possible_wrap)]
+            let glib_error_code = error_code as c_int;
+            g_set_error_literal(error, fwupd_error_quark(), glib_error_code, c_msg.as_ptr());
         }
     }
 }
 
-/// Opaque GQuark (a guint32 in GLib).
+/// Opaque `GQuark` (a guint32 in `GLib`).
 type GQuark = u32;
 
 #[allow(dead_code)]

--- a/rust/fwupd-ffi/src/glib/gstring.rs
+++ b/rust/fwupd-ffi/src/glib/gstring.rs
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
-//! Minimal GString FFI helpers for returning GLib strings from Rust.
+//! Minimal `GString` FFI helpers for returning `GLib` strings from Rust.
 
 use std::ffi::CString;
 use std::os::raw::c_char;
 
-/// Opaque GString -- matches the GLib `GString` struct layout.
+/// Opaque `GString` -- matches the `GLib` `GString` struct layout.
 #[repr(C)]
 pub struct GString {
     pub str_: *mut c_char,
@@ -27,13 +27,15 @@ impl GString {
     /// Create a new `GString *` from a Rust string.
     ///
     /// The returned `GString` is owned by the caller and must be freed accordingly.
+    ///
+    /// # Panics
+    /// This function panics if `s` contains a null byte.
+    #[must_use]
     pub fn from_rust_string(s: &str) -> *mut GString {
         let cs = CString::new(s).expect("Unexpected null byte in string");
         unsafe {
             let gstr = g_string_new(cs.as_ptr());
-            if gstr.is_null() {
-                panic!("g_string_new() returned NULL");
-            }
+            assert!(!gstr.is_null(), "g_string_new() returned NULL");
             gstr
         }
     }

--- a/rust/fwupd-ffi/src/glib/mod.rs
+++ b/rust/fwupd-ffi/src/glib/mod.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
-//! GLib FFI helpers
+//! `GLib` FFI helpers
 
 mod gerror;
 mod gstring;
@@ -12,9 +12,9 @@ mod gstring;
 pub use gerror::*;
 pub use gstring::*;
 
-/// GLib gboolean TRUE
+/// `GLib` gboolean TRUE
 pub const GTRUE: i32 = 1;
-/// GLib gboolean FALSE
+/// `GLib` gboolean FALSE
 pub const GFALSE: i32 = 0;
 
 pub const G_SEEK_CUR: i32 = 0;


### PR DESCRIPTION
- Use backticks around GLib types in docs
- `as cint` → `.cast_signed()`
- `if { panic! }` → `assert!`
- `#[must_use]` docs together with a `# Panics` doc section

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Prep work for #10819, cc @tmuehlbacher-bnr

