### PR TITLE
Expand our helper scripts with some functionality

### DIFF
--- a/contrib/build-venv.sh
+++ b/contrib/build-venv.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 # shellcheck disable=SC1091

--- a/contrib/setup
+++ b/contrib/setup
@@ -10,6 +10,49 @@ HELPER_ARGS=""
 INSTALL_BUILD_DEPS="n"
 SETUP_PRE_PUSH="n"
 
+howto() {
+    echo ""
+    echo "To enter fwupd development environment run:"
+    echo ""
+    echo "# source venv/bin/activate"
+    echo ""
+}
+
+instructions() {
+    cat <<'EOF'
+echo "To build or rebuild fwupd within development environment run:"
+echo ""
+echo "# build-fwupd"
+echo ""
+echo "To run the test suite run:"
+echo ""
+echo "# test-fwupd"
+echo ""
+echo "To run any tool under gdbserver add DEBUG=1 to env, for example:"
+echo ""
+echo "# DEBUG=1 fwupdtool get-devices"
+echo ""
+echo "To leave fwupd development environment run:"
+echo ""
+echo "# deactivate"
+EOF
+}
+
+usage() {
+    echo "Usage: $(basename "$0") [OPTIONS]"
+    echo ""
+    echo "Set up the fwupd build"
+    echo ""
+    echo "OPTIONS:"
+    echo "  --debug                   ... enable debugging output"
+    echo "  --help                    ... print this help"
+    echo "  --os=[fedora|ubuntu|...]  ... the operating system to set up the build for."
+    echo ""
+    echo "Once set up, the following commands become available:"
+    howto
+    instructions | bash
+}
+
 setup_deps() {
     if [ "$INSTALL_BUILD_DEPS" = "y" ]; then
         case $OS in
@@ -84,23 +127,8 @@ setup_virtualenv() {
     fi
     # shellcheck disable=SC1091
     source "${VENV}/bin/activate"
+    instructions >>"${VENV}/bin/activate"
     cat >>"${VENV}/bin/activate" <<EOF
-echo "To build or rebuild fwupd within development environment run:"
-echo ""
-echo "# build-fwupd"
-echo ""
-echo "To run the test suite run:"
-echo ""
-echo "# test-fwupd"
-echo ""
-echo "To run any tool under gdbserver add DEBUG=1 to env, for example:"
-echo ""
-echo "# DEBUG=1 fwupdtool get-devices"
-echo ""
-echo "To leave fwupd development environment run:"
-echo ""
-echo "# deactivate"
-
 if [ -n "\$BASH_VERSION" ]; then
     . data/bash-completion/fwupdtool
     . data/bash-completion/fwupdmgr
@@ -141,20 +169,7 @@ check_meson() {
 }
 
 detect_os() {
-    for i in "$@"; do
-        case $i in
-        --os=*)
-            OS="${i#*=}"
-            shift
-            ;;
-        --debug)
-            DEBUG=1
-            shift
-            ;;
-        *) ;;
-        esac
-    done
-    if [ -z "$OS" ]; then
+    if [ -z "${OS:-}" ]; then
         OS="$(python3 "$HELPER" detect-profile)"
         if [ -z "$OS" ]; then
             install_pip distro
@@ -166,18 +181,28 @@ detect_os() {
         HELPER_ARGS="$HELPER_ARGS --os $OS"
     fi
     if [ -n "$DEBUG" ]; then
-        set -x
         HELPER_ARGS="$HELPER_ARGS --debug"
     fi
 }
 
-howto() {
-    echo ""
-    echo "To enter fwupd development environment run:"
-    echo ""
-    echo "# source venv/bin/activate"
-    echo ""
-}
+for i in "$@"; do
+    case $i in
+    --os=*)
+        OS="${i#*=}"
+        shift
+        ;;
+    --debug)
+        set -x
+        DEBUG=1
+        shift
+        ;;
+    -h | --help)
+        usage
+        exit 0
+        ;;
+    *) ;;
+    esac
+done
 
 #already setup
 if [ -f venv/bin/build-fwupd ]; then
@@ -193,7 +218,7 @@ if [ -z "$PYTHON_VERSION" ]; then
 fi
 
 #needed for arguments for some commands
-detect_os "$@"
+detect_os
 
 #if interactive install build deps and prepare environment
 if [ -n "$CI" ]; then

