### PR TITLE
modem-manager: Fix case of Rolling RW101 debug mode GUIDs

### DIFF
--- a/plugins/modem-manager/modem-manager.quirk
+++ b/plugins/modem-manager/modem-manager.quirk
@@ -228,14 +228,14 @@ Flags = uninhibit-modemmanager-after-fastboot-reboot,detach-at-fastboot-has-no-r
 CounterpartGuid = USB\VID_33F8&PID_D00D
 
 # Rolling RW101 Debug
-[USB\VID_33F8&PID_01a8]
+[USB\VID_33F8&PID_01A8]
 GType = FuMmFastbootDevice
 Summary = Rolling RW101-GL Module
 Flags = uninhibit-modemmanager-after-fastboot-reboot,detach-at-fastboot-has-no-response
 CounterpartGuid = USB\VID_33F8&PID_D00D
 
 # Rolling RW101-CAT12 Debug
-[USB\VID_33F8&PID_01a9]
+[USB\VID_33F8&PID_01A9]
 GType = FuMmFastbootDevice
 Summary = Rolling RW101-GL-12 Module
 Flags = uninhibit-modemmanager-after-fastboot-reboot,detach-at-fastboot-has-no-response


### PR DESCRIPTION
Fixes #10826

When adding the debug mode quirks for Rolling RW101 (PID 0x01A8) and
RW101-CAT12 (PID 0x01A9) in #10826, the PID values were written in
lowercase hex. Since fwupd GUID hashing is case-sensitive, these
entries do not match the Device IDs reported by ModemManager (e.g.
USB\VID_33F8&PID_01A8), which results in the following error when
updating:

failed to detach: failed to wait for detach replug: device
1f058dc6a6f1438d2223e932f3f73334105ba318 did not come back

Update the PID values to uppercase hex, keeping the same style as the
previously submitted RW101 quirks.

- [x] Code fix