### PR TITLE
emmc: Fix error recovery command when setting install mode fails

### DIFF
--- a/plugins/emmc/fu-emmc-device.c
+++ b/plugins/emmc/fu-emmc-device.c
@@ -563,7 +563,7 @@ fu_emmc_device_write_firmware(FuDevice *device,
 			g_prefix_error_literal(error, "multi-cmd failed setting install mode: ");
 			if (!fu_ioctl_execute(ioctl,
 					      MMC_IOC_CMD,
-					      (guint8 *)&multi_cmd->cmds[2],
+					      (guint8 *)&multi_cmd->cmds[3],
 					      sizeof(struct mmc_ioc_cmd),
 					      NULL,
 					      FU_EMMC_DEVICE_IOCTL_TIMEOUT,


### PR DESCRIPTION
When setting install mode fails, fwupd attempts to exit FFU mode by executing a single MMC_IOC_CMD to switch the device back to normal mode.

Commit e1c74bc5c418 ("emmc: let FFU use close-ended mode") inserted MMC_SET_BLOCK_COUNT at cmds[1], shifting MMC_WRITE_MULTIPLE_BLOCK to cmds[2] and the normal mode switch to cmds[3].

While it updated the error fallback in the chunk write loop to execute cmds[3], the install mode error recovery was missed and still referenced cmds[2], which points to MMC_WRITE_MULTIPLE_BLOCK instead of the normal mode switch.

Fix this by properly executing cmds[3] on failure.

Type of pull request:
- [x] Code fix