--- a/contrib/setup
+++ b/contrib/setup
@@ -18,6 +18,10 @@ else
     R=""
 fi
 
+task() {
+    echo -e "${B}[$0]${R} $*"
+}
+
 howto() {
     echo -e ""
     echo -e "To enter fwupd development environment run:"
@@ -106,14 +110,14 @@ setup_vscode() {
         TEMPLATE="${SOURCED}/${f}"
         TARGETF="${TARGETD}/${f}"
         mkdir -p "${TARGETD}"
-        echo "Copy ${TEMPLATE} to ${TARGETF}."
+        task "Copy ${TEMPLATE} to ${TARGETF}."
         cp "${TEMPLATE}" "${TARGETF}"
     done
 }
 
 setup_git() {
     if [ -z "$CI" ]; then
-        echo "Configuring git environment"
+        task "Configuring git environment"
         git config include.path ../.gitconfig
     fi
 }
@@ -130,7 +134,7 @@ install_pip() {
 
 setup_virtualenv() {
     VENV="${PWD}/venv"
-    echo "Setting up virtualenv in ${VENV}"
+    task "Setting up virtualenv in ${VENV}"
     if [ "$OS" = "nixos" ]; then
         python3 -m venv "${VENV}" --prompt fwupd
         touch "${VENV}/.nixos"
@@ -154,7 +158,7 @@ EOF
 
 setup_precommit() {
     if [ -z "$CI" ]; then
-        echo "Configuring pre-commit hooks"
+        task "Configuring pre-commit hooks"
         install_pip pre-commit
         pre-commit install
     fi
@@ -257,4 +261,5 @@ setup_precommit
 #needs to be after pre-commit is sourced
 setup_prepush
 
+task "Setup complete"
 howto

--- a/contrib/setup
+++ b/contrib/setup
@@ -7,16 +7,20 @@ cd "$(dirname "$0")/.."
 
 HELPER=./contrib/ci/fwupd_setup_helpers.py
 HELPER_ARGS=""
+INSTALL_BUILD_DEPS="n"
+SETUP_PRE_PUSH="n"
 
 setup_deps() {
-    if [ -z "$CI" ]; then
-        read -rp "Install build dependencies? (y/N) " question
-    else
-        question=y
-    fi
-    if [ "$question" = "y" ]; then
-        # shellcheck disable=SC2086
-        python3 "$HELPER" install-dependencies $HELPER_ARGS -y
+    if [ "$INSTALL_BUILD_DEPS" = "y" ]; then
+        case $OS in
+        debian | ubuntu | arch | fedora | darwin | freebsd)
+            # shellcheck disable=SC2086
+            python3 "$HELPER" install-dependencies $HELPER_ARGS -y
+            ;;
+        nixos)
+            echo "NixOS detected, using nix-shell for build dependencies"
+            ;;
+        esac
     fi
 }
 
@@ -114,13 +118,10 @@ setup_precommit() {
 }
 
 setup_prepush() {
-    if [ -z "$CI" ]; then
-        echo ""
-        read -rp "Run tests locally before pushing to remote branches? THIS WILL SLOW DOWN EVERY PUSH but reduce the risk of failing CI. (y/N) " question
-    else
-        question=y
+    if ! command -v pre-commit >/dev/null 2>&1; then
+        return
     fi
-    if [ "$question" = "y" ]; then
+    if [ "$SETUP_PRE_PUSH" = "y" ]; then
         pre-commit install -t pre-push
     else
         pre-commit uninstall -t pre-push
@@ -195,16 +196,15 @@ fi
 detect_os "$@"
 
 #if interactive install build deps and prepare environment
-if [ -t 2 ]; then
-    case $OS in
-    debian | ubuntu | arch | fedora | darwin | freebsd)
-        setup_deps
-        ;;
-    nixos)
-        echo "NixOS detected, using nix-shell for build dependencies"
-        ;;
-    esac
+if [ -n "$CI" ]; then
+    INSTALL_BUILD_DEPS="y"
+    SETUP_PRE_PUSH="y"
+elif [ -t 2 ]; then
+    read -rp "Install build dependencies? (y/N) " INSTALL_BUILD_DEPS
+    read -rp "Run tests locally before pushing to remote branches? THIS WILL SLOW DOWN EVERY PUSH but reduce the risk of failing CI. (y/N) " SETUP_PRE_PUSH
 fi
+
+setup_deps
 setup_virtualenv
 setup_run_wrappers
 check_markdown
@@ -215,8 +215,6 @@ check_meson
 setup_precommit
 
 #needs to be after pre-commit is sourced
-if [ -t 2 ]; then
-    setup_prepush
-fi
+setup_prepush
 
 howto

--- a/contrib/setup
+++ b/contrib/setup
@@ -10,45 +10,60 @@ HELPER_ARGS=""
 INSTALL_BUILD_DEPS="n"
 SETUP_PRE_PUSH="n"
 
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+    B="\033[1m" # bold
+    R="\033[0m" # regular
+else
+    B=""
+    R=""
+fi
+
 howto() {
-    echo ""
-    echo "To enter fwupd development environment run:"
-    echo ""
-    echo "# source venv/bin/activate"
-    echo ""
+    echo -e ""
+    echo -e "To enter fwupd development environment run:"
+    echo -e ""
+    echo -e "    # ${B}source venv/bin/activate${R}"
+    echo -e ""
 }
 
 instructions() {
     cat <<'EOF'
-echo "To build or rebuild fwupd within development environment run:"
-echo ""
-echo "# build-fwupd"
-echo ""
-echo "To run the test suite run:"
-echo ""
-echo "# test-fwupd"
-echo ""
-echo "To run any tool under gdbserver add DEBUG=1 to env, for example:"
-echo ""
-echo "# DEBUG=1 fwupdtool get-devices"
-echo ""
-echo "To leave fwupd development environment run:"
-echo ""
-echo "# deactivate"
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+    B="\033[1m" # bold
+    R="\033[0m" # regular
+else
+    B=""
+    R=""
+fi
+echo -e "To build or rebuild fwupd within development environment run:"
+echo -e ""
+echo -e "${B}    # build-fwupd${R}"
+echo -e ""
+echo -e "To run the test suite run:"
+echo -e ""
+echo -e "${B}    # test-fwupd${R}"
+echo -e ""
+echo -e "To run any tool under gdbserver add DEBUG=1 to env, for example:"
+echo -e ""
+echo -e "${B}    # DEBUG=1 fwupdtool get-devices${R}"
+echo -e ""
+echo -e "To leave fwupd development environment run:"
+echo -e ""
+echo -e "${B}    # deactivate${R}"
 EOF
 }
 
 usage() {
-    echo "Usage: $(basename "$0") [OPTIONS]"
-    echo ""
-    echo "Set up the fwupd build"
-    echo ""
-    echo "OPTIONS:"
-    echo "  --debug                   ... enable debugging output"
-    echo "  --help                    ... print this help"
-    echo "  --os=[fedora|ubuntu|...]  ... the operating system to set up the build for."
-    echo ""
-    echo "Once set up, the following commands become available:"
+    echo -e "${B}Usage: $(basename "$0") [OPTIONS]${R}"
+    echo -e ""
+    echo -e "Set up the fwupd build"
+    echo -e ""
+    echo -e "${B}OPTIONS:${R}"
+    echo -e "  ${B}--debug${R}                   ... enable debugging output"
+    echo -e "  ${B}--help${R}                    ... print this help"
+    echo -e "  ${B}--os=[fedora|ubuntu|...]${R}  ... the operating system to set up the build for."
+    echo -e ""
+    echo -e "Once set up, the following commands become available:"
     howto
     instructions | bash
 }
@@ -206,7 +221,7 @@ done
 
 #already setup
 if [ -f venv/bin/build-fwupd ]; then
-    echo "$0 has already been run"
+    echo -e "${B}$0 has already been run${R}"
     howto
     exit 0
 fi

--- a/contrib/test-venv.sh
+++ b/contrib/test-venv.sh
@@ -29,6 +29,12 @@ usage() {
     echo -e "        Only applies if meson is in the selected tests."
     echo -e "        If given as --meson-args (without '=') all further arguments"
     echo -e "        are passed as-is to meson test."
+    echo -e ""
+    echo -e "    ${B}--sudo=[auto|noask|skip]${R}"
+    echo -e "        Behavior for sudo (if used for selected tests)"
+    echo -e "            ${B}auto${R}          ask for the sudo password if required (default)"
+    echo -e "            ${B}noask${R}         only run sudo commands if already authenticated"
+    echo -e "            ${B}skip${R}          skip sudo commands (and tests that rely on it)"
 }
 
 # Print a message with a background color
@@ -79,6 +85,7 @@ run_fwupdtool=false
 run_meson=false
 run_mtd=false
 run_all=true
+sudo_mode="auto"
 meson_args=()
 
 while [ $# -gt 0 ]; do
@@ -124,6 +131,18 @@ while [ $# -gt 0 ]; do
         meson_args=("$@")
         shift $#
         ;;
+    --sudo=*)
+        sudo_mode="${1#--sudo=}"
+        case "$sudo_mode" in
+        auto | noask | skip) ;;
+        *)
+            echo "Unknown sudo mode: $sudo_mode" >&2
+            usage >&2
+            exit 1
+            ;;
+        esac
+        shift
+        ;;
     -h | --help)
         usage
         exit 0
