### PR TITLE
synaptics-rmi: Fix PDT cache pointers

### DIFF
--- a/plugins/synaptics-rmi/fu-self-test.c
+++ b/plugins/synaptics-rmi/fu-self-test.c
@@ -6,7 +6,146 @@
 
 #include "config.h"
 
+#include "fu-context-private.h"
+#include "fu-synaptics-rmi-device.h"
 #include "fu-synaptics-rmi-firmware.h"
+
+/* a device that answers different PDT scans, dropping F01 or F34 in subsequent rounds */
+#define FU_TYPE_SYNAPTICS_RMI_MOCK_DEVICE (fu_synaptics_rmi_mock_device_get_type())
+G_DECLARE_FINAL_TYPE(FuSynapticsRmiMockDevice,
+		     fu_synaptics_rmi_mock_device,
+		     FU,
+		     SYNAPTICS_RMI_MOCK_DEVICE,
+		     FuSynapticsRmiDevice)
+
+struct _FuSynapticsRmiMockDevice {
+	FuSynapticsRmiDevice parent_instance;
+	guint scan_round;
+};
+
+G_DEFINE_TYPE(FuSynapticsRmiMockDevice, fu_synaptics_rmi_mock_device, FU_TYPE_SYNAPTICS_RMI_DEVICE)
+
+/* PDT entry: query, command, control, data, (version << 5) | irq-sources, number */
+static const guint8 pdt_f34[] = {0x20, 0x21, 0x22, 0x23, 0x41, 0x34};
+static const guint8 pdt_f01[] = {0x10, 0x11, 0x12, 0x13, 0x01, 0x01};
+static const guint8 pdt_end[RMI_DEVICE_PDT_ENTRY_SIZE] = {0};
+
+static GByteArray *
+fu_synaptics_rmi_mock_device_read(FuSynapticsRmiDevice *device,
+				  guint16 addr,
+				  gsize req_sz,
+				  GError **error)
+{
+	FuSynapticsRmiMockDevice *self = FU_SYNAPTICS_RMI_MOCK_DEVICE(device);
+	const guint8 *src = pdt_end;
+
+	if (self->scan_round == 0) {
+		if (addr == 0x00e9)
+			src = pdt_f34;
+		else if (addr == 0x00e3)
+			src = pdt_f01;
+	} else if (self->scan_round == 1) {
+		if (addr == 0x00e9)
+			src = pdt_f34;
+	} else if (self->scan_round == 2) {
+		if (addr == 0x00e9)
+			src = pdt_f01;
+	}
+	return g_byte_array_new_take(g_memdup2(src, req_sz), req_sz);
+}
+
+static gboolean
+fu_synaptics_rmi_mock_device_write(FuSynapticsRmiDevice *device,
+				   guint16 addr,
+				   GByteArray *req,
+				   FuSynapticsRmiDeviceFlags flags,
+				   GError **error)
+{
+	return TRUE;
+}
+
+static gboolean
+fu_synaptics_rmi_mock_device_set_page(FuSynapticsRmiDevice *device, guint8 page, GError **error)
+{
+	return TRUE;
+}
+
+static gboolean
+fu_synaptics_rmi_mock_device_wait_for_attr(FuSynapticsRmiDevice *device,
+					   guint8 source_mask,
+					   guint timeout_ms,
+					   GError **error)
+{
+	return TRUE;
+}
+
+static void
+fu_synaptics_rmi_mock_device_init(FuSynapticsRmiMockDevice *self)
+{
+}
+
+static void
+fu_synaptics_rmi_mock_device_class_init(FuSynapticsRmiMockDeviceClass *klass)
+{
+	FuSynapticsRmiDeviceClass *rmi_class = FU_SYNAPTICS_RMI_DEVICE_CLASS(klass);
+	rmi_class->read = fu_synaptics_rmi_mock_device_read;
+	rmi_class->write = fu_synaptics_rmi_mock_device_write;
+	rmi_class->set_page = fu_synaptics_rmi_mock_device_set_page;
+	rmi_class->wait_for_attr = fu_synaptics_rmi_mock_device_wait_for_attr;
+}
+
+static void
+fu_synaptics_rmi_device_pdt_rescan_func(void)
+{
+	gboolean ret;
+	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuSynapticsRmiMockDevice) device =
+	    g_object_new(FU_TYPE_SYNAPTICS_RMI_MOCK_DEVICE, "context", ctx, NULL);
+	g_autoptr(GError) error = NULL;
+
+	fu_synaptics_rmi_device_set_max_page(FU_SYNAPTICS_RMI_DEVICE(device), 1);
+
+	/* initial PDT has both F34 and F01 */
+	ret = fu_synaptics_rmi_device_scan_pdt(FU_SYNAPTICS_RMI_DEVICE(device), &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* caches F01 in round 0 */
+	ret = fu_synaptics_rmi_device_reset(FU_SYNAPTICS_RMI_DEVICE(device), &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* caches F34 in round 0 */
+	ret = fu_synaptics_rmi_device_wait_for_idle(FU_SYNAPTICS_RMI_DEVICE(device),
+						    0,
+						    FU_SYNAPTICS_RMI_DEVICE_WAIT_FOR_IDLE_FLAG_NONE,
+						    &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* the device drops F01 and we rescan: cached functions are freed & refreshed */
+	device->scan_round = 1;
+	ret = fu_synaptics_rmi_device_scan_pdt(FU_SYNAPTICS_RMI_DEVICE(device), &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* must fail cleanly with NOT_SUPPORTED rather than dereferencing freed/NULL F01 */
+	ret = fu_synaptics_rmi_device_disable_irqs(FU_SYNAPTICS_RMI_DEVICE(device), &error);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
+	g_assert_false(ret);
+
+	/* the device drops F34 and keeps F01 on next rescan */
+	g_clear_error(&error);
+	device->scan_round = 2;
+	ret = fu_synaptics_rmi_device_scan_pdt(FU_SYNAPTICS_RMI_DEVICE(device), &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* must fail cleanly with NOT_SUPPORTED rather than dereferencing freed/NULL F34 */
+	ret = fu_synaptics_rmi_device_disable_irqs(FU_SYNAPTICS_RMI_DEVICE(device), &error);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
+	g_assert_false(ret);
+}
 
 static void
 fu_synaptics_rmi_firmware_0x_func(void)
@@ -50,5 +189,6 @@ main(int argc, char **argv)
 	g_type_ensure(FU_TYPE_SYNAPTICS_RMI_FIRMWARE);
 	g_test_add_func("/synaptics-rmi/firmware-0x", fu_synaptics_rmi_firmware_0x_func);
 	g_test_add_func("/synaptics-rmi/firmware-10", fu_synaptics_rmi_firmware_10_func);
+	g_test_add_func("/synaptics-rmi/pdt-rescan", fu_synaptics_rmi_device_pdt_rescan_func);
 	return g_test_run();
 }

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
@@ -216,6 +216,15 @@ fu_synaptics_rmi_device_reset(FuSynapticsRmiDevice *self, GError **error)
 	return TRUE;
 }
 
+/**
+ * fu_synaptics_rmi_device_scan_pdt:
+ * @self: a #FuSynapticsRmiDevice
+ * @error: (nullable): #GError
+ *
+ * Scans the Page Descriptor Table (PDT) and caches available RMI functions.
+ *
+ * Returns: %TRUE on success
+ **/
 gboolean
 fu_synaptics_rmi_device_scan_pdt(FuSynapticsRmiDevice *self, GError **error)
 {
@@ -224,6 +233,10 @@ fu_synaptics_rmi_device_scan_pdt(FuSynapticsRmiDevice *self, GError **error)
 
 	/* clear old list */
 	g_ptr_array_set_size(priv->functions, 0);
+
+	/* invalidate the cached pointers into the list */
+	priv->f01 = NULL;
+	priv->f34 = NULL;
 
 	/* scan pages */
 	for (guint page = 0; page < priv->max_page; page++) {
@@ -282,6 +295,10 @@ fu_synaptics_rmi_device_scan_pdt(FuSynapticsRmiDevice *self, GError **error)
 			func->command_base,
 			func->query_base);
 	}
+
+	/* re-cache: these stay NULL if the device did not advertise the function */
+	priv->f01 = fu_synaptics_rmi_device_get_function(self, 0x01, NULL);
+	priv->f34 = fu_synaptics_rmi_device_get_function(self, 0x34, NULL);
 
 	/* success */
 	return TRUE;
@@ -828,12 +845,28 @@ fu_synaptics_rmi_device_write_bootloader_id(FuSynapticsRmiDevice *self, GError *
 	return TRUE;
 }
 
+/**
+ * fu_synaptics_rmi_device_disable_irqs:
+ * @self: a #FuSynapticsRmiDevice
+ * @error: (nullable): #GError
+ *
+ * Disables interrupts for F01 and F34 on the device.
+ *
+ * Returns: %TRUE on success
+ **/
 gboolean
 fu_synaptics_rmi_device_disable_irqs(FuSynapticsRmiDevice *self, GError **error)
 {
 	FuSynapticsRmiDevicePrivate *priv = GET_PRIVATE(self);
 	g_autoptr(GByteArray) interrupt_disable_req = g_byte_array_new();
 
+	if (priv->f01 == NULL || priv->f34 == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "f01 and f34 are required to disable interrupts");
+		return FALSE;
+	}
 	fu_byte_array_append_uint8(interrupt_disable_req,
 				   priv->f34->interrupt_mask | priv->f01->interrupt_mask);
 	if (!fu_synaptics_rmi_device_write(self,

--- a/plugins/synaptics-rmi/meson.build
+++ b/plugins/synaptics-rmi/meson.build
@@ -38,6 +38,7 @@ if get_option('tests')
   )
   e = executable(
     'synaptics-rmi-self-test',
+    rustgen.process('fu-synaptics-rmi.rs'),
     sources: [
       'fu-self-test.c',
     ],


### PR DESCRIPTION
Hello,

This fixes a null deref and a use-after-free with the cached PDT pointers, as well as adding a unit test, which I tried to make it as simple/short as possible (Gemini helped).

Specific details are in the commit messages.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
