### PR TITLE
Revert "ci: Remove the apt cache on ubuntu too"

### DIFF
--- a/contrib/ci/Dockerfile-ubuntu.in
+++ b/contrib/ci/Dockerfile-ubuntu.in
@@ -16,7 +16,6 @@ RUN set -euxo pipefail; \
     python3-apt \
     sudo \
 %%%DEPENDENCIES%%%; \
-    apt-get clean; \
-    rm -rf /var/lib/apt/lists/*
+    apt-get clean
 WORKDIR /github/workspace
 %%%RUSTUP%%%


### PR DESCRIPTION
We no longer have the apt cache when this script is executed, see commit 3d7ed4a8bb89 ("ci: Remove the apt cache on ubuntu too") so trying to install pip leads to an apt error
   Package python3-pip is not available, but is referred to by another package.

Having said that, this seems to be a leftover from when we weren't guaranteed to have meson in the right version, so we can do away with this altogether.

Fixes: 3d7ed4a8bb89 ("ci: Remove the apt cache on ubuntu too")

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