@@ -148,7 +167,21 @@ fi
 VENV="$(dirname "$0")/.."
 BUILD="${VENV}/build"
 INSTALLED_TESTS="${VENV}/dist/share/installed-tests/fwupd"
-SUDO=$(command -v sudo 2>/dev/null)
+case "$sudo_mode" in
+skip)
+    SUDO=""
+    ;;
+noask)
+    if sudo -n true 2>/dev/null; then
+        SUDO="$(command -v sudo 2>/dev/null)"
+    else
+        SUDO=""
+    fi
+    ;;
+*)
+    SUDO="$(command -v sudo 2>/dev/null)"
+    ;;
+esac
 export G_TEST_BUILDDIR="${INSTALLED_TESTS}"
 export G_TEST_SRCDIR="${INSTALLED_TESTS}"
 export GI_TYPELIB_PATH="${BUILD}/libfwupd"
@@ -163,30 +196,42 @@ if [ "$run_meson" = true ]; then
 fi
 
 if [ "$run_mtd" = true ]; then
-    print_msg "blue" "Testing mtd-self-test"
-    "${SUDO}" modprobe mtdram
-    "${SUDO}" \
-        G_TEST_BUILDDIR="${G_TEST_BUILDDIR}" \
-        LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" \
-        G_TEST_SRCDIR="${G_TEST_SRCDIR}" \
-        "${VENV}"/dist/libexec/installed-tests/fwupd/mtd-self-test
+    if [ -z "$SUDO" ]; then
+        echo "Skipping mtd-self-test (requires sudo)"
+    else
+        print_msg "blue" "Testing mtd-self-test"
+        "${SUDO}" modprobe mtdram
+        "${SUDO}" \
+            G_TEST_BUILDDIR="${G_TEST_BUILDDIR}" \
+            LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" \
+            G_TEST_SRCDIR="${G_TEST_SRCDIR}" \
+            "${VENV}"/dist/libexec/installed-tests/fwupd/mtd-self-test
+    fi
 fi
 
 if [ "$run_fwupdtool" = true ]; then
