### PR TITLE
Fix vendor prefix strip when case folding changes length

### DIFF
--- a/libfwupdplugin/fu-device-test.c
+++ b/libfwupdplugin/fu-device-test.c
@@ -106,6 +106,11 @@ fu_device_name_func(void)
 	fu_device_set_vendor(device2, "Intel");
 	g_assert_cmpstr(fu_device_get_name(device2), ==, "Core™ i7-10850H CPU @ 2.70GHz");
 
+	/* vendor prefix that shrinks when uppercased: U+0131 is 2 bytes, 'I' is 1 */
+	fu_device_set_name(device2, "IIIII Widget");
+	fu_device_set_vendor(device2, "\xc4\xb1\xc4\xb1\xc4\xb1\xc4\xb1\xc4\xb1");
+	g_assert_cmpstr(fu_device_get_name(device2), ==, "Widget");
+
 	/* name and vendor are the same */
 #ifndef SUPPORTED_BUILD
 	g_test_expect_message("FuDevice", G_LOG_LEVEL_WARNING, "name and vendor are the same*");

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -3310,7 +3310,9 @@ fu_device_fixup_vendor_name(FuDevice *self)
 			return;
 		}
 		if (g_str_has_prefix(name_up, vendor_up)) {
-			gsize vendor_len = strlen(vendor);
+			/* Case folding alters UTF-8 byte length, e.g. 'ı' -> 'I' is 2 vs 1 bytes.
+			 * Use the length of the matched prefix, not the original vendor length */
+			gsize vendor_len = strlen(vendor_up);
 			g_autofree gchar *name1 = g_strdup(priv->name + vendor_len);
 			g_autofree gchar *name2 = fu_strstrip(name1);
 			g_debug("removing vendor prefix of '%s' from '%s'", vendor, priv->name);


### PR DESCRIPTION
Hello,

This fixes one last byte length bug and adds a unit test which demonstrates it and serves as a regression test.

Further details in the commit messages.

- [ ] New plugin
- [x] Code fix
- [ ] Feature
- [ ] Documentation
