### PR TITLE
lenovo-accessory: Add Lenovo AI Mouse support

### DIFF
--- a/plugins/lenovo-accessory/fu-lenovo-accessory-hid-dual-device.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-hid-dual-device.c
@@ -164,7 +164,7 @@ fu_lenovo_accessory_hid_dual_device_setup(FuDevice *device, GError **error)
 	gboolean found_report = FALSE;
 
 	/* the command interface is a vendor HID collection (UsagePage 0xFF00,
-	 * Usage 0x02) carrying a 64-byte report; confirm it is present so we
+	 * Usage 0x01 or 0x02) carrying a 64-byte report; confirm it is present so we
 	 * fail early on a device that does not speak this protocol */
 	descriptors = fu_hid_device_parse_descriptors(FU_HID_DEVICE(self), error);
 	if (descriptors == NULL)
@@ -172,17 +172,32 @@ fu_lenovo_accessory_hid_dual_device_setup(FuDevice *device, GError **error)
 	for (guint i = 0; i < descriptors->len; i++) {
 		FuHidDescriptor *desc = g_ptr_array_index(descriptors, i);
 		g_autoptr(FuHidReport) report = NULL;
+		/* try Usage 0x01 first (newer devices like Chrome AI Mouse) */
 		report = fu_hid_descriptor_find_report(desc,
 						       NULL,
 						       "usage-page",
 						       0xFF00,
 						       "usage",
-						       0x02,
+						       0x01,
 						       "report-size",
 						       8,
 						       "report-count",
 						       0x40,
 						       NULL);
+		/* fallback to Usage 0x02 for older devices */
+		if (report == NULL) {
+			report = fu_hid_descriptor_find_report(desc,
+							       NULL,
+							       "usage-page",
+							       0xFF00,
+							       "usage",
+							       0x02,
+							       "report-size",
+							       8,
+							       "report-count",
+							       0x40,
+							       NULL);
+		}
 		if (report != NULL) {
 			found_report = TRUE;
 			break;
@@ -192,7 +207,7 @@ fu_lenovo_accessory_hid_dual_device_setup(FuDevice *device, GError **error)
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_NOT_SUPPORTED,
-				    "no vendor command report (0xFF00/0x02) found");
+				    "no vendor command report (0xFF00/0x01 or 0xFF00/0x02) found");
 		return FALSE;
 	}
 	if (!fu_lenovo_accessory_impl_get_fwversion(FU_LENOVO_ACCESSORY_IMPL(device),
@@ -230,6 +245,7 @@ fu_lenovo_accessory_hid_dual_device_set_quirk_kv(FuDevice *device,
 		if (!fu_strtoull(value, &tmp, 0, G_MAXUINT8, FU_INTEGER_BASE_AUTO, error))
 			return FALSE;
 		self->interface_number = (guint8)tmp;
+		fu_hid_device_set_interface(FU_HID_DEVICE(self), self->interface_number);
 		return TRUE;
 	}
 

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-hid-dual-device.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-hid-dual-device.c
@@ -11,6 +11,7 @@
 
 struct _FuLenovoAccessoryHidDualDevice {
 	FuHidDevice parent_instance;
+	guint8 interface_number;
 };
 
 static void
@@ -216,6 +217,30 @@ fu_lenovo_accessory_hid_dual_device_set_progress(FuDevice *device, FuProgress *p
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 0, "reload");
 }
 
+static gboolean
+fu_lenovo_accessory_hid_dual_device_set_quirk_kv(FuDevice *device,
+						 const gchar *key,
+						 const gchar *value,
+						 GError **error)
+{
+	FuLenovoAccessoryHidDualDevice *self = FU_LENOVO_ACCESSORY_HID_DUAL_DEVICE(device);
+	guint64 tmp = 0;
+
+	if (g_strcmp0(key, "LenovoAccessoryInterface") == 0) {
+		if (!fu_strtoull(value, &tmp, 0, G_MAXUINT8, FU_INTEGER_BASE_AUTO, error))
+			return FALSE;
+		self->interface_number = (guint8)tmp;
+		return TRUE;
+	}
+
+	/* failed */
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
+	return FALSE;
+}
+
 static void
 fu_lenovo_accessory_hid_dual_device_impl_iface_init(FuLenovoAccessoryImplInterface *iface)
 {
@@ -232,11 +257,15 @@ fu_lenovo_accessory_hid_dual_device_class_init(FuLenovoAccessoryHidDualDeviceCla
 	device_class->set_progress = fu_lenovo_accessory_hid_dual_device_set_progress;
 	device_class->setup = fu_lenovo_accessory_hid_dual_device_setup;
 	device_class->attach = fu_lenovo_accessory_hid_dual_device_attach;
+	device_class->set_quirk_kv = fu_lenovo_accessory_hid_dual_device_set_quirk_kv;
 }
 
 static void
 fu_lenovo_accessory_hid_dual_device_init(FuLenovoAccessoryHidDualDevice *self)
 {
+	/* default interface for dual-bank dongles with 4 interfaces */
+	self->interface_number = FU_LENOVO_ACCESSORY_IFACE_CMD;
+
 	fu_device_set_remove_delay(FU_DEVICE(self), 10000); /* ms */
 	fu_device_add_protocol(FU_DEVICE(self), "com.lenovo.accessory");
 	fu_device_set_install_duration(FU_DEVICE(self), 60);
@@ -246,5 +275,5 @@ fu_lenovo_accessory_hid_dual_device_init(FuLenovoAccessoryHidDualDevice *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_DUAL_IMAGE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE);
-	fu_hid_device_set_interface(FU_HID_DEVICE(self), FU_LENOVO_ACCESSORY_IFACE_CMD);
+	fu_hid_device_set_interface(FU_HID_DEVICE(self), self->interface_number);
 }

--- a/plugins/lenovo-accessory/lenovo-accessory.quirk
+++ b/plugins/lenovo-accessory/lenovo-accessory.quirk
@@ -166,3 +166,18 @@ Name = Helios Gen II Keyboard
 Plugin = lenovo_accessory
 Flags = no-generic-version
 GType = FuLenovoAccessoryBleDevice
+
+# Chrome AI Mouse (BT Mode)
+[BLUETOOTH\VID_17EF&PID_62F4]
+Name = Chrome AI Mouse
+Plugin = lenovo_accessory
+Flags = no-generic-version
+GType = FuLenovoAccessoryBleDevice
+
+# Chrome AI Mouse
+[USB\VID_17EF&PID_62F5]
+Name = Chrome AI Mouse
+Plugin = lenovo_accessory
+GType = FuLenovoAccessoryHidDualDevice
+Flags = detach-kernel-driver
+LenovoAccessoryInterface = 0x02


### PR DESCRIPTION
## Summary

This PR adds support for the Chrome AI Mouse (17EF:62F4/62F5) with both Bluetooth and USB dual-bank firmware update modes.

## Changes

1. **Configurable HID interface** (commit fc866bb)
   - Add `LenovoAccessoryInterface` quirk key to override default interface number
   - Enable devices with non-standard interface layouts (e.g., 3 interfaces instead of 4)
   - Chrome AI Mouse uses interface 2 instead of the typical interface 3

2. **HID Usage 0x01 support** (commit bfde763)
   - Support newer devices using HID Usage 0x01 on firmware update interface
   - Fall back to Usage 0x02 for backward compatibility with existing devices
   - Fix missing `fu_hid_device_set_interface()` call in `set_quirk_kv()`

## New Devices

- Chrome AI Mouse (BT): 17EF:62F4
- Chrome AI Mouse (USB): 17EF:62F5

## Testing

Firmware update verified working on Chrome AI Mouse via both BLE and USB dual-bank modes.

## Backward Compatibility

- Single-bank devices unchanged
- Dual-bank devices maintain compatibility with existing Usage 0x02 dongles
- Default interface number remains 3 for all existing devices