-    print_msg "yellow" "Testing fwupdtool.sh"
-    "${INSTALLED_TESTS}"/fwupdtool.sh
+    if [ -z "$SUDO" ]; then
+        echo "Skipping fwupdtool test (requires sudo)"
+    else
+        print_msg "yellow" "Testing fwupdtool.sh"
+        "${INSTALLED_TESTS}"/fwupdtool.sh
 
-    # artifacts from the test run
-    rm -f fwupdtool.txt
+        # artifacts from the test run
+        rm -f fwupdtool.txt
+    fi
 fi
 
 if [ "$run_fwupd" = true ]; then
-    print_msg "pink" "Starting daemon"
-    G_DEBUG=fatal-criticals "${VENV}"/bin/fwupd --verbose --no-timestamp >fwupd.txt 2>&1 &
+    if [ -z "$SUDO" ]; then
+        echo "Skipping fwupd test (requires sudo)"
+    else
+        print_msg "pink" "Starting daemon"
+        G_DEBUG=fatal-criticals "${VENV}"/bin/fwupd --verbose --no-timestamp >fwupd.txt 2>&1 &
 
-    print_msg "pink" "Testing fwupd.sh"
-    "${INSTALLED_TESTS}"/fwupd.sh
+        print_msg "pink" "Testing fwupd.sh"
+        "${INSTALLED_TESTS}"/fwupd.sh
 
