### PR TITLE
Allow enumeration BIOS settings to take either string or integer

### DIFF
--- a/libfwupd/fwupd-bios-setting-test.c
+++ b/libfwupd/fwupd-bios-setting-test.c
@@ -68,6 +68,25 @@ fwupd_bios_settings_raw_mapped_func(void)
 			==,
 			"False");
 	g_assert_cmpstr(fwupd_test_bios_setting_get_value_raw(setting), ==, "0");
+
+	/* the user can also provide the raw value directly, e.g. "1" instead of "True" */
+	ret = fwupd_bios_setting_write_value(FWUPD_BIOS_SETTING(setting), "1", &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_cmpstr(fwupd_bios_setting_get_current_value(FWUPD_BIOS_SETTING(setting)),
+			==,
+			"True");
+	g_assert_cmpstr(fwupd_test_bios_setting_get_value_raw(setting), ==, "1");
+
+	/* unsupported values should fail and leave the current value unchanged */
+	ret = fwupd_bios_setting_write_value(FWUPD_BIOS_SETTING(setting), "2", &error);
+	g_assert_false(ret);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
+	g_clear_error(&error);
+	g_assert_cmpstr(fwupd_bios_setting_get_current_value(FWUPD_BIOS_SETTING(setting)),
+			==,
+			"True");
+	g_assert_cmpstr(fwupd_test_bios_setting_get_value_raw(setting), ==, "1");
 }
 
 static void

--- a/libfwupd/fwupd-bios-setting.c
+++ b/libfwupd/fwupd-bios-setting.c
@@ -542,15 +542,26 @@ fwupd_bios_setting_map_possible_value(FwupdBiosSetting *self, const gchar *key, 
 	/* explicitly specified by fwupd_bios_setting_add_possible_value_full() */
 	if (priv->possible_values_to_raw != NULL) {
 		const gchar *value_raw = g_hash_table_lookup(priv->possible_values_to_raw, key);
-		if (value_raw == NULL) {
-			g_set_error(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOT_SUPPORTED,
-				    "cannot map %s to display value",
-				    key);
-			return NULL;
-		}
-		return value_raw;
+		gpointer value_raw_key = NULL;
+
+		/* the user provided the display value, e.g. "Disabled" */
+		if (value_raw != NULL)
+			return value_raw;
+
+		/* the user provided the raw value directly, e.g. "0" */
+		if (priv->possible_values_from_raw != NULL &&
+		    g_hash_table_lookup_extended(priv->possible_values_from_raw,
+						 key,
+						 &value_raw_key,
+						 NULL))
+			return value_raw_key;
+
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "cannot map %s to display value",
+			    key);
+		return NULL;
 	}
 
 	lower_key = g_utf8_strdown(key, -1);
@@ -941,6 +952,15 @@ fwupd_bios_setting_write_value(FwupdBiosSetting *self, const gchar *value, GErro
 	/* proxy */
 	if (!klass->write_value(self, value_raw, error))
 		return FALSE;
+
+	/* the user may have provided the raw value, so store the canonical display value */
+	if (priv->kind == FWUPD_BIOS_SETTING_KIND_ENUMERATION &&
+	    priv->possible_values_from_raw != NULL) {
+		const gchar *value_display =
+		    g_hash_table_lookup(priv->possible_values_from_raw, value_raw);
+		if (value_display != NULL)
+			value = value_display;
+	}
 	fwupd_bios_setting_set_current_value(self, value);
 
 	/* success */


### PR DESCRIPTION
Given the following setting:
```
Dedicated Video Memory:
  Setting type:         Enumeration
  Current Value:        Minimum (512 MB)
  Description:          GPU unified memory architecture carveout size for system memory
  AppStream ID:         org.fwupd.bios.video-memory
  Icon:                 video-display
  Read Only:            False
    0:                  Minimum (512 MB)
    1:                  (1 GB)
    2:                  (2 GB)
    3:                  (4 GB)
    4:                  Medium (8 GB)
    5:                  High (16 GB)
```

Users are trying to do `set-bios-setting "Dedicated Video Memory" 3` and this doesn't work.

Allow that combo to work in addition to the string.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
