### PR TITLE
trivial: Actually return FALSE if a linux efivar guid doesn't exist

### DIFF
--- a/libfwupdplugin/fu-linux-efivars.c
+++ b/libfwupdplugin/fu-linux-efivars.c
@@ -223,7 +223,7 @@ fu_linux_efivars_exists_guid(FuEfivars *efivars, const gchar *guid)
 		if (g_str_has_suffix(fn, guid))
 			return TRUE;
 	}
-	return TRUE;
+	return FALSE;
 }
 
 static gboolean


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
