### PR TITLE
contrib: Disable Python deprecation warnings in test-venv.sh

### DIFF
--- a/contrib/test-venv.sh
+++ b/contrib/test-venv.sh
@@ -13,6 +13,7 @@ export GI_TYPELIB_PATH=${BUILD}/libfwupd
 export LD_LIBRARY_PATH=${BUILD}/libfwupd
 export DAEMON_BUILDDIR=${BUILD}/src
 export PATH=${VENV}/bin:$PATH
+export PYTHONWARNINGS="ignore::DeprecationWarning:gi.events"
 
 echo "Build time test suite"
 meson test -C "${BUILD}" "$@"


### PR DESCRIPTION
```
  /usr/lib64/python3.14/site-packages/gi/events.py:890: DeprecationWarning:
     'asyncio.get_event_loop_policy' is deprecated and slated for removal in Python 3.16
```
Repeated 376179 times which seems a tad excessive.

---

We have this set in the CI but it doesn't seem to feed into all the jobs and I got quite upset about the log spam locally. Happy to take a suggestion on where to better put this.


Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
