### PR TITLE
trivial: Fix pedantic rust warnings

### DIFF
--- a/rust/fwupd/src/bitflags.rs
+++ b/rust/fwupd/src/bitflags.rs
@@ -87,8 +87,8 @@ use std::ops::{BitAnd, BitOr};
 ///     }
 /// }
 /// ```
-/// All APIs except [Bitflags::iter()] work on the underlying
-/// bit field values. Check the documentation for [Bitflags::iter()] to
+/// All APIs except [`Bitflags::iter()`] work on the underlying
+/// bit field values. Check the documentation for [`Bitflags::iter()`] to
 /// avoid surprises.
 pub trait Bitflags: Copy
 where
@@ -121,6 +121,7 @@ where
     fn flag_bits(flag: Self::Flag) -> Self::Bits;
 
     /// Returns a bitmask with no bits set.
+    #[must_use]
     fn empty() -> Self {
         Self::from_bits(Self::Bits::default())
     }


### PR DESCRIPTION
To do this I used: cargo clippy --fix -- -W clippy::pedantic

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
