### PR TITLE
device-event: zero unused buffer space on short event reads

### DIFF
--- a/libfwupdplugin/fu-device-event-test.c
+++ b/libfwupdplugin/fu-device-event-test.c
@@ -151,6 +151,37 @@ fu_device_event_strict_order_func(void)
 	g_assert_null(event_tmp);
 }
 
+static void
+fu_device_event_copy_data_func(void)
+{
+	gboolean ret;
+	gsize actual_length = 0;
+	guint8 buf[8] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+	const guint8 data[4] = {0x11, 0x22, 0x33, 0x44};
+	g_autoptr(FuDeviceEvent) event = fu_device_event_new("foo:bar:baz");
+	g_autoptr(GError) error = NULL;
+
+	fu_device_event_set_data(event, "Data", data, sizeof(data));
+
+	/* copy 4-byte recorded event into an 8-byte buffer */
+	ret = fu_device_event_copy_data(event, "Data", buf, sizeof(buf), &actual_length, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_cmpint(actual_length, ==, 4);
+
+	/* verify payload copied correctly */
+	g_assert_cmpint(buf[0], ==, 0x11);
+	g_assert_cmpint(buf[1], ==, 0x22);
+	g_assert_cmpint(buf[2], ==, 0x33);
+	g_assert_cmpint(buf[3], ==, 0x44);
+
+	/* verify the tail was zeroed rather than retaining 0xFF */
+	g_assert_cmpint(buf[4], ==, 0x00);
+	g_assert_cmpint(buf[5], ==, 0x00);
+	g_assert_cmpint(buf[6], ==, 0x00);
+	g_assert_cmpint(buf[7], ==, 0x00);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -159,5 +190,6 @@ main(int argc, char **argv)
 	g_test_add_func("/fwupd/device-event/uncompressed", fu_device_event_uncompressed_func);
 	g_test_add_func("/fwupd/device-event/donor", fu_device_event_donor_func);
 	g_test_add_func("/fwupd/device-event/strict-order", fu_device_event_strict_order_func);
+	g_test_add_func("/fwupd/device-event/copy-data", fu_device_event_copy_data_func);
 	return g_test_run();
 }

--- a/libfwupdplugin/fu-device-event.c
+++ b/libfwupdplugin/fu-device-event.c
@@ -474,8 +474,14 @@ fu_device_event_copy_data(FuDeviceEvent *self,
 	buf_src = g_base64_decode(blobstr, &bufsz_src);
 	if (actual_length != NULL)
 		*actual_length = bufsz_src;
-	if (buf != NULL)
+	if (buf != NULL) {
+		/* the recorded blob may be shorter than the buffer the caller asked us to
+		 * fill, so we zero the remainder so a short event cannot leave the caller
+		 * looking at whatever was already in the allocation */
+		if (bufsz_src < bufsz)
+			memset(buf + bufsz_src, 0x0, bufsz - bufsz_src);
 		return fu_memcpy_safe(buf, bufsz, 0x0, buf_src, bufsz_src, 0x0, bufsz_src, error);
+	}
 	return TRUE;
 }
 

--- a/plugins/bnr-dp/fu-bnr-dp-device.c
+++ b/plugins/bnr-dp/fu-bnr-dp-device.c
@@ -171,7 +171,7 @@ fu_bnr_dp_device_read_response(FuBnrDpDevice *self, GByteArray *data, GError **e
 			    fu_struct_bnr_dp_aux_response_get_data_len(st_response));
 		return FALSE;
 	}
-	g_byte_array_set_size(data, fu_struct_bnr_dp_aux_response_get_data_len(st_response));
+	fu_byte_array_set_size(data, fu_struct_bnr_dp_aux_response_get_data_len(st_response), 0x0);
 	if (data->len > 0) {
 		if (!fu_dpaux_device_read(FU_DPAUX_DEVICE(self),
 					  FU_BNR_DP_DEVICE_DATA_OFFSET,


### PR DESCRIPTION
This ensures buffers are consistently zero-initialized to avoid leaking uninitialized memory when reading smaller-than-expected data.

In fu_device_event_copy_data(), zero the remaining buffer tail when the recorded emulation event payload is shorter than the requested buf size. Added a unit test to verify it works.

In bnr-dp replace g_byte_array_set_size() -> fu_byte_array_set_size() to zero-initialize newly allocated bytes when resizing the response buffer.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
