### PR TITLE
A set of cleanups for our docker generation

### DIFF
--- a/.github/workflows/create_containers.yml
+++ b/.github/workflows/create_containers.yml
@@ -9,11 +9,11 @@ jobs:
     permissions:
       contents: read
       packages: write # for docker/build-push-action
-    runs-on: ${{ case(matrix.env.ARCH == 'arm64', 'ubuntu-24.04-arm', 'ubuntu-latest') }}
+    runs-on: ${{ case(matrix.distros.ARCH == 'arm64', 'ubuntu-24.04-arm', 'ubuntu-latest') }}
     strategy:
       fail-fast: false
       matrix:
-        env:
+        distros:
           # NOTE: values are joined by '-' for name of container image
           - { DISTRO: arch, ARCH: amd64 }
           - { DISTRO: centos, ARCH: amd64 }
@@ -25,14 +25,17 @@ jobs:
           - { DISTRO: fedora, ARCH: amd64 }
           - { DISTRO: ubuntu, ARCH: amd64 }
           - { DISTRO: ubuntu, ARCH: amd64, VARIANT: android }
-    env: ${{ matrix.env }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Generate Dockerfile
-        run: ./contrib/ci/generate_docker.py
+        run: >-
+          ./contrib/ci/generate_docker.py
+          --distro "${{ matrix.distros.DISTRO }}"
+          --arch "${{ matrix.distros.ARCH }}"
+          ${{ matrix.distros.VARIANT && format('--variant "{0}"', matrix.distros.VARIANT) || '' }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Login to GitHub Container Registry
@@ -46,4 +49,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: "ghcr.io/fwupd/fwupd/fwupd-${{ join(matrix.env.*, '-') }}:latest"
+          tags: "ghcr.io/fwupd/fwupd/fwupd-${{ join(matrix.distros.*, '-') }}:latest"

--- a/.github/workflows/create_containers.yml
+++ b/.github/workflows/create_containers.yml
@@ -14,17 +14,16 @@ jobs:
       fail-fast: false
       matrix:
         distros:
-          # NOTE: values are joined by '-' for name of container image
-          - { DISTRO: arch, ARCH: amd64 }
-          - { DISTRO: centos, ARCH: amd64 }
-          - { DISTRO: debian, ARCH: amd64 }
-          - { DISTRO: debian, ARCH: amd64, VARIANT: i386 }
-          - { DISTRO: debian, ARCH: amd64, VARIANT: tartan }
-          - { DISTRO: debian, ARCH: arm64 }
-          - { DISTRO: debian, ARCH: arm64, VARIANT: cross-s390x }
-          - { DISTRO: fedora, ARCH: amd64 }
-          - { DISTRO: ubuntu, ARCH: amd64 }
-          - { DISTRO: ubuntu, ARCH: amd64, VARIANT: android }
+          - { DISTRO: arch, VERSION: latest, ARCH: amd64 }
+          - { DISTRO: centos, VERSION: stream9, ARCH: amd64 }
+          - { DISTRO: debian, VERSION: testing, ARCH: amd64 }
+          - { DISTRO: debian, VERSION: testing, ARCH: amd64, VARIANT: i386 }
+          - { DISTRO: debian, VERSION: unstable, ARCH: amd64, VARIANT: tartan }
+          - { DISTRO: debian, VERSION: testing, ARCH: arm64 }
+          - { DISTRO: debian, VERSION: testing, ARCH: arm64, VARIANT: cross-s390x }
+          - { DISTRO: fedora, VERSION: 44, ARCH: amd64 }
+          - { DISTRO: ubuntu, VERSION: rolling, ARCH: amd64 }
+          - { DISTRO: ubuntu, VERSION: rolling, ARCH: amd64, VARIANT: android }
     steps:
       - name: Check out the repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -34,6 +33,7 @@ jobs:
         run: >-
           ./contrib/ci/generate_docker.py
           --distro "${{ matrix.distros.DISTRO }}"
+          --version "${{ matrix.distros.VERSION }}"
           --arch "${{ matrix.distros.ARCH }}"
           ${{ matrix.distros.VARIANT && format('--variant "{0}"', matrix.distros.VARIANT) || '' }}
       - name: Set up Docker Buildx
@@ -44,9 +44,21 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build container tag
+        id: tag
+        env:
+          DISTRO: ${{ matrix.distros.DISTRO }}
+          ARCH: ${{ matrix.distros.ARCH }}
+          VARIANT: ${{ matrix.distros.VARIANT }}
+        run: |
+          tag="ghcr.io/fwupd/fwupd/fwupd-${DISTRO}-${ARCH}"
+          if [ -n "${VARIANT}" ]; then
+            tag="${tag}-${VARIANT}"
+          fi
+          echo "tag=${tag}:latest" >> "$GITHUB_OUTPUT"
       - name: Push to GitHub Packages
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           push: true
-          tags: "ghcr.io/fwupd/fwupd/fwupd-${{ join(matrix.distros.*, '-') }}:latest"
+          tags: ${{ steps.tag.outputs.tag }}

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -12,7 +12,7 @@ A Dockerfile for Fedora can be generated in `contrib`.
 To prepare the Docker container run this command:
 
 ```shell
-OS=fedora ./generate_docker.py build
+./generate_docker.py --distro fedora --arch amd64 build
 ```
 
 To build the RPMs run this command (from the root of your git checkout):
@@ -37,9 +37,9 @@ A Dockerfile for Debian or Ubuntu can be generated in `contrib`.
 To prepare the Docker container run one of these commands:
 
 ```shell
-OS=debian-x86_64 ./generate_docker.py build
-OS=debian-i386 ./generate_docker.py build
-OS=ubuntu-x86_64 ./generate_docker.py build
+./generate_docker.py --distro debian --arch amd64 build
+./generate_docker.py --distro debian --arch amd64 --variant i386 build
+./generate_docker.py --distro ubuntu --arch amd64 build
 ```
 
 To build the DEBs run one of these commands (from the root of your git checkout):
@@ -66,7 +66,7 @@ A Dockerfile for Arch can be generated in `contrib`.
 To prepare the Docker container run this command:
 
 ```shell
-OS=arch ./generate_docker.py
+./generate_docker.py --distro arch --arch amd64 build
 ```
 
 To build the PKGs run this command (from the root of your git checkout):

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -12,7 +12,7 @@ A Dockerfile for Fedora can be generated in `contrib`.
 To prepare the Docker container run this command:
 
 ```shell
-./generate_docker.py --distro fedora --arch amd64 build
+./generate_docker.py --distro fedora --version 44 --arch amd64 build
 ```
 
 To build the RPMs run this command (from the root of your git checkout):
@@ -37,9 +37,9 @@ A Dockerfile for Debian or Ubuntu can be generated in `contrib`.
 To prepare the Docker container run one of these commands:
 
 ```shell
-./generate_docker.py --distro debian --arch amd64 build
-./generate_docker.py --distro debian --arch amd64 --variant i386 build
-./generate_docker.py --distro ubuntu --arch amd64 build
+./generate_docker.py --distro debian --version testing --arch amd64 build
+./generate_docker.py --distro debian --version testing --arch amd64 --variant i386 build
+./generate_docker.py --distro ubuntu --version rolling --arch amd64 build
 ```
 
 To build the DEBs run one of these commands (from the root of your git checkout):
@@ -66,7 +66,7 @@ A Dockerfile for Arch can be generated in `contrib`.
 To prepare the Docker container run this command:
 
 ```shell
-./generate_docker.py --distro arch --arch amd64 build
+./generate_docker.py --distro arch --version latest --arch amd64 build
 ```
 
 To build the PKGs run this command (from the root of your git checkout):

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -7,7 +7,7 @@ The build can be performed using Linux containers with [Docker](https://www.dock
 
 ## RPM packages
 
-A Dockerfile for Fedora can be generated in `contrib`.
+A Dockerfile for Fedora can be generated in `contrib/ci`.
 
 To prepare the Docker container run this command:
 
@@ -32,7 +32,7 @@ docker run --privileged -e QUBES=true  -t -v `pwd`:/github/workspace fwupd-fedor
 
 ## DEB packages
 
-A Dockerfile for Debian or Ubuntu can be generated in `contrib`.
+A Dockerfile for Debian or Ubuntu can be generated in `contrib/ci`.
 
 To prepare the Docker container run one of these commands:
 
@@ -61,7 +61,7 @@ docker run --privileged -t -v `pwd`:/github/workspace fwupd-debian-x86_64-qubes
 
 ## PKG packages
 
-A Dockerfile for Arch can be generated in `contrib`.
+A Dockerfile for Arch can be generated in `contrib/ci`.
 
 To prepare the Docker container run this command:
 

--- a/contrib/ci/Dockerfile-arch.in
+++ b/contrib/ci/Dockerfile-arch.in
@@ -5,9 +5,9 @@ ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 ENV CI_NETWORK=true
 RUN echo fubar > /etc/machine-id
-RUN sed "s,#en_US.UTF-8,en_US.UTF-8," /etc/locale.gen -i
-RUN echo "LANG=en_US.UTF-8" > /etc/locale.conf
-RUN locale-gen
+RUN sed "s,#en_US.UTF-8,en_US.UTF-8," /etc/locale.gen -i && \
+    echo "LANG=en_US.UTF-8" > /etc/locale.conf && \
+    locale-gen
 RUN pacman -Syu --noconfirm archlinux-keyring
 RUN pacman -Syu --noconfirm --needed \
 %%%DEPENDENCIES%%% && \

--- a/contrib/ci/Dockerfile-arch.in
+++ b/contrib/ci/Dockerfile-arch.in
@@ -1,5 +1,5 @@
 # -*- mode: dockerfile -*-
-FROM archlinux:latest
+FROM archlinux:%%%VERSION%%%
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8

--- a/contrib/ci/Dockerfile-arch.in
+++ b/contrib/ci/Dockerfile-arch.in
@@ -10,5 +10,6 @@ RUN echo "LANG=en_US.UTF-8" > /etc/locale.conf
 RUN locale-gen
 RUN pacman -Syu --noconfirm archlinux-keyring
 RUN pacman -Syu --noconfirm --needed \
-%%%DEPENDENCIES%%%
+%%%DEPENDENCIES%%% && \
+    pacman -Sc --noconfirm
 WORKDIR /github/workspace

--- a/contrib/ci/Dockerfile-arch.in
+++ b/contrib/ci/Dockerfile-arch.in
@@ -1,6 +1,7 @@
 # -*- mode: dockerfile -*-
 FROM archlinux:latest
 ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 ENV CI_NETWORK=true
 RUN echo fubar > /etc/machine-id

--- a/contrib/ci/Dockerfile-centos.in
+++ b/contrib/ci/Dockerfile-centos.in
@@ -10,8 +10,8 @@ RUN dnf copr enable rhughes/fwupd-epel-9 -y
 RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 RUN crb enable
 RUN dnf -y install \
-%%%DEPENDENCIES%%%
-RUN ls -R /var/cache
+%%%DEPENDENCIES%%% && \
+    dnf clean all
 RUN wget -P /var/cache https://github.com/fwupd/fwupd/releases/download/1.9.31/fwupd-1.9.31.tar.xz
 RUN wget -P /var/cache https://github.com/fwupd/fwupd-efi/archive/refs/tags/1.7.tar.gz
 WORKDIR /github/workspace

--- a/contrib/ci/Dockerfile-centos.in
+++ b/contrib/ci/Dockerfile-centos.in
@@ -3,6 +3,7 @@ FROM quay.io/centos/centos:stream9
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
+ENV CI_NETWORK=true
 RUN echo fubar > /etc/machine-id
 RUN dnf -y update
 RUN dnf copr enable rhughes/fwupd-epel-9 -y

--- a/contrib/ci/Dockerfile-centos.in
+++ b/contrib/ci/Dockerfile-centos.in
@@ -5,7 +5,6 @@ ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 RUN echo fubar > /etc/machine-id
 RUN dnf -y update
-RUN echo fubar > /etc/machine-id
 RUN dnf copr enable rhughes/fwupd-epel-9 -y
 RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 RUN crb enable

--- a/contrib/ci/Dockerfile-centos.in
+++ b/contrib/ci/Dockerfile-centos.in
@@ -1,5 +1,5 @@
 # -*- mode: dockerfile -*-
-FROM quay.io/centos/centos:stream9
+FROM quay.io/centos/centos:%%%VERSION%%%
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8

--- a/contrib/ci/Dockerfile-debian-tartan.in
+++ b/contrib/ci/Dockerfile-debian-tartan.in
@@ -1,5 +1,8 @@
 # -*- mode: dockerfile -*-
 FROM debian:unstable
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 ENV CI_NETWORK=true
 ENV DEBIAN_FRONTEND=noninteractive
 RUN echo fubar > /etc/machine-id

--- a/contrib/ci/Dockerfile-debian-tartan.in
+++ b/contrib/ci/Dockerfile-debian-tartan.in
@@ -1,5 +1,5 @@
 # -*- mode: dockerfile -*-
-FROM debian:unstable
+FROM debian:%%%VERSION%%%
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8

--- a/contrib/ci/Dockerfile-debian-tartan.in
+++ b/contrib/ci/Dockerfile-debian-tartan.in
@@ -1,9 +1,9 @@
 # -*- mode: dockerfile -*-
 FROM debian:unstable
 ENV CI_NETWORK=true
+ENV DEBIAN_FRONTEND=noninteractive
 RUN echo fubar > /etc/machine-id
 RUN set -euxo pipefail; \
-    export DEBIAN_FRONTEND=noninteractive; \
 %%%SETUP%%% \
     apt-get update -qq; \
     apt-get install -qq --yes --no-install-recommends \

--- a/contrib/ci/Dockerfile-debian.in
+++ b/contrib/ci/Dockerfile-debian.in
@@ -1,5 +1,8 @@
 # -*- mode: dockerfile -*-
 FROM debian:testing
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 ENV CI_NETWORK=true
 ENV DEBIAN_FRONTEND=noninteractive
 RUN echo fubar > /etc/machine-id

--- a/contrib/ci/Dockerfile-debian.in
+++ b/contrib/ci/Dockerfile-debian.in
@@ -1,9 +1,9 @@
 # -*- mode: dockerfile -*-
 FROM debian:testing
 ENV CI_NETWORK=true
+ENV DEBIAN_FRONTEND=noninteractive
 RUN echo fubar > /etc/machine-id
 RUN set -euxo pipefail; \
-    export DEBIAN_FRONTEND=noninteractive; \
 %%%SETUP%%% \
     apt-get update -qq; \
     apt-get install -qq --yes --no-install-recommends \

--- a/contrib/ci/Dockerfile-debian.in
+++ b/contrib/ci/Dockerfile-debian.in
@@ -1,5 +1,5 @@
 # -*- mode: dockerfile -*-
-FROM debian:testing
+FROM debian:%%%VERSION%%%
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8

--- a/contrib/ci/Dockerfile-fedora.in
+++ b/contrib/ci/Dockerfile-fedora.in
@@ -5,7 +5,6 @@ ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 RUN echo fubar > /etc/machine-id
 RUN dnf -y update
-RUN echo fubar > /etc/machine-id
 RUN dnf --enablerepo=updates-testing -y install \
 %%%DEPENDENCIES%%%
 WORKDIR /github/workspace

--- a/contrib/ci/Dockerfile-fedora.in
+++ b/contrib/ci/Dockerfile-fedora.in
@@ -7,5 +7,6 @@ ENV CI_NETWORK=true
 RUN echo fubar > /etc/machine-id
 RUN dnf -y update
 RUN dnf --enablerepo=updates-testing -y install \
-%%%DEPENDENCIES%%%
+%%%DEPENDENCIES%%% && \
+    dnf clean all
 WORKDIR /github/workspace

--- a/contrib/ci/Dockerfile-fedora.in
+++ b/contrib/ci/Dockerfile-fedora.in
@@ -3,6 +3,7 @@ FROM fedora:44
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
+ENV CI_NETWORK=true
 RUN echo fubar > /etc/machine-id
 RUN dnf -y update
 RUN dnf --enablerepo=updates-testing -y install \

--- a/contrib/ci/Dockerfile-fedora.in
+++ b/contrib/ci/Dockerfile-fedora.in
@@ -1,5 +1,5 @@
 # -*- mode: dockerfile -*-
-FROM fedora:44
+FROM fedora:%%%VERSION%%%
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8

--- a/contrib/ci/Dockerfile-ubuntu.in
+++ b/contrib/ci/Dockerfile-ubuntu.in
@@ -1,5 +1,5 @@
 # -*- mode: dockerfile -*-
-FROM ubuntu:rolling
+FROM ubuntu:%%%VERSION%%%
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8

--- a/contrib/ci/Dockerfile-ubuntu.in
+++ b/contrib/ci/Dockerfile-ubuntu.in
@@ -1,10 +1,10 @@
 # -*- mode: dockerfile -*-
 FROM ubuntu:rolling
 ENV CI_NETWORK=true
+ENV DEBIAN_FRONTEND=noninteractive
 ENV CC=clang
 RUN echo fubar > /etc/machine-id
 RUN set -euxo pipefail; \
-    export DEBIAN_FRONTEND=noninteractive; \
     apt-get update -qq; \
     apt-get install -qq --yes --no-install-recommends software-properties-common; \
     add-apt-repository -y ppa:peter-hutterer/meson1.11; \

--- a/contrib/ci/Dockerfile-ubuntu.in
+++ b/contrib/ci/Dockerfile-ubuntu.in
@@ -1,5 +1,8 @@
 # -*- mode: dockerfile -*-
 FROM ubuntu:rolling
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 ENV CI_NETWORK=true
 ENV DEBIAN_FRONTEND=noninteractive
 ENV CC=clang

--- a/contrib/ci/README.md
+++ b/contrib/ci/README.md
@@ -110,8 +110,8 @@ The following builds are performed for every commit or pull request:
 ## Adding a new target
 
 Dockerfiles are generated dynamically by the python script `generate_docker.py`.
-The python script takes `--distro`, `--arch` and optionally `--variant` commandline
-arguments to determine what target to generate a Dockerfile for.
+The python script takes `--distro`, `--version`, `--arch` and optionally `--variant`
+commandline arguments to determine what target to generate a Dockerfile for.
 
 ### dependencies.xml
 

--- a/contrib/ci/README.md
+++ b/contrib/ci/README.md
@@ -110,7 +110,8 @@ The following builds are performed for every commit or pull request:
 ## Adding a new target
 
 Dockerfiles are generated dynamically by the python script `generate_docker.py`.
-The python script will recognize the environment variable `DISTRO` to determine what target to generate a Dockerfile for.
+The python script takes `--distro`, `--arch` and optionally `--variant` commandline
+arguments to determine what target to generate a Dockerfile for.
 
 ### dependencies.xml
 

--- a/contrib/ci/generate_docker.py
+++ b/contrib/ci/generate_docker.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
 
+import argparse
 import os
 import shutil
 import subprocess
@@ -12,14 +13,6 @@ import sys
 from pathlib import Path
 
 from fwupd_setup_helpers import ARCH_TO_DEPS_MAP, parse_dependencies
-
-
-def getenv_unwrap(name: str) -> str:
-    val = os.getenv(name)
-    if val is None:
-        print(f"environment variable has not been set: '{name}'")
-        sys.exit(1)
-    return val
 
 
 def get_container_cmd():
@@ -31,75 +24,98 @@ def get_container_cmd():
         return "podman"
 
 
-directory = os.path.dirname(sys.argv[0])
-DISTRO = getenv_unwrap("DISTRO")
-ARCH = getenv_unwrap("ARCH")
-VARIANT = os.getenv("VARIANT")
-CROSS = c if VARIANT and (c := str(VARIANT).removeprefix("cross-")) != VARIANT else None
+def generate_dockerfile(distro: str, arch: str, variant: str | None) -> str:
+    """Generate a Dockerfile from the template for the given distro/arch/variant."""
 
-
-# find first existing
-dockerfiles = [
-    Path(directory) / f"Dockerfile-{DISTRO}-{VARIANT}.in",
-    Path(directory) / f"Dockerfile-{DISTRO}.in",
-]
-try:
-    template_file = next(p for p in dockerfiles if p.exists())
-except StopIteration:
-    raise FileNotFoundError("Missing template Dockerfile for {DISTRO}") from None
-with open(template_file) as file:
-    content = file.read()
-
-
-# special cases
-match (DISTRO, VARIANT):
-    case ("debian", "i386"):
-        content = content.replace("FROM debian:testing", "FROM i386/debian:testing")
-
-
-# insert commands to prepare cross compile
-if CROSS:
-    cross_setup = f"""\
-    sed -i 's|Types: deb|Types: deb deb-src|' /etc/apt/sources.list.d/debian.sources; \\
-    dpkg --add-architecture {CROSS};"""
-else:
-    cross_setup = "    "
-content = content.replace("%%%SETUP%%%", cross_setup)
-
-
-# insert dependencies to install
-if CROSS:
-    deps_parsed, build_indep = parse_dependencies(
-        DISTRO, ARCH_TO_DEPS_MAP[CROSS], False, cross=True
+    directory = os.path.dirname(sys.argv[0])
+    cross = (
+        c if variant and (c := str(variant).removeprefix("cross-")) != variant else None
     )
-    deps = deps_parsed + build_indep + [f"crossbuild-essential-{CROSS}"]
-elif VARIANT in ["i386", "android"]:
-    deps_parsed, build_indep = parse_dependencies(DISTRO, VARIANT, False)
-    deps = deps_parsed + build_indep
-else:
-    deps_parsed, build_indep = parse_dependencies(DISTRO, ARCH_TO_DEPS_MAP[ARCH], False)
-    deps = deps_parsed + build_indep
-deps = sorted(set(deps))
-deps = [f"    {i}" for i in deps]
-deps = " \\\n".join(deps)
-content = content.replace("%%%DEPENDENCIES%%%", deps)
 
-# install android rust target
-rustup: list[str] = []
-if VARIANT == "android":
-    rustup.append("COPY contrib/ci/android.sh .")
-    rustup.append("RUN sh android.sh")
-content = content.replace("%%%RUSTUP%%%", "\n".join(rustup))
+    # find first existing
+    dockerfiles = [
+        Path(directory) / f"Dockerfile-{distro}-{variant}.in",
+        Path(directory) / f"Dockerfile-{distro}.in",
+    ]
+    try:
+        template_file = next(p for p in dockerfiles if p.exists())
+    except StopIteration:
+        raise FileNotFoundError(f"Missing template Dockerfile for {distro}") from None
+    with open(template_file) as file:
+        content = file.read()
+
+    # special cases
+    match (distro, variant):
+        case ("debian", "i386"):
+            content = content.replace("FROM debian:testing", "FROM i386/debian:testing")
+
+    # insert commands to prepare cross compile
+    if cross:
+        cross_setup = f"""\
+    sed -i 's|Types: deb|Types: deb deb-src|' /etc/apt/sources.list.d/debian.sources; \\
+    dpkg --add-architecture {cross};"""
+    else:
+        cross_setup = "    "
+    content = content.replace("%%%SETUP%%%", cross_setup)
+
+    # insert dependencies to install
+    if cross:
+        deps_parsed, build_indep = parse_dependencies(
+            distro, ARCH_TO_DEPS_MAP[cross], False, cross=True
+        )
+        deps = deps_parsed + build_indep + [f"crossbuild-essential-{cross}"]
+    elif variant in ["i386", "android"]:
+        deps_parsed, build_indep = parse_dependencies(distro, variant, False)
+        deps = deps_parsed + build_indep
+    else:
+        deps_parsed, build_indep = parse_dependencies(
+            distro, ARCH_TO_DEPS_MAP[arch], False
+        )
+        deps = deps_parsed + build_indep
+    deps = sorted(set(deps))
+    deps = [f"    {i}" for i in deps]
+    deps = " \\\n".join(deps)
+    content = content.replace("%%%DEPENDENCIES%%%", deps)
+
+    # install android rust target
+    rustup: list[str] = []
+    if variant == "android":
+        rustup.append("COPY contrib/ci/android.sh .")
+        rustup.append("RUN sh android.sh")
+    content = content.replace("%%%RUSTUP%%%", "\n".join(rustup))
+
+    return content
+
+
+parser = argparse.ArgumentParser(
+    description="Generate and optionally build a Dockerfile for CI"
+)
+parser.add_argument(
+    "--distro", required=True, help="Distribution name (e.g. fedora, debian)"
+)
+parser.add_argument("--arch", default="amd64", help="Architecture (e.g. amd64, arm64)")
+parser.add_argument(
+    "--variant", default=None, help="Build variant (e.g. i386, android, cross-s390x)"
+)
+
+subparsers = parser.add_subparsers(dest="command")
+subparsers.add_parser(
+    "build", help="Build the container image after generating the Dockerfile"
+)
+
+args = parser.parse_args()
+
+content = generate_dockerfile(args.distro, args.arch, args.variant)
 
 with open("Dockerfile", "w") as file:
     file.write(content)
 
-if len(sys.argv) == 2 and sys.argv[1] == "build":
+if args.command == "build":
     cmd = get_container_cmd()
-    args = [cmd, "build", "-t", f"fwupd-{DISTRO}"]
+    build_args = [cmd, "build", "-t", f"fwupd-{args.distro}"]
     if http_proxy := os.environ.get("http_proxy"):
-        args += [f"--build-arg=http_proxy={http_proxy}"]
+        build_args += [f"--build-arg=http_proxy={http_proxy}"]
     if https_proxy := os.environ.get("https_proxy"):
-        args += [f"--build-arg=https_proxy={https_proxy}"]
-    args += ["-f", "./Dockerfile", "."]
-    subprocess.check_call(args)
+        build_args += [f"--build-arg=https_proxy={https_proxy}"]
+    build_args += ["-f", "./Dockerfile", "."]
+    subprocess.check_call(build_args)

--- a/contrib/ci/generate_docker.py
+++ b/contrib/ci/generate_docker.py
@@ -97,9 +97,9 @@ with open("Dockerfile", "w") as file:
 if len(sys.argv) == 2 and sys.argv[1] == "build":
     cmd = get_container_cmd()
     args = [cmd, "build", "-t", f"fwupd-{DISTRO}"]
-    if "http_proxy" in os.environ:
-        args += [f"--build-arg=http_proxy={os.environ['http_proxy']}"]
-    if "https_proxy" in os.environ:
-        args += [f"--build-arg=https_proxy={os.environ['https_proxy']}"]
+    if http_proxy := os.environ.get("http_proxy"):
+        args += [f"--build-arg=http_proxy={http_proxy}"]
+    if https_proxy := os.environ.get("https_proxy"):
+        args += [f"--build-arg=https_proxy={https_proxy}"]
     args += ["-f", "./Dockerfile", "."]
     subprocess.check_call(args)

--- a/contrib/ci/generate_docker.py
+++ b/contrib/ci/generate_docker.py
@@ -24,8 +24,10 @@ def get_container_cmd():
         return "podman"
 
 
-def generate_dockerfile(distro: str, arch: str, variant: str | None) -> str:
-    """Generate a Dockerfile from the template for the given distro/arch/variant."""
+def generate_dockerfile(
+    distro: str, version: str, arch: str, variant: str | None
+) -> str:
+    """Generate a Dockerfile from the template for the given distro/version/arch/variant."""
 
     directory = os.path.dirname(sys.argv[0])
     cross = (
@@ -44,10 +46,14 @@ def generate_dockerfile(distro: str, arch: str, variant: str | None) -> str:
     with open(template_file) as file:
         content = file.read()
 
+    content = content.replace("%%%VERSION%%%", version)
+
     # special cases
     match (distro, variant):
         case ("debian", "i386"):
-            content = content.replace("FROM debian:testing", "FROM i386/debian:testing")
+            content = content.replace(
+                f"FROM debian:{version}", f"FROM i386/debian:{version}"
+            )
 
     # insert commands to prepare cross compile
     if cross:
@@ -95,6 +101,11 @@ parser.add_argument(
 )
 parser.add_argument("--arch", default="amd64", help="Architecture (e.g. amd64, arm64)")
 parser.add_argument(
+    "--version",
+    required=True,
+    help="Distribution version/tag (e.g. 44, testing, rolling)",
+)
+parser.add_argument(
     "--variant", default=None, help="Build variant (e.g. i386, android, cross-s390x)"
 )
 
@@ -105,7 +116,7 @@ subparsers.add_parser(
 
 args = parser.parse_args()
 
-content = generate_dockerfile(args.distro, args.arch, args.variant)
+content = generate_dockerfile(args.distro, args.version, args.arch, args.variant)
 
 with open("Dockerfile", "w") as file:
     file.write(content)


### PR DESCRIPTION
Sits on top of #10839, commits are the ones not starting with `trivial`. This patchset attempts to clean up our Dockerfile generation a bit which seems to have a few organically grown discrepancies. The goal is to make a future switch to container-prep (see #10756) a bit more straightforward to understand.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
