### PR TITLE
cros-ec: keep raw_version terminated when the FWID area fills it

### DIFF
--- a/plugins/cros-ec/fu-cros-ec-firmware.c
+++ b/plugins/cros-ec/fu-cros-ec-firmware.c
@@ -115,13 +115,14 @@ fu_cros_ec_firmware_ensure_version(FuCrosEcFirmware *self, GError **error)
 			g_prefix_error(error, "unable to get bytes from %s: ", fmap_fwid_name);
 			return FALSE;
 		}
+		/* the FWID area may fill the whole field, so keep room for the terminator */
 		if (!fu_memcpy_safe((guint8 *)section->raw_version,
 				    FU_FMAP_FIRMWARE_STRLEN,
 				    0x0,
 				    g_bytes_get_data(fwid_bytes, NULL),
 				    g_bytes_get_size(fwid_bytes),
 				    0x0,
-				    g_bytes_get_size(fwid_bytes),
+				    MIN(g_bytes_get_size(fwid_bytes), FU_FMAP_FIRMWARE_STRLEN - 1),
 				    error))
 			return FALSE;
 


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

**Unterminated FWID copy in fu_cros_ec_firmware_ensure_version**

The `RO_FRID`/`RW_FWID` area is copied into the 32-byte `raw_version` field with the area size as the copy length, so an image whose FWID fills the field leaves no terminator and `fu_cros_ec_version_parse()` then walks on into the neighbouring struct members. The plugin's own builder seed already has that shape (24 characters space-padded to 32), and clamping the copy to `FU_FMAP_FIRMWARE_STRLEN - 1` leaves images that do carry a NUL behaving as before.
