### PR TITLE
OSS-Fuzz: Enable fuzzers target tpm event log

### DIFF
--- a/contrib/ci/oss-fuzz.py
+++ b/contrib/ci/oss-fuzz.py
@@ -454,6 +454,8 @@ def _build(bld: Builder) -> None:
         Fuzzer("efi-load-option", pattern="efi-load-option"),
         Fuzzer("ifd"),
         Fuzzer("ifd-bios", pattern="ifd-bios"),
+        Fuzzer("tpm-eventlog-v1", pattern="tpm-eventlog-v1"),
+        Fuzzer("tpm-eventlog-v2", pattern="tpm-eventlog-v2"),
         Fuzzer("zip"),
     ]:
         src = bld.substitute(


### PR DESCRIPTION
This PR enable the new OSS-Fuzz fuzzer for the two version of tpm event log handing.