-    # artifacts from the test run
-    rm -f fwupd.txt
+        # artifacts from the test run
+        rm -f fwupd.txt
+    fi
 fi

--- a/contrib/test-venv.sh
+++ b/contrib/test-venv.sh
@@ -78,6 +78,14 @@ print_msg() {
     fi
 }
 
+chown_state_dir() {
+    # Tests/tools run as root may create dist/var which can cause
+    # subsequent tests to fail if they can't write to that directory.
+    if [ -n "${SUDO}" ] && [ -d "${VENV}"/dist/var ]; then
+        "${SUDO}" chown -R "$(id -u)":"$(id -g)" "${VENV}"/dist/var
+    fi
+}
+
 set -e
 
 run_fwupd=false
@@ -190,6 +198,8 @@ export DAEMON_BUILDDIR="${BUILD}/src"
 export PATH="${VENV}/bin:$PATH"
 export PYTHONWARNINGS="ignore::DeprecationWarning:gi.events"
 
+trap chown_state_dir EXIT INT TERM
+
 if [ "$run_meson" = true ]; then
     print_msg "green" "Testing meson test suite"
     meson test -C "${BUILD}" "${meson_args[@]}"
@@ -206,6 +216,8 @@ if [ "$run_mtd" = true ]; then
             LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" \
             G_TEST_SRCDIR="${G_TEST_SRCDIR}" \
             "${VENV}"/dist/libexec/installed-tests/fwupd/mtd-self-test
+
+        chown_state_dir
     fi
 fi
 
@@ -218,6 +230,8 @@ if [ "$run_fwupdtool" = true ]; then
 
         # artifacts from the test run
         rm -f fwupdtool.txt
+
+        chown_state_dir
     fi
 fi
 
@@ -228,10 +242,15 @@ if [ "$run_fwupd" = true ]; then
         print_msg "pink" "Starting daemon"
         G_DEBUG=fatal-criticals "${VENV}"/bin/fwupd --verbose --no-timestamp >fwupd.txt 2>&1 &
 
+        # give the daemon time to create the state directories
+        sleep 0.5
+        chown_state_dir
+
         print_msg "pink" "Testing fwupd.sh"
         "${INSTALLED_TESTS}"/fwupd.sh
 
         # artifacts from the test run
         rm -f fwupd.txt
+
     fi
 fi

--- a/contrib/test-venv.sh
+++ b/contrib/test-venv.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 # shellcheck disable=SC1091

--- a/contrib/test-venv.sh
+++ b/contrib/test-venv.sh
@@ -86,7 +86,24 @@ chown_state_dir() {
     fi
 }
 
+cleanup() {
+    if [ -n "$FWUPD_PID" ]; then
+        kill "$FWUPD_PID" 2>/dev/null || true
+        # Give the daemon a few seconds to exit cleanly, then force-kill
+        local _
+        for _ in 1 2 3 4 5; do
+            kill -0 "$FWUPD_PID" 2>/dev/null || break
+            sleep 1
+        done
+        kill -KILL "$FWUPD_PID" 2>/dev/null || true
+        wait "$FWUPD_PID" 2>/dev/null || true
+    fi
+    chown_state_dir
+}
+
 set -e
+
+FWUPD_PID=""
 
 run_fwupd=false
 run_fwupdtool=false
@@ -198,7 +215,7 @@ export DAEMON_BUILDDIR="${BUILD}/src"
 export PATH="${VENV}/bin:$PATH"
 export PYTHONWARNINGS="ignore::DeprecationWarning:gi.events"
 
-trap chown_state_dir EXIT INT TERM
+trap cleanup EXIT INT TERM
 
 if [ "$run_meson" = true ]; then
     print_msg "green" "Testing meson test suite"
@@ -241,6 +258,7 @@ if [ "$run_fwupd" = true ]; then
     else
         print_msg "pink" "Starting daemon"
         G_DEBUG=fatal-criticals "${VENV}"/bin/fwupd --verbose --no-timestamp >fwupd.txt 2>&1 &
+        FWUPD_PID=$!
 
         # give the daemon time to create the state directories
         sleep 0.5

--- a/contrib/test-venv.sh
+++ b/contrib/test-venv.sh
@@ -31,6 +31,47 @@ usage() {
     echo -e "        are passed as-is to meson test."
 }
 
