### PR TITLE
Bind the BlueZ signal subscriptions to the correct GMainContext

### DIFF
--- a/src/fu-bluez-backend.c
+++ b/src/fu-bluez-backend.c
@@ -18,8 +18,6 @@ struct _FuBluezBackend {
 
 G_DEFINE_TYPE(FuBluezBackend, fu_bluez_backend, FU_TYPE_BACKEND)
 
-#define FU_BLUEZ_BACKEND_TIMEOUT 1500 /* ms */
-
 static void
 fu_bluez_backend_object_properties_changed(FuBluezBackend *self, GDBusProxy *proxy)
 {
@@ -128,48 +126,6 @@ fu_bluez_backend_object_removed_cb(GDBusObjectManager *manager,
 	fu_backend_device_removed(FU_BACKEND(self), device_tmp);
 }
 
-typedef struct {
-	GDBusObjectManager *object_manager;
-	GMainLoop *loop;
-	GError **error;
-	GCancellable *cancellable;
-	GSource *timeout_source;
-} FuBluezBackendHelper;
-
-static void
-fu_bluez_backend_helper_free(FuBluezBackendHelper *helper)
-{
-	if (helper->object_manager != NULL)
-		g_object_unref(helper->object_manager);
-	if (helper->timeout_source != NULL) {
-		g_source_destroy(helper->timeout_source);
-		g_source_unref(helper->timeout_source);
-	}
-	g_cancellable_cancel(helper->cancellable);
-	g_main_loop_unref(helper->loop);
-	g_free(helper);
-}
-
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuBluezBackendHelper, fu_bluez_backend_helper_free)
-
-static void
-fu_bluez_backend_connect_cb(GObject *source_object, GAsyncResult *res, gpointer user_data)
-{
-	FuBluezBackendHelper *helper = (FuBluezBackendHelper *)user_data;
-	helper->object_manager =
-	    g_dbus_object_manager_client_new_for_bus_finish(res, helper->error);
-	g_main_loop_quit(helper->loop);
-}
-
-static gboolean
-fu_bluez_backend_timeout_cb(gpointer user_data)
-{
-	FuBluezBackendHelper *helper = (FuBluezBackendHelper *)user_data;
-	g_cancellable_cancel(helper->cancellable);
-	g_clear_pointer(&helper->timeout_source, g_source_unref);
-	return G_SOURCE_REMOVE;
-}
-
 static gboolean
 fu_bluez_backend_setup(FuBackend *backend,
 		       FuBackendSetupFlags flags,
@@ -179,33 +135,29 @@ fu_bluez_backend_setup(FuBackend *backend,
 	FuBluezBackend *self = FU_BLUEZ_BACKEND(backend);
 	FuContext *ctx = fu_backend_get_context(backend);
 	GMainContext *main_ctx = fu_context_get_main_context(ctx);
-	g_autoptr(FuBluezBackendHelper) helper = g_new0(FuBluezBackendHelper, 1);
 
-	/* in some circumstances the bluez daemon will just hang... do not wait
-	 * forever and make fwupd startup also fail */
-	helper->error = error;
-	helper->loop = g_main_loop_new(main_ctx, FALSE);
-	helper->cancellable = g_cancellable_new();
-	helper->timeout_source = fu_context_add_timeout(ctx,
-							FU_BLUEZ_BACKEND_TIMEOUT,
-							fu_bluez_backend_timeout_cb,
-							helper);
+	/* GDBusObjectManagerClient subscribes to the bus signals from ::init, and
+	 * g_dbus_connection_signal_subscribe() binds the subscription to the
+	 * thread-default main context of the *calling* thread. The async constructor
+	 * runs ::init in a GTask worker thread, which has no thread-default context --
+	 * so the subscription would be bound to the global default context and the
+	 * device property changes would never be dispatched. Construct synchronously
+	 * with @main_ctx pushed so that everything is bound to the context we iterate. */
 	g_main_context_push_thread_default(main_ctx);
-	g_dbus_object_manager_client_new_for_bus(G_BUS_TYPE_SYSTEM,
-						 G_DBUS_OBJECT_MANAGER_CLIENT_FLAGS_NONE,
-						 "org.bluez",
-						 "/",
-						 NULL,
-						 NULL,
-						 NULL,
-						 helper->cancellable,
-						 fu_bluez_backend_connect_cb,
-						 helper);
+	self->object_manager = g_dbus_object_manager_client_new_for_bus_sync(
+	    G_BUS_TYPE_SYSTEM,
+	    G_DBUS_OBJECT_MANAGER_CLIENT_FLAGS_DO_NOT_AUTO_START,
+	    "org.bluez",
+	    "/",
+	    NULL,
+	    NULL,
+	    NULL,
+	    NULL,
+	    error);
 	g_main_context_pop_thread_default(main_ctx);
-	g_main_loop_run(helper->loop);
-	if (helper->object_manager == NULL)
+
+	if (self->object_manager == NULL)
 		return FALSE;
-	self->object_manager = g_steal_pointer(&helper->object_manager);
 
 	if (flags & FU_BACKEND_SETUP_FLAG_USE_HOTPLUG) {
 		g_signal_connect(G_DBUS_OBJECT_MANAGER(self->object_manager),


### PR DESCRIPTION
Fixes #10862.

`GDBusObjectManagerClient` subscribes to the bus signals from `::init`, and `g_dbus_connection_signal_subscribe()` binds the subscription to the thread-default main context of the *calling* thread.

The async constructor does not implement `init_async`, so GLib falls back to the default `GAsyncInitable` implementation, which runs `::init` in a GTask worker thread:

```c
static void
async_initable_iface_init (GAsyncInitableIface *async_initable_iface)
{
  /* for now, just use default: run GInitable code in thread */
}
```

That worker thread has no thread-default context, so the subscription ends up bound to the global default context -- which nothing iterates once a custom `GMainContext` is in use. Wrapping the async call in `g_main_context_push_thread_default()` does not help, because that only affects the context the completion callback is invoked in, not the one `::init` runs under.

So no `org.bluez.Device1` `PropertiesChanged` signal was ever dispatched, `::g-properties-changed` never fired, and a BLE device that reboots and reconnects with the same D-Bus object path was never noticed -- `fu_device_list_wait_for_replug()` timed out with `failed to wait for attach replug`.

This regressed in a43aaa18a, before which both the backend and the device list used the global default context, so they agreed.

## The change

Construct the object manager synchronously with the context pushed, so that everything is bound to the context we actually iterate. `libfwupdplugin/fu-bluez-device.c` already constructs its proxies synchronously, so this is consistent with the rest of the BlueZ code.

The startup timeout from 4a1baae30 cannot stay a `GSource` -- nothing would be iterating the context while the sync call blocks -- so it cancels from a watchdog thread instead. The blocking call that can actually hang is `GetManagedObjects`, whose proxy is created inside `::init` and so is not reachable to set a shorter timeout on.

## Testing

Tested on a BLE mouse (`BLUETOOTH\VID_17EF&PID_629A`) which reboots and reconnects after `dfu_exit`:

```
fwupdtool install ../fw/Lenovo-mouse_629a-vs1.0.00.cab --allow-older
...
Successfully installed firmware
```

Also verified the USB path (`USB\VID_17EF&PID_62F5`) still works, and `test-fwupd` passes (145 ok, 0 fail, 2 skipped).