### PR TITLE
rust: Add the clippy pedantic requirement to Cargo.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -159,7 +159,7 @@ repos:
         types: [rust]
       - id: cargo-clippy
         name: cargo clippy
-        entry: cargo clippy -- -W clippy::pedantic -D warnings
+        entry: cargo clippy --  -D warnings
         language: system
         # Only run on our real Rust code
         files: ^rust/

--- a/rust/fwupd-ffi/Cargo.toml
+++ b/rust/fwupd-ffi/Cargo.toml
@@ -9,3 +9,6 @@ crate-type = ["staticlib"]
 
 [dependencies]
 fwupd = { path = "../fwupd" }
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }

--- a/rust/fwupd/Cargo.toml
+++ b/rust/fwupd/Cargo.toml
@@ -5,3 +5,6 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }


### PR DESCRIPTION
This way it's available during normal runs and not just during pre-commit.

cc @tmuehlbacher 

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