+# Print a message with a background color
+print_msg() {
+    colorname="$1"
+    msg="$2"
+
+    if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+        reset="\033[0m"
+        pad="               "
+        larrow="\xee\x82\xb2" # 
+        rarrow="\xee\x82\xb0" # 
+        case "$colorname" in
+        pink)
+            rgb="239;177;246" # #efb1f6
+            ;;
+        blue)
+            rgb="00;215;255" # #00d7ff
+            ;;
+        green)
+            rgb="00;255;175" # #00ffaf
+            ;;
+        yellow)
+            rgb="255;215;00" # #ffd700
+            ;;
+        *)
+            echo "Unsupported color '$colorname'" >&2
+            exit 1
+            ;;
+        esac
+
+        # Escape sequences:
+        # \033[38;2;r;g;bm  - foreground truecolor r,g,b (decimal)
+        # \033[48;2;r;g;bm  - background truecolor r,g,b (decimal)
+
+        fg="\033[38;2;0;0;0m"
+        # shellcheck disable=SC2059
+        echo -e "\033[38;2;${rgb}m${larrow}\033[48;2;${rgb}m${fg}${pad}${msg}${pad}${reset}\033[38;2;${rgb}m${rarrow}${reset}\n"
+    else
+        echo "${msg}"
+    fi
+}
+
 set -e
 
 run_fwupd=false
@@ -117,12 +158,12 @@ export PATH="${VENV}/bin:$PATH"
 export PYTHONWARNINGS="ignore::DeprecationWarning:gi.events"
 
 if [ "$run_meson" = true ]; then
-    echo "Testing meson test suite"
+    print_msg "green" "Testing meson test suite"
     meson test -C "${BUILD}" "${meson_args[@]}"
 fi
 
 if [ "$run_mtd" = true ]; then
-    echo "Testing mtd-self-test"
+    print_msg "blue" "Testing mtd-self-test"
     "${SUDO}" modprobe mtdram
     "${SUDO}" \
         G_TEST_BUILDDIR="${G_TEST_BUILDDIR}" \
@@ -132,7 +173,7 @@ if [ "$run_mtd" = true ]; then
 fi
 
 if [ "$run_fwupdtool" = true ]; then
-    echo "Testing fwupdtool.sh"
+    print_msg "yellow" "Testing fwupdtool.sh"
     "${INSTALLED_TESTS}"/fwupdtool.sh
 
     # artifacts from the test run
@@ -140,10 +181,10 @@ if [ "$run_fwupdtool" = true ]; then
 fi
 
 if [ "$run_fwupd" = true ]; then
-    echo "Starting daemon"
+    print_msg "pink" "Starting daemon"
     G_DEBUG=fatal-criticals "${VENV}"/bin/fwupd --verbose --no-timestamp >fwupd.txt 2>&1 &
 
-    echo "Testing fwupd.sh"
+    print_msg "pink" "Testing fwupd.sh"
     "${INSTALLED_TESTS}"/fwupd.sh
 
     # artifacts from the test run

--- a/contrib/test-venv.sh
+++ b/contrib/test-venv.sh
@@ -1,5 +1,105 @@
 #!/usr/bin/env bash
+#
+# fwupd test helper script.
+#
+usage() {
+    if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+        B="\033[1m"
+        R="\033[0m"
+    else
+        B=""
+        R=""
+    fi
+    echo -e "${B}Usage: $(basename "$0") [OPTIONS]${R}"
+    echo -e ""
+    echo -e "Test this build of fwupd"
+    echo -e ""
+    echo -e "${B}OPTIONS:${R}"
+    echo -e "    ${B}--tests=TESTS${R}"
+    echo -e "        Select subset of tests to run:"
+    echo -e "            ${B}all${R}           run all tests (default)"
+    echo -e "            ${B}fwupd${R}         run the fwupd tests"
+    echo -e "            ${B}fwupdtool${R}     run the fwupdtool tests"
+    echo -e "            ${B}meson${R}         run the meson test suite"
+    echo -e "            ${B}mtd${R}           run the mtd self-test"
+    echo -e ""
+    echo -e "    ${B}--meson-args=\"arg1[ ...]\"${R}"
+    echo -e "    ${B}--meson-args arg1 [...]${R}"
+    echo -e "        Pass arguments to the meson test command."
+    echo -e "        Only applies if meson is in the selected tests."
+    echo -e "        If given as --meson-args (without '=') all further arguments"
+    echo -e "        are passed as-is to meson test."
+}
+
 set -e
