### PR TITLE
trivial: Do not allow a wildcard name match when finding efivars

### DIFF
--- a/libfwupdplugin/fu-dummy-efivars.c
+++ b/libfwupdplugin/fu-dummy-efivars.c
@@ -86,22 +86,9 @@ fu_dummy_efivars_delete_with_glob(FuEfivars *efivars,
 }
 
 static gboolean
-fu_dummy_efivars_exists_guid(FuDummyEfivars *self, const gchar *guid)
-{
-	for (guint i = 0; i < self->keys->len; i++) {
-		FuDummyEfivarsKey *key = g_ptr_array_index(self->keys, i);
-		if (g_strcmp0(guid, key->guid) == 0)
-			return TRUE;
-	}
-	return FALSE;
-}
-
-static gboolean
 fu_dummy_efivars_exists(FuEfivars *efivars, const gchar *guid, const gchar *name)
 {
 	FuDummyEfivars *self = FU_DUMMY_EFIVARS(efivars);
-	if (name == NULL)
-		return fu_dummy_efivars_exists_guid(self, guid);
 	return fu_dummy_efivars_find_by_guid_name(self, guid, name) != NULL;
 }
 

--- a/libfwupdplugin/fu-efivars.c
+++ b/libfwupdplugin/fu-efivars.c
@@ -138,7 +138,7 @@ fu_efivars_delete_with_glob(FuEfivars *self,
  * fu_efivars_exists:
  * @self: a #FuEfivars
  * @guid: Globally unique identifier
- * @name: (nullable): Variable name
+ * @name: (not nullable): Variable name
  *
  * Test if a variable exists
  *
@@ -153,6 +153,7 @@ fu_efivars_exists(FuEfivars *self, const gchar *guid, const gchar *name)
 
 	g_return_val_if_fail(FU_IS_EFIVARS(self), FALSE);
 	g_return_val_if_fail(guid != NULL, FALSE);
+	g_return_val_if_fail(name != NULL, FALSE);
 
 	if (efivars_class->exists == NULL)
 		return FALSE;

--- a/libfwupdplugin/fu-efivars.h
+++ b/libfwupdplugin/fu-efivars.h
@@ -24,7 +24,7 @@ struct _FuEfivarsClass {
 	guint64 (*space_used)(FuEfivars *self, GError **error) G_GNUC_NON_NULL(1);
 	guint64 (*space_free)(FuEfivars *self, GError **error) G_GNUC_NON_NULL(1);
 	gboolean (*exists)(FuEfivars *self, const gchar *guid, const gchar *name)
-	    G_GNUC_NON_NULL(1, 2);
+	    G_GNUC_NON_NULL(1, 2, 3);
 	GFileMonitor *(*get_monitor)(FuEfivars *self,
 				     const gchar *guid,
 				     const gchar *name,
@@ -71,7 +71,7 @@ fu_efivars_space_used(FuEfivars *self, GError **error) G_GNUC_NON_NULL(1);
 guint64
 fu_efivars_space_free(FuEfivars *self, GError **error) G_GNUC_NON_NULL(1);
 gboolean
-fu_efivars_exists(FuEfivars *self, const gchar *guid, const gchar *name) G_GNUC_NON_NULL(1, 2);
+fu_efivars_exists(FuEfivars *self, const gchar *guid, const gchar *name) G_GNUC_NON_NULL(1, 2, 3);
 GFileMonitor *
 fu_efivars_get_monitor(FuEfivars *self, const gchar *guid, const gchar *name, GError **error)
     G_GNUC_NON_NULL(1, 2, 3);

--- a/libfwupdplugin/fu-freebsd-efivars.c
+++ b/libfwupdplugin/fu-freebsd-efivars.c
@@ -80,21 +80,6 @@ fu_freebsd_efivars_delete_with_glob(FuEfivars *efivars,
 }
 
 static gboolean
-fu_freebsd_efivars_exists_guid(const gchar *guid)
-{
-	efi_guid_t *guidt = NULL;
-	gchar *name = NULL;
-	efi_guid_t test;
-
-	efi_str_to_guid(guid, &test);
-	while (efi_get_next_variable_name(&guidt, &name) == 1) {
-		if (memcmp(&test, guidt, sizeof(test)) == 0)
-			return TRUE;
-	}
-	return FALSE;
-}
-
-static gboolean
 fu_freebsd_efivars_get_data(FuEfivars *efivars,
 			    const gchar *guid,
 			    const gchar *name,
@@ -111,10 +96,6 @@ fu_freebsd_efivars_get_data(FuEfivars *efivars,
 static gboolean
 fu_freebsd_efivars_exists(FuEfivars *efivars, const gchar *guid, const gchar *name)
 {
-	/* any name */
-	if (name == NULL)
-		return fu_freebsd_efivars_exists_guid(guid);
-
 	return fu_freebsd_efivars_get_data(efivars, guid, name, NULL, NULL, NULL, NULL);
 }
 

--- a/libfwupdplugin/fu-linux-efivars.c
+++ b/libfwupdplugin/fu-linux-efivars.c
@@ -207,33 +207,9 @@ fu_linux_efivars_delete_with_glob(FuEfivars *efivars,
 }
 
 static gboolean
-fu_linux_efivars_exists_guid(FuEfivars *efivars, const gchar *guid)
-{
-	const gchar *fn;
-	g_autofree gchar *efivarsdir = NULL;
-	g_autoptr(GDir) dir = NULL;
-
-	efivarsdir = fu_linux_efivars_get_path(efivars, NULL);
-	if (efivarsdir == NULL)
-		return FALSE;
-	dir = g_dir_open(efivarsdir, 0, NULL);
-	if (dir == NULL)
-		return FALSE;
-	while ((fn = g_dir_read_name(dir)) != NULL) {
-		if (g_str_has_suffix(fn, guid))
-			return TRUE;
-	}
-	return TRUE;
-}
-
-static gboolean
 fu_linux_efivars_exists(FuEfivars *efivars, const gchar *guid, const gchar *name)
 {
 	g_autofree gchar *fn = NULL;
-
-	/* any name */
-	if (name == NULL)
-		return fu_linux_efivars_exists_guid(efivars, guid);
 
 	fn = fu_linux_efivars_get_filename(efivars, guid, name, NULL);
 	if (fn == NULL)


### PR DESCRIPTION
The name-less mode has been broken and untested for years as nothing actually uses it anymore. Many thanks to @whot for spotting it.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
