### PR TITLE
pixart-rf: bound the wireless model-name read in to_string

### DIFF
--- a/plugins/pixart-rf/fu-pixart-rf-wireless-device.c
+++ b/plugins/pixart-rf/fu-pixart-rf-wireless-device.c
@@ -29,8 +29,10 @@ static void
 fu_pixart_rf_wireless_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuPixartRfWirelessDevice *self = FU_PIXART_RF_WIRELESS_DEVICE(device);
+	g_autofree gchar *model_name =
+	    fu_strsafe((const gchar *)self->model.name, sizeof(self->model.name));
 	fu_pixart_rf_ota_fw_state_to_string(&self->fwstate, idt, str);
-	fwupd_codec_string_append(str, idt, "ModelName", (gchar *)self->model.name);
+	fwupd_codec_string_append(str, idt, "ModelName", model_name);
 	fwupd_codec_string_append_hex(str, idt, "ModelType", self->model.type);
 	fwupd_codec_string_append_hex(str, idt, "ModelTarget", self->model.target);
 }


### PR DESCRIPTION
**Unbounded model-name read in wireless to_string**

`fu_pixart_rf_wireless_device_to_string()` hands the raw `model.name` field straight to `fwupd_codec_string_append()`, which walks it as a NUL-terminated string. The 12 bytes are copied verbatim from the receiver in `fu_pixart_rf_wireless_device_new()` with no terminator, so a device reporting a full 12-byte name makes the printer run past the field into the neighbouring `type`/`target` members and report a corrupted ModelName.

The receiver and BLE paths already bound the same buffer with `g_strndup()`; this printer was the one spot left reading it raw. Wrapped it in `fu_strsafe()` so the read stays inside the field. Behaviour is unchanged for a name that already carries a terminator.