+
+run_fwupd=false
+run_fwupdtool=false
+run_meson=false
+run_mtd=false
+run_all=true
+meson_args=()
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+    --tests=*)
+        tests="${1#--tests=}"
+        run_all=false
+        old_IFS="$IFS"
+        IFS=','
+        for t in $tests; do
+            case "$t" in
+            all)
+                run_all=true
+                ;;
+            fwupd)
+                run_fwupd=true
+                ;;
+            fwupdtool)
+                run_fwupdtool=true
+                ;;
+            mtd)
+                run_mtd=true
+                ;;
+            meson)
+                run_meson=true
+                ;;
+            *)
+                echo "Unknown test name: '$t'" >&2
+                exit 1
+                ;;
+            esac
+        done
+        IFS="$old_IFS"
+        shift
+        ;;
+    --meson-args=*)
+        read -ra meson_args <<<"${1#--meson-args=}"
+        shift
+        ;;
+    --meson-args)
+        shift
+        # Everything after --meson-args is passed through to meson test
+        meson_args=("$@")
+        shift $#
+        ;;
+    -h | --help)
+        usage
+        exit 0
+        ;;
+    *)
+        echo "Unknown option: $1" >&2
+        exit 1
+        ;;
+    esac
+done
+
+if [ "$run_all" = true ]; then
+    run_fwupd=true
+    run_fwupdtool=true
+    run_meson=true
+    run_mtd=true
+fi
 
 # shellcheck disable=SC1091
 . "$(dirname "$(readlink -f "$0")")/nix.sh"
@@ -16,11 +116,12 @@ export DAEMON_BUILDDIR="${BUILD}/src"
 export PATH="${VENV}/bin:$PATH"
 export PYTHONWARNINGS="ignore::DeprecationWarning:gi.events"
 
-echo "Build time test suite"
-meson test -C "${BUILD}" "$@"
+if [ "$run_meson" = true ]; then
+    echo "Testing meson test suite"
+    meson test -C "${BUILD}" "${meson_args[@]}"
+fi
 
-# If we have arguments to pass to meson test, skip the other tests
-if [ $# -eq 0 ]; then
+if [ "$run_mtd" = true ]; then
     echo "Testing mtd-self-test"
     "${SUDO}" modprobe mtdram
     "${SUDO}" \
@@ -28,10 +129,17 @@ if [ $# -eq 0 ]; then
         LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" \
         G_TEST_SRCDIR="${G_TEST_SRCDIR}" \
         "${VENV}"/dist/libexec/installed-tests/fwupd/mtd-self-test
+fi
 
+if [ "$run_fwupdtool" = true ]; then
     echo "Testing fwupdtool.sh"
     "${INSTALLED_TESTS}"/fwupdtool.sh
 
+    # artifacts from the test run
+    rm -f fwupdtool.txt
+fi
+
+if [ "$run_fwupd" = true ]; then
     echo "Starting daemon"
     G_DEBUG=fatal-criticals "${VENV}"/bin/fwupd --verbose --no-timestamp >fwupd.txt 2>&1 &
 
@@ -39,5 +147,5 @@ if [ $# -eq 0 ]; then
     "${INSTALLED_TESTS}"/fwupd.sh
 
     # artifacts from the test run
-    rm -f fwupd.txt fwupdtool.txt
+    rm -f fwupd.txt
 fi


### PR DESCRIPTION
This sits on top of #10839, commits not prefixed `trivial` are the meat of this PR. This adds:
- `test-fwupd --tests=meson,fwupdtool` for selection of some tets
- `test-fwupd --help` and some "pretty" color printing in general
- `test-fwupd --sudo=noask` so it skips the tests requiring new sudo auth (batch mode)
- `setup --help` and the questions are now asked before doing anything so we don't need to wait
- Fixes to the permission errors in the root-created state directories during `test-fwupd` so we can run the script as user now without having tests fail because they can't write to the state dir
- ~~A makefile to easily run `make` and `make test` and have it DTRT.~~ *edit: the mere presence of a Makefile broke the debian packaging CI bits and I don't have the energy to fight that*


~~I'm not too married to the idea of a makefile so I'm happy to drop this (by now I have most of my local scripts adjusted anyway). The others are useful either way, IMO.~~

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
