### PR TITLE
trivial: Fix zero-padded pair versions

### DIFF
--- a/libfwupd/fwupd-enums.rs
+++ b/libfwupd/fwupd-enums.rs
@@ -197,4 +197,7 @@ enum FwupdVersionFormat {
     // Compal BIOS-style version number, as two hex bytes.
     // Since: 2.1.4
     CompalBios,
+    // Two AABB.CCDD version numbers with a zero-padded second section.
+    // Since: 2.2.1
+    PairPadded,
 }

--- a/libfwupdplugin/fu-device-test.c
+++ b/libfwupdplugin/fu-device-test.c
@@ -18,11 +18,43 @@ static void
 fu_device_version_format_func(void)
 {
 	g_autoptr(FuDevice) device = fu_device_new(NULL);
+	g_autoptr(FuDevice) device_aux = fu_device_new(NULL);
+	g_autoptr(FuDevice) device_format = fu_device_new(NULL);
+	g_autoptr(FuDevice) device_raw = fu_device_new(NULL);
+	g_autoptr(FuDevice) device_version = fu_device_new(NULL);
+
 	fu_device_add_private_flag(device, FU_DEVICE_PRIVATE_FLAG_ENSURE_SEMVER);
 	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);
 	/* nocheck:set-version */
 	fu_device_set_version(device, "Ver1.2.3 RELEASE");
 	g_assert_cmpstr(fu_device_get_version(device), ==, "1.2.3");
+
+	fu_device_set_version(device_format, "26.6"); /* nocheck:set-version */
+	fu_device_set_version_lowest(device_format, "26.6");	 /* nocheck:set-version */
+	fu_device_set_version_highest(device_format, "26.6");	 /* nocheck:set-version */
+	fu_device_set_version_bootloader(device_format, "26.6"); /* nocheck:set-version */
+	fu_device_set_version_format(device_format, FWUPD_VERSION_FORMAT_PAIR_PADDED);
+	g_assert_cmpstr(fu_device_get_version(device_format), ==, "26.06");
+	g_assert_cmpstr(fu_device_get_version_lowest(device_format), ==, "26.06");
+	g_assert_cmpstr(fu_device_get_version_highest(device_format), ==, "26.06");
+	g_assert_cmpstr(fu_device_get_version_bootloader(device_format), ==, "26.06");
+
+	fu_device_set_version(device_raw, "26.6"); /* nocheck:set-version */
+	fu_device_set_version_raw(device_raw, 0x1a06);
+	fu_device_set_version_format(device_raw, FWUPD_VERSION_FORMAT_PAIR_PADDED);
+	g_assert_cmpstr(fu_device_get_version(device_raw), ==, "26.06");
+
+	fu_device_set_version_format(device_version, FWUPD_VERSION_FORMAT_PAIR_PADDED);
+	fu_device_set_version(device_version, "26.6"); /* nocheck:set-version */
+	g_assert_cmpstr(fu_device_get_version(device_version), ==, "26.06");
+
+	fu_device_set_version_format(device_aux, FWUPD_VERSION_FORMAT_PAIR_PADDED);
+	fu_device_set_version_lowest(device_aux, "26.6");     /* nocheck:set-version */
+	fu_device_set_version_highest(device_aux, "26.6");    /* nocheck:set-version */
+	fu_device_set_version_bootloader(device_aux, "26.6"); /* nocheck:set-version */
+	g_assert_cmpstr(fu_device_get_version_lowest(device_aux), ==, "26.06");
+	g_assert_cmpstr(fu_device_get_version_highest(device_aux), ==, "26.06");
+	g_assert_cmpstr(fu_device_get_version_bootloader(device_aux), ==, "26.06");
 }
 
 static void
@@ -45,6 +77,39 @@ fu_device_version_format_raw_func(void)
 	g_assert_cmpstr(fu_device_get_version(device), ==, "256");
 	g_assert_cmpstr(fu_device_get_version_lowest(device), ==, "257");
 	g_assert_cmpstr(fu_device_get_version_highest(device), ==, "258");
