### PR TITLE
Do not generate vala artifacts during build

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: install dependencies
         run: |
-          brew install meson usb.ids gobject-introspection vala gi-docgen
+          brew install meson usb.ids gobject-introspection gi-docgen
           python3 -m pip install --user jinja2 --break-system-packages
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/contrib/PKGBUILD
+++ b/contrib/PKGBUILD
@@ -46,7 +46,6 @@ makedepends=(
   python-cairo
   python-dbus
   python-gobject
-  vala
   valgrind
 )
 checkdepends=(umockdev)

--- a/contrib/ci/check-meson-install-tags.py
+++ b/contrib/ci/check-meson-install-tags.py
@@ -19,15 +19,6 @@ def parse_version(ver):
     return tuple(map(int, ver.split(".")))
 
 
-# see https://github.com/mesonbuild/meson/pull/14890
-def old_meson_missing_vapi_deps_tag() -> bool:
-    version_str = subprocess.check_output(
-        ["meson", "--version"],
-        text=True,
-    )
-    return parse_version(version_str.strip()) <= parse_version("1.9.0")
-
-
 def objects_with_tag(obj) -> Iterator[dict]:
     match obj:
         case dict(d):
@@ -83,13 +74,9 @@ def check(install_plan) -> int:
     tags = collect_tags(install_plan)
 
     # check for files missing install tag
-    ignore_vapi_deps = old_meson_missing_vapi_deps_tag()
     for null_file in collect_files(install_plan, None):
-        if ignore_vapi_deps and null_file.endswith("fwupd.deps"):
-            logging.warning(f"missing meson install tag: {null_file}")
-        else:
-            logging.error(f"missing meson install tag: {null_file}")
-            exit_code = 1
+        logging.error(f"missing meson install tag: {null_file}")
+        exit_code = 1
 
     # check for incorrect test file tags
     for tag in [t for t in tags if t != "tests"]:

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -1620,30 +1620,6 @@
       <package variant="aarch64" />
     </distro>
   </dependency>
-  <dependency id="valac">
-    <distro id="arch">
-      <package variant="x86_64">vala</package>
-    </distro>
-    <distro id="centos">
-      <package variant="x86_64">vala</package>
-    </distro>
-    <distro id="fedora">
-      <package variant="x86_64">vala</package>
-      <package variant="aarch64">vala</package>
-    </distro>
-    <distro id="darwin">
-      <package>vala</package>
-    </distro>
-    <distro id="debian">
-      <control />
-      <native />
-    </distro>
-    <distro id="ubuntu">
-      <control />
-      <package variant="x86_64" />
-      <package variant="aarch64" />
-    </distro>
-  </dependency>
   <dependency id="valgrind">
     <distro id="arch">
       <package variant="x86_64" />

--- a/contrib/debian/libfwupd-dev.install
+++ b/contrib/debian/libfwupd-dev.install
@@ -3,5 +3,3 @@ usr/include/fwupd-*/libfwupd
 usr/lib/*/libfwupd.so
 usr/lib/*/pkgconfig/fwupd.pc
 usr/share/gir-1.0/Fwupd-*.gir
-usr/share/vala/vapi/fwupd.deps
-usr/share/vala/vapi/fwupd.vapi

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -72,10 +72,6 @@ endif
 override_dh_install:
 	find debian/tmp/usr -type f -name "*a" -print | xargs rm -f
 	sed -i 's,wheel,sudo,' debian/tmp/usr/share/polkit-1/rules.d/org.freedesktop.fwupd.rules
-ifneq ($(DEB_BUILD_ARCH),$(DEB_HOST_ARCH))
-	# vapi is not generated during cross-compilation
-	sed -i '/\/vala\//d' debian/libfwupd-dev.install
-endif
 	dh_install
 	dh_install -pfwupd $$(pkg-config --variable=systemdsystemunitdir systemd | sed s,^/,,)
 	#install MSR conf if needed (depending on distro)

--- a/contrib/freebsd/Makefile
+++ b/contrib/freebsd/Makefile
@@ -13,7 +13,6 @@ LICENSE=	LGPL21
 
 BUILD_DEPENDS=	gi-docgen:textproc/gi-docgen \
 		help2man:misc/help2man \
-		vala:lang/vala \
 		${LOCALBASE}/libexec/fwupd/efi/fwupdx64.efi:sysutils/fwupd-efi \
 		${PYTHON_PKGNAMEPREFIX}gobject3>0:devel/py-gobject3@${PY_FLAVOR}
 LIB_DEPENDS=	libcurl.so:ftp/curl \

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -87,7 +87,6 @@ BuildRequires: gi-docgen
 BuildRequires: gnutls-devel
 BuildRequires: gnutls-utils
 BuildRequires: meson
-BuildRequires: vala
 BuildRequires: pkgconfig(bash-completion)
 BuildRequires: git-core
 BuildRequires: libdrm-devel
@@ -428,7 +427,6 @@ systemctl --no-reload preset fwupd-refresh.timer &>/dev/null || :
 %{_datadir}/doc/libfwupdplugin
 %{_datadir}/doc/libfwupd
 %endif
-%{_datadir}/vala/vapi
 %if 0%{?libfwupd_19x_version}
 %{_includedir}/fwupd-1
 %endif

--- a/contrib/snap/snapcraft.yaml
+++ b/contrib/snap/snapcraft.yaml
@@ -250,7 +250,6 @@ parts:
       - -usr/share/lintian
       - -usr/share/pkgconfig
       - -usr/share/polkit-1
-      - -usr/share/vala
       - -usr/share/doc
       - -usr/share/info
       - -usr/share/gir-1.0

--- a/libfwupd/meson.build
+++ b/libfwupd/meson.build
@@ -251,15 +251,6 @@ if introspection.allowed()
     install: true,
   )
 
-  if not meson.is_cross_build()
-    gnome.generate_vapi(
-      'fwupd',
-      sources: fwupd_gir[0],
-      packages: ['gio-2.0'],
-      install: true,
-    )
-  endif
-
   # Verify the map file is correct -- note we can't actually use the generated
   # file for two reasons:
   #


### PR DESCRIPTION
I'm not sure anyone is actually using vala with libfwupd, and anyone that does want to use vala can use the gir to do the same thing.

If we're adding complexity (e.g. rust) we also have to remove complexity to stay sane, apologies.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
