### PR TITLE
modem-manager: Add quirks for Rolling RW101 modules

### DIFF
--- a/plugins/modem-manager/modem-manager.quirk
+++ b/plugins/modem-manager/modem-manager.quirk
@@ -226,3 +226,17 @@ GType = FuMmFastbootDevice
 Summary = Rolling RW101-GL Module
 Flags = uninhibit-modemmanager-after-fastboot-reboot,detach-at-fastboot-has-no-response
 CounterpartGuid = USB\VID_33F8&PID_D00D
+
+# Rolling RW101 Debug
+[USB\VID_33F8&PID_01a8]
+GType = FuMmFastbootDevice
+Summary = Rolling RW101-GL Module
+Flags = uninhibit-modemmanager-after-fastboot-reboot,detach-at-fastboot-has-no-response
+CounterpartGuid = USB\VID_33F8&PID_D00D
+
+# Rolling RW101-CAT12 Debug
+[USB\VID_33F8&PID_01a9]
+GType = FuMmFastbootDevice
+Summary = Rolling RW101-GL Module
+Flags = uninhibit-modemmanager-after-fastboot-reboot,detach-at-fastboot-has-no-response
+CounterpartGuid = USB\VID_33F8&PID_D00D

--- a/plugins/modem-manager/modem-manager.quirk
+++ b/plugins/modem-manager/modem-manager.quirk
@@ -237,6 +237,6 @@ CounterpartGuid = USB\VID_33F8&PID_D00D
 # Rolling RW101-CAT12 Debug
 [USB\VID_33F8&PID_01a9]
 GType = FuMmFastbootDevice
-Summary = Rolling RW101-GL Module
+Summary = Rolling RW101-GL-12 Module
 Flags = uninhibit-modemmanager-after-fastboot-reboot,detach-at-fastboot-has-no-response
 CounterpartGuid = USB\VID_33F8&PID_D00D


### PR DESCRIPTION
Add support for Rolling RW101-GL and RW101-CAT12 modules:
- PID 0x01A8: Rolling RW101 (debug mode)
- PID 0x01A9: Rolling RW101-CAT12 (debug mode)

All use FuMmFastbootDevice type with appropriate flags.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation


---