+}
+
+static void
+fu_device_version_format_metadata_func(void)
+{
+	gboolean ret;
+	const gchar *xml = "<component>"
+			   "<custom>"
+			   "<value key=\"LVFS::VersionFormat\">pair-padded</value>"
+			   "</custom>"
+			   "</component>";
+	g_autoptr(FuDevice) device = fu_device_new(NULL);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(XbNode) component = NULL;
+	g_autoptr(XbSilo) silo = NULL;
+
+	fu_device_add_private_flag(device, FU_DEVICE_PRIVATE_FLAG_MD_SET_VERFMT);
+	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_PAIR);
+	fu_device_set_version(device, "26.6"); /* nocheck:set-version */
+
+	silo = xb_silo_new_from_xml(xml, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(silo);
+	component = xb_silo_query_first(silo, "component", &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(component);
+
+	fu_device_ensure_from_component(device, component);
+	g_assert_cmpint(fu_device_get_version_format(device), ==, FWUPD_VERSION_FORMAT_PAIR_PADDED);
+	g_assert_cmpstr(fu_device_get_version(device), ==, "26.06");
+
+	ret = fu_device_has_private_flag(device, FU_DEVICE_PRIVATE_FLAG_MD_SET_VERFMT);
+	g_assert_false(ret);
 }
 
 static void
@@ -1079,6 +1144,8 @@ main(int argc, char **argv)
 	g_test_add_func("/fwupd/device/open-refcount", fu_device_open_refcount_func);
 	g_test_add_func("/fwupd/device/version-format", fu_device_version_format_func);
 	g_test_add_func("/fwupd/device/version-format-raw", fu_device_version_format_raw_func);
+	g_test_add_func("/fwupd/device/version-format-metadata",
+			fu_device_version_format_metadata_func);
 	g_test_add_func("/fwupd/device/retry-success", fu_device_retry_success_func);
 	g_test_add_func("/fwupd/device/retry-failed", fu_device_retry_failed_func);
 	g_test_add_func("/fwupd/device/retry-hardware", fu_device_retry_hardware_func);

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -3480,6 +3480,29 @@ fu_device_set_id(FuDevice *self, const gchar *id)
 }
 
 /**
+ * fu_device_ensure_version_safe:
+ * @self: a #FuDevice
+ * @version: (nullable): a string, e.g. `1.2.3`
+ *
+ * Returns a sanitized version string if required.
+ */
+static gchar *
+fu_device_ensure_version_safe(FuDevice *self, const gchar *version)
+{
+	g_autofree gchar *version_safe = NULL;
+
+	if (fu_device_has_private_flag(self, FU_DEVICE_PRIVATE_FLAG_ENSURE_SEMVER) ||
+	    fu_device_get_version_format(self) == FWUPD_VERSION_FORMAT_PAIR_PADDED) {
+		version_safe =
+		    fu_version_ensure_semver(version, fu_device_get_version_format(self));
+		if (g_strcmp0(version, version_safe) != 0)
+			g_debug("converted '%s' to '%s'", version, version_safe);
+		return g_steal_pointer(&version_safe);
+	}
+	return g_strdup(version);
+}
+
+/**
  * fu_device_set_version_format:
  * @self: a #FuDevice
  * @fmt: the version format, e.g. %FWUPD_VERSION_FORMAT_PLAIN
@@ -3524,6 +3547,17 @@ fu_device_set_version_format(FuDevice *self, FwupdVersionFormat fmt)
 			fu_device_set_version_highest(self, version);
 		}
 	}
+	if (fmt == FWUPD_VERSION_FORMAT_PAIR_PADDED) {
+		if (fu_device_get_version(self) != NULL)
+			fu_device_set_version(self, fu_device_get_version(self));
+		if (fu_device_get_version_lowest(self) != NULL)
+			fu_device_set_version_lowest(self, fu_device_get_version_lowest(self));
+		if (fu_device_get_version_highest(self) != NULL)
+			fu_device_set_version_highest(self, fu_device_get_version_highest(self));
+		if (fu_device_get_version_bootloader(self) != NULL)
+			fu_device_set_version_bootloader(self,
+							 fu_device_get_version_bootloader(self));
+	}
 }
 
 /**
@@ -3543,15 +3577,7 @@ fu_device_set_version(FuDevice *self, const gchar *version)
 
 	g_return_if_fail(FU_IS_DEVICE(self));
 
-	/* sanitize if required */
-	if (fu_device_has_private_flag(self, FU_DEVICE_PRIVATE_FLAG_ENSURE_SEMVER)) {
-		version_safe =
-		    fu_version_ensure_semver(version, fu_device_get_version_format(self));
-		if (g_strcmp0(version, version_safe) != 0)
-			g_debug("converted '%s' to '%s'", version, version_safe);
-	} else {
-		version_safe = g_strdup(version);
-	}
+	version_safe = fu_device_ensure_version_safe(self, version);
 
 	/* print a console warning for an invalid version, if semver */
 	if (version_safe != NULL &&
@@ -3591,15 +3617,7 @@ fu_device_set_version_lowest(FuDevice *self, const gchar *version)
 
 	g_return_if_fail(FU_IS_DEVICE(self));
 
-	/* sanitize if required */
-	if (fu_device_has_private_flag(self, FU_DEVICE_PRIVATE_FLAG_ENSURE_SEMVER)) {
-		version_safe =
-		    fu_version_ensure_semver(version, fu_device_get_version_format(self));
-		if (g_strcmp0(version, version_safe) != 0)
-			g_debug("converted '%s' to '%s'", version, version_safe);
-	} else {
-		version_safe = g_strdup(version);
-	}
+	version_safe = fu_device_ensure_version_safe(self, version);
 
 	/* print a console warning for an invalid version, if semver */
 	if (version_safe != NULL &&
@@ -3639,15 +3657,7 @@ fu_device_set_version_highest(FuDevice *self, const gchar *version)
 
 	g_return_if_fail(FU_IS_DEVICE(self));
 
-	/* sanitize if required */
-	if (fu_device_has_private_flag(self, FU_DEVICE_PRIVATE_FLAG_ENSURE_SEMVER)) {
-		version_safe =
-		    fu_version_ensure_semver(version, fu_device_get_version_format(self));
-		if (g_strcmp0(version, version_safe) != 0)
-			g_debug("converted '%s' to '%s'", version, version_safe);
-	} else {
-		version_safe = g_strdup(version);
-	}
+	version_safe = fu_device_ensure_version_safe(self, version);
 
 	/* print a console warning for an invalid version, if semver */
 	if (version_safe != NULL &&
@@ -3682,18 +3692,12 @@ fu_device_set_version_highest(FuDevice *self, const gchar *version)
 void
 fu_device_set_version_bootloader(FuDevice *self, const gchar *version)
 {
+	g_autofree gchar *version_safe = NULL;
+
 	g_return_if_fail(FU_IS_DEVICE(self));
 
-	/* sanitize if required */
-	if (fu_device_has_private_flag(self, FU_DEVICE_PRIVATE_FLAG_ENSURE_SEMVER)) {
-		g_autofree gchar *version_safe =
-		    fu_version_ensure_semver(version, fu_device_get_version_format(self));
-		if (g_strcmp0(version, version_safe) != 0)
-			g_debug("converted '%s' to '%s'", version, version_safe);
-		fwupd_device_set_version_bootloader(FWUPD_DEVICE(self), version_safe);
-	} else {
-		fwupd_device_set_version_bootloader(FWUPD_DEVICE(self), version);
-	}
+	version_safe = fu_device_ensure_version_safe(self, version);
+	fwupd_device_set_version_bootloader(FWUPD_DEVICE(self), version_safe);
 }
 
 /**

--- a/libfwupdplugin/fu-version-common.c
+++ b/libfwupdplugin/fu-version-common.c
@@ -17,7 +17,7 @@
 #include "fu-version-common.h"
 
 /*
- * nocheck:magic-inlines=81
+ * nocheck:magic-inlines=93
  */
 
 #define FU_COMMON_VERSION_DECODE_BCD(val) (((((val) >> 4) & 0x0f) * 10) + ((val) & 0x0f))
@@ -53,6 +53,12 @@ fu_version_from_uint64(guint64 val, FwupdVersionFormat kind)
 	if (kind == FWUPD_VERSION_FORMAT_PAIR) {
 		/* AABBCCDD.EEFFGGHH */
 		return g_strdup_printf("%" G_GUINT64_FORMAT ".%" G_GUINT64_FORMAT "",
+				       (val >> 32) & 0xffffffff,
+				       val & 0xffffffff);
+	}
+	if (kind == FWUPD_VERSION_FORMAT_PAIR_PADDED) {
+		/* AABBCCDD.EEFFGGHH */
+		return g_strdup_printf("%" G_GUINT64_FORMAT ".%02" G_GUINT64_FORMAT,
 				       (val >> 32) & 0xffffffff,
 				       val & 0xffffffff);
 	}
@@ -110,6 +116,10 @@ fu_version_from_uint32(guint32 val, FwupdVersionFormat kind)
 	if (kind == FWUPD_VERSION_FORMAT_PAIR) {
 		/* AABB.CCDD */
 		return g_strdup_printf("%u.%u", (val >> 16) & 0xffff, val & 0xffff);
+	}
+	if (kind == FWUPD_VERSION_FORMAT_PAIR_PADDED) {
+		/* AABB.CCDD */
+		return g_strdup_printf("%u.%02u", (val >> 16) & 0xffff, val & 0xffff);
 	}
 	if (kind == FWUPD_VERSION_FORMAT_COMPAL_BIOS) {
 		/* AA.BB */
@@ -209,6 +219,8 @@ fu_version_from_uint32_hex(guint32 val, FwupdVersionFormat kind)
 		return g_strdup_printf("%x", val);
 	if (kind == FWUPD_VERSION_FORMAT_PAIR)
 		return g_strdup_printf("%x.%x", (val >> 16) & 0xffff, val & 0xffff);
+	if (kind == FWUPD_VERSION_FORMAT_PAIR_PADDED)
+		return g_strdup_printf("%x.%02x", (val >> 16) & 0xffff, val & 0xffff);
 	if (kind == FWUPD_VERSION_FORMAT_TRIPLET) {
 		return g_strdup_printf("%x.%x.%x",
 				       (val >> 24) & 0xff,
@@ -273,6 +285,10 @@ fu_version_from_uint24(guint32 val, FwupdVersionFormat kind)
 		/* BB.CCDD */
 		return g_strdup_printf("%u.%u", (val >> 16) & 0xff, val & 0xffff);
 	}
+	if (kind == FWUPD_VERSION_FORMAT_PAIR_PADDED) {
+		/* BB.CCDD */
+		return g_strdup_printf("%u.%02u", (val >> 16) & 0xff, val & 0xffff);
+	}
 	if (kind == FWUPD_VERSION_FORMAT_NUMBER || kind == FWUPD_VERSION_FORMAT_PLAIN) {
 		/* BBCCDD */
 		return g_strdup_printf("%" G_GUINT32_FORMAT, val);
@@ -308,6 +324,8 @@ fu_version_from_uint16(guint16 val, FwupdVersionFormat kind)
 	}
 	if (kind == FWUPD_VERSION_FORMAT_PAIR)
 		return g_strdup_printf("%u.%u", (guint)(val >> 8) & 0xff, (guint)val & 0xff);
+	if (kind == FWUPD_VERSION_FORMAT_PAIR_PADDED)
+		return g_strdup_printf("%u.%02u", (guint)(val >> 8) & 0xff, (guint)val & 0xff);
 	if (kind == FWUPD_VERSION_FORMAT_COMPAL_BIOS)
 		return g_strdup_printf("%02x.%02x", (guint)(val >> 8) & 0xff, (guint)val & 0xff);
 	if (kind == FWUPD_VERSION_FORMAT_QUAD) {
@@ -355,6 +373,8 @@ fu_version_from_uint16_hex(guint16 val, FwupdVersionFormat kind)
 		return g_strdup_printf("0x%x", val);
 	if (kind == FWUPD_VERSION_FORMAT_PAIR)
 		return g_strdup_printf("%x.%x", (guint)(val >> 8) & 0xff, (guint)val & 0xff);
+	if (kind == FWUPD_VERSION_FORMAT_PAIR_PADDED)
+		return g_strdup_printf("%x.%02x", (guint)(val >> 8) & 0xff, (guint)val & 0xff);
 	if (kind == FWUPD_VERSION_FORMAT_BCD) {
 		return g_strdup_printf("%x.%x",
 				       (guint)FU_COMMON_VERSION_DECODE_BCD(val >> 8),
@@ -434,8 +454,8 @@ fu_version_format_number_sections(FwupdVersionFormat fmt)
 	if (fmt == FWUPD_VERSION_FORMAT_PLAIN || fmt == FWUPD_VERSION_FORMAT_NUMBER ||
 	    fmt == FWUPD_VERSION_FORMAT_HEX)
 		return 1;
-	if (fmt == FWUPD_VERSION_FORMAT_PAIR || fmt == FWUPD_VERSION_FORMAT_COMPAL_BIOS ||
-	    fmt == FWUPD_VERSION_FORMAT_BCD)
+	if (fmt == FWUPD_VERSION_FORMAT_PAIR || fmt == FWUPD_VERSION_FORMAT_PAIR_PADDED ||
+	    fmt == FWUPD_VERSION_FORMAT_COMPAL_BIOS || fmt == FWUPD_VERSION_FORMAT_BCD)
 		return 2;
 	if (fmt == FWUPD_VERSION_FORMAT_TRIPLET || fmt == FWUPD_VERSION_FORMAT_SURFACE_LEGACY ||
 	    fmt == FWUPD_VERSION_FORMAT_SURFACE || fmt == FWUPD_VERSION_FORMAT_DELL_BIOS ||
@@ -445,6 +465,24 @@ fu_version_format_number_sections(FwupdVersionFormat fmt)
 	    fmt == FWUPD_VERSION_FORMAT_INTEL_ME2 || fmt == FWUPD_VERSION_FORMAT_INTEL_CSME19)
 		return 4;
 	return 0;
+}
+
+static void
+fu_version_ensure_semver_append(GString *str,
+				const gchar *section,
+				FwupdVersionFormat fmt,
+				guint idx)
+{
+	guint64 tmp = 0;
+
+	if (str->len > 0)
+		g_string_append(str, ".");
+	if (fmt == FWUPD_VERSION_FORMAT_PAIR_PADDED && idx == 1 &&
+	    fu_strtoull(section, &tmp, 0, G_MAXUINT64, FU_INTEGER_BASE_10, NULL)) {
+		g_string_append_printf(str, "%02" G_GUINT64_FORMAT, tmp);
+		return;
+	}
+	g_string_append(str, section);
 }
 
 /**
@@ -464,6 +502,7 @@ fu_version_ensure_semver(const gchar *version, FwupdVersionFormat fmt)
 {
 	guint sections_actual;
 	guint sections_expected = fu_version_format_number_sections(fmt);
+	guint idx = 0;
 	g_autofree gchar *tmp = NULL;
 	g_auto(GStrv) split = NULL;
 	g_autoptr(GString) str = g_string_new(NULL);
@@ -479,19 +518,13 @@ fu_version_ensure_semver(const gchar *version, FwupdVersionFormat fmt)
 
 	/* add zero sections as required */
 	if (sections_actual < sections_expected) {
-		for (guint i = 0; i < sections_expected - sections_actual; i++) {
-			if (str->len > 0)
-				g_string_append(str, ".");
-			g_string_append(str, "0");
-		}
+		for (guint i = 0; i < sections_expected - sections_actual; i++)
+			fu_version_ensure_semver_append(str, "0", fmt, idx++);
 	}
 
 	/* only add enough sections for the format */
-	for (guint i = 0; i < sections_actual && i < sections_expected; i++) {
-		if (str->len > 0)
-			g_string_append(str, ".");
-		g_string_append(str, split[i]);
-	}
+	for (guint i = 0; i < sections_actual && i < sections_expected; i++)
+		fu_version_ensure_semver_append(str, split[i], fmt, idx++);
 
 	/* success */
 	return g_string_free(g_steal_pointer(&str), FALSE);
@@ -652,7 +685,7 @@ fu_version_format_convert_base(FwupdVersionFormat fmt)
 	if (fmt == FWUPD_VERSION_FORMAT_DELL_BIOS || fmt == FWUPD_VERSION_FORMAT_DELL_BIOS_MSB ||
 	    fmt == FWUPD_VERSION_FORMAT_SURFACE || fmt == FWUPD_VERSION_FORMAT_SURFACE_LEGACY)
 		return FWUPD_VERSION_FORMAT_TRIPLET;
-	if (fmt == FWUPD_VERSION_FORMAT_BCD)
+	if (fmt == FWUPD_VERSION_FORMAT_BCD || fmt == FWUPD_VERSION_FORMAT_PAIR_PADDED)
 		return FWUPD_VERSION_FORMAT_PAIR;
 	if (fmt == FWUPD_VERSION_FORMAT_HEX)
 		return FWUPD_VERSION_FORMAT_NUMBER;

--- a/libfwupdplugin/fu-version-test.c
+++ b/libfwupdplugin/fu-version-test.c
@@ -42,6 +42,9 @@ fu_version_verify_format_func(void)
 	ret = fu_version_verify_format("12.34", FWUPD_VERSION_FORMAT_COMPAL_BIOS, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
+	ret = fu_version_verify_format("26.06", FWUPD_VERSION_FORMAT_PAIR_PADDED, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
 }
 
 static void
@@ -58,6 +61,8 @@ fu_version_semver_func(void)
 		   {"CBET1.2.3", "1.2.3", FWUPD_VERSION_FORMAT_TRIPLET},
 		   {"4.11-1190-g12d8072e6b-dirty", "4.11.1190", FWUPD_VERSION_FORMAT_TRIPLET},
 		   {"4.11-1190-g12d8072e6b-dirty", "4.11", FWUPD_VERSION_FORMAT_PAIR},
+		   {"26.6", "26.06", FWUPD_VERSION_FORMAT_PAIR_PADDED},
+		   {"26.06", "26.06", FWUPD_VERSION_FORMAT_PAIR_PADDED},
 		   {NULL, NULL}};
 	for (guint i = 0; map[i].old != NULL; i++) {
 		g_autofree gchar *tmp = fu_version_ensure_semver(map[i].old, map[i].fmt);
@@ -96,6 +101,8 @@ fu_version_func(void)
 	    {0x00ff0001, "255.0.1", FWUPD_VERSION_FORMAT_DELL_BIOS},
 	    {0x010f0201, "1.15.2", FWUPD_VERSION_FORMAT_DELL_BIOS_MSB},
 	    {0xc8, "0x000000c8", FWUPD_VERSION_FORMAT_HEX},
+	    {0x001a0006, "26.06", FWUPD_VERSION_FORMAT_PAIR_PADDED},
+	    {0x001a000a, "26.10", FWUPD_VERSION_FORMAT_PAIR_PADDED},
 	    {0x0, "00.00", FWUPD_VERSION_FORMAT_COMPAL_BIOS},
 	    {0xff, "00.ff", FWUPD_VERSION_FORMAT_COMPAL_BIOS},
 	    {0x0000ff01, "ff.01", FWUPD_VERSION_FORMAT_COMPAL_BIOS},
@@ -121,6 +128,7 @@ fu_version_func(void)
 	    {0xffffffffffffffff, "65535.65535.65535.65535", FWUPD_VERSION_FORMAT_QUAD},
 	    {0xff, "0.255", FWUPD_VERSION_FORMAT_PAIR},
 	    {0xffffffffffffffff, "4294967295.4294967295", FWUPD_VERSION_FORMAT_PAIR},
+	    {0x1a00000006, "26.06", FWUPD_VERSION_FORMAT_PAIR_PADDED},
 	    {0x0, "0", FWUPD_VERSION_FORMAT_NUMBER},
 	    {0x11000000c8, "0x00000011000000c8", FWUPD_VERSION_FORMAT_HEX},
 	    {0x0, "00.00", FWUPD_VERSION_FORMAT_COMPAL_BIOS},
@@ -136,6 +144,7 @@ fu_version_func(void)
 	    {0x0, "0.0", FWUPD_VERSION_FORMAT_PAIR},
 	    {0xff, "0.255", FWUPD_VERSION_FORMAT_PAIR},
 	    {0xff01, "255.1", FWUPD_VERSION_FORMAT_PAIR},
+	    {0x1a06, "26.06", FWUPD_VERSION_FORMAT_PAIR_PADDED},
 	    {0x0, "0.0", FWUPD_VERSION_FORMAT_BCD},
 	    {0x0110, "1.10", FWUPD_VERSION_FORMAT_BCD},
 	    {0x9999, "99.99", FWUPD_VERSION_FORMAT_BCD},

--- a/src/fu-release.c
+++ b/src/fu-release.c
@@ -600,7 +600,11 @@ static gboolean
 fu_release_check_verfmt_compatible(FuRelease *self, FwupdVersionFormat fmt_rel)
 {
 	FwupdVersionFormat fmt_dev = fu_device_get_version_format(self->device);
-	if (fmt_dev == FWUPD_VERSION_FORMAT_BCD && fmt_rel == FWUPD_VERSION_FORMAT_PAIR)
+	if (fmt_dev == FWUPD_VERSION_FORMAT_BCD &&
+	    (fmt_rel == FWUPD_VERSION_FORMAT_PAIR || fmt_rel == FWUPD_VERSION_FORMAT_PAIR_PADDED))
+		return TRUE;
+	if ((fmt_dev == FWUPD_VERSION_FORMAT_PAIR || fmt_dev == FWUPD_VERSION_FORMAT_PAIR_PADDED) &&
+	    (fmt_rel == FWUPD_VERSION_FORMAT_PAIR || fmt_rel == FWUPD_VERSION_FORMAT_PAIR_PADDED))
 		return TRUE;
 	return fmt_dev == fmt_rel;
 }


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Fix prompts like:

```
Upgrade System Firmware from 26.6 to 26.08?
```

The installed version should be shown as `26.06`.
