### PR TITLE
ci: Disable the tartan container build

### DIFF
--- a/.github/workflows/create_containers.yml
+++ b/.github/workflows/create_containers.yml
@@ -18,7 +18,7 @@ jobs:
           - { DISTRO: centos, VERSION: stream9, ARCH: amd64 }
           - { DISTRO: debian, VERSION: testing, ARCH: amd64 }
           - { DISTRO: debian, VERSION: testing, ARCH: amd64, VARIANT: i386 }
-          - { DISTRO: debian, VERSION: unstable, ARCH: amd64, VARIANT: tartan }
+          # - { DISTRO: debian, VERSION: unstable, ARCH: amd64, VARIANT: tartan }
           - { DISTRO: debian, VERSION: testing, ARCH: arm64 }
           - { DISTRO: debian, VERSION: testing, ARCH: arm64, VARIANT: cross-s390x }
           - { DISTRO: fedora, VERSION: 44, ARCH: amd64 }


### PR DESCRIPTION
This is an incomplete MR but posted for feedback, esp cc @tmuehlbacher who added it.

Simple question: why are we building the tartan container if we're not using it (and afaict never used it)? Is it worth it?

And if no, the next question is how much of the tartan setup we should keep in tree since it's likely going to go stale. Based on the existing MRs that fixed various tartan-related issues I'm guessing it's being used locally but does anyone use the upstream container we rebuild every night?

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
