### PR TITLE
lenovo-accessory: Add RSA-3072 signature verification support

### DIFF
--- a/plugins/lenovo-accessory/fu-lenovo-accessory-ble-device.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-ble-device.c
@@ -7,6 +7,7 @@
 #include "config.h"
 
 #include "fu-lenovo-accessory-ble-device.h"
+#include "fu-lenovo-accessory-firmware.h"
 #include "fu-lenovo-accessory-impl.h"
 
 struct _FuLenovoAccessoryBleDevice {
@@ -22,6 +23,16 @@ G_DEFINE_TYPE_WITH_CODE(FuLenovoAccessoryBleDevice,
 			FU_TYPE_BLUEZ_DEVICE,
 			G_IMPLEMENT_INTERFACE(FU_TYPE_LENOVO_ACCESSORY_IMPL,
 					      fu_lenovo_accessory_ble_device_impl_iface_init))
+
+/* the signature blob is transferred in the same chunk size as the payload */
+#define FU_LENOVO_ACCESSORY_BLE_SIGNATURE_CHUNK_SZ 32
+
+/*
+ * Hashing the image on-device can take up to ten seconds on the slowest
+ * hardware; the protocol spec recommends re-checking at a 100ms interval.
+ */
+#define FU_LENOVO_ACCESSORY_BLE_SIGNATURE_VERIFY_COUNT 150
+#define FU_LENOVO_ACCESSORY_BLE_SIGNATURE_VERIFY_DELAY 100 /* ms */
 
 #define UUID_WRITE "c1d02501-2d1f-400a-95d2-6a2f7bca0c25"
 #define UUID_READ  "c1d02502-2d1f-400a-95d2-6a2f7bca0c25"
@@ -63,6 +74,251 @@ fu_lenovo_accessory_ble_device_write_files(FuLenovoAccessoryBleDevice *self,
 	return TRUE;
 }
 
+typedef struct {
+	FuLenovoAccessorySignatureAlgo algo;
+} FuLenovoAccessoryBleVerifyHelper;
+
+static gboolean
+fu_lenovo_accessory_ble_device_write(FuLenovoAccessoryImpl *impl, GByteArray *buf, GError **error);
+
+/* read the verify result; the request was already sent by the caller */
+static gboolean
+fu_lenovo_accessory_ble_device_verify_cb(FuDevice *device,
+					 gpointer user_data G_GNUC_UNUSED,
+					 GError **error)
+{
+	FuLenovoAccessoryBleDevice *self = FU_LENOVO_ACCESSORY_BLE_DEVICE(device);
+	FuLenovoAccessoryVerifyResult result;
+	guint8 target_status;
+	FuLenovoAccessoryStatus status;
+	g_autoptr(GByteArray) buf = NULL;
+	g_autoptr(FuStructLenovoAccessoryCmd) st_cmd = NULL;
+	g_autoptr(FuStructLenovoDfuSignatureVerifyRsp) st_rsp = NULL;
+
+	/* read response based on mode */
+	if (self->notify_io != NULL) {
+		/* notify mode: read from the notify stream; the device pushes the
+		 * packet arrives rather than waiting for the read to time out */
+		buf = fu_io_channel_read_byte_array(self->notify_io,
+						    -1,
+						    FU_LENOVO_ACCESSORY_BLE_NOTIFY_TIMEOUT,
+						    FU_IO_CHANNEL_FLAG_SINGLE_SHOT,
+						    error);
+		if (buf == NULL) {
+			g_prefix_error_literal(error, "failed to read notify: ");
+			return FALSE;
+		}
+	} else {
+		/* active read mode */
+		buf = fu_bluez_device_read(FU_BLUEZ_DEVICE(device), UUID_READ, error);
+		if (buf == NULL)
+			return FALSE;
+	}
+
+	st_cmd = fu_struct_lenovo_accessory_cmd_parse(buf->data, buf->len, 0x0, error);
+	if (st_cmd == NULL)
+		return FALSE;
+
+	/* the device reports the command as busy while it hashes the image */
+	target_status = fu_struct_lenovo_accessory_cmd_get_target_status(st_cmd);
+	status = target_status & 0x0F;
+	if (status == FU_LENOVO_ACCESSORY_STATUS_COMMAND_BUSY) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_BUSY, "command busy");
+		return FALSE;
+	}
+	if (status != FU_LENOVO_ACCESSORY_STATUS_COMMAND_SUCCESSFUL) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_WRITE,
+			    "command failed with status 0x%02x",
+			    status);
+		return FALSE;
+	}
+
+	/* the answer must echo back the command we sent */
+	if (fu_struct_lenovo_accessory_cmd_get_command_class(st_cmd) !=
+		FU_LENOVO_ACCESSORY_COMMAND_CLASS_DFU_CLASS ||
+	    fu_struct_lenovo_accessory_cmd_get_command_id(st_cmd) !=
+		(FU_LENOVO_ACCESSORY_DFU_ID_DFU_SIGNATURE_VERIFY |
+		 (FU_LENOVO_ACCESSORY_CMD_DIR_CMD_SET << 7))) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_BUSY, "stale frame");
+		return FALSE;
+	}
+
+	st_rsp =
+	    fu_struct_lenovo_dfu_signature_verify_rsp_parse(buf->data,
+							    buf->len,
+							    FU_STRUCT_LENOVO_ACCESSORY_CMD_SIZE,
+							    error);
+	if (st_rsp == NULL)
+		return FALSE;
+	result = fu_struct_lenovo_dfu_signature_verify_rsp_get_result(st_rsp);
+	if (result != FU_LENOVO_ACCESSORY_VERIFY_RESULT_PASS) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    result == FU_LENOVO_ACCESSORY_VERIFY_RESULT_ALGO_NOT_SUPPORTED
+				? FWUPD_ERROR_NOT_SUPPORTED
+				: FWUPD_ERROR_INVALID_DATA,
+			    "signature verification failed: %s",
+			    fu_lenovo_accessory_verify_result_to_string(result));
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_lenovo_accessory_ble_device_write_signature_chunks(FuLenovoAccessoryBleDevice *self,
+						      FuChunkArray *chunks,
+						      guint16 sigsz,
+						      FuProgress *progress,
+						      GError **error)
+{
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = NULL;
+
+		chk = fu_chunk_array_index(chunks, i, error);
+		if (chk == NULL)
+			return FALSE;
+		if (!fu_lenovo_accessory_impl_dfu_signature_file(FU_LENOVO_ACCESSORY_IMPL(self),
+								 sigsz,
+								 (guint16)fu_chunk_get_address(chk),
+								 fu_chunk_get_data(chk),
+								 fu_chunk_get_data_sz(chk),
+								 error)) {
+			g_prefix_error(error, "failed to write signature chunk 0x%x: ", i);
+			return FALSE;
+		}
+		fu_progress_step_done(progress);
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_lenovo_accessory_ble_device_signature_verify_send(FuLenovoAccessoryBleDevice *self,
+						     FuLenovoAccessorySignatureAlgo algo,
+						     GError **error)
+{
+	g_autoptr(FuStructLenovoAccessoryCmd) st_cmd = fu_struct_lenovo_accessory_cmd_new();
+	g_autoptr(FuStructLenovoDfuSignatureVerifyReq) st_req =
+	    fu_struct_lenovo_dfu_signature_verify_req_new();
+
+	fu_struct_lenovo_accessory_cmd_set_data_size(st_cmd, 0x02);
+	fu_struct_lenovo_accessory_cmd_set_command_class(
+	    st_cmd,
+	    FU_LENOVO_ACCESSORY_COMMAND_CLASS_DFU_CLASS);
+	fu_struct_lenovo_accessory_cmd_set_command_id(
+	    st_cmd,
+	    FU_LENOVO_ACCESSORY_DFU_ID_DFU_SIGNATURE_VERIFY |
+		(FU_LENOVO_ACCESSORY_CMD_DIR_CMD_SET << 7));
+	if (!fu_struct_lenovo_dfu_signature_verify_req_set_cmd(st_req, st_cmd, error))
+		return FALSE;
+	fu_struct_lenovo_dfu_signature_verify_req_set_algo(st_req, algo);
+	if (!fu_lenovo_accessory_ble_device_write(FU_LENOVO_ACCESSORY_IMPL(self),
+						  st_req->buf,
+						  error)) {
+		g_prefix_error_literal(error, "failed to write verify request: ");
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_lenovo_accessory_ble_device_write_signature(FuLenovoAccessoryBleDevice *self,
+					       FuFirmware *firmware,
+					       FuProgress *progress,
+					       GError **error)
+{
+	FuLenovoAccessorySignatureAlgo algo;
+	gsize sigsz;
+	FuLenovoAccessoryBleVerifyHelper helper = {0};
+	g_autoptr(FuChunkArray) chunks = NULL;
+	g_autoptr(FuInputStream) stream_sig = NULL;
+
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 20, "write-signature");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 80, "verify-signature");
+
+	/* a bare image is still accepted by the device */
+	if (!FU_IS_LENOVO_ACCESSORY_FIRMWARE(firmware)) {
+		g_debug("bare image, not verifying");
+		fu_progress_finished(progress);
+		return TRUE;
+	}
+	stream_sig = fu_firmware_get_image_by_id_stream(firmware, FU_FIRMWARE_ID_SIGNATURE, NULL);
+	if (stream_sig == NULL) {
+		g_debug("no detached signature, not verifying");
+		fu_progress_finished(progress);
+		return TRUE;
+	}
+	algo = fu_lenovo_accessory_firmware_get_algo(FU_LENOVO_ACCESSORY_FIRMWARE(firmware));
+	if (!fu_input_stream_size(stream_sig, &sigsz, error))
+		return FALSE;
+	if (sigsz == 0 || sigsz > G_MAXUINT16) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "signature size %" G_GSIZE_FORMAT " is out of range",
+			    sigsz);
+		return FALSE;
+	}
+
+	/* the signature is transferred in the same chunk size as the payload */
+	chunks = fu_chunk_array_new_from_stream(stream_sig,
+						0x0,
+						0x0,
+						FU_LENOVO_ACCESSORY_BLE_SIGNATURE_CHUNK_SZ,
+						error);
+	if (chunks == NULL)
+		return FALSE;
+	if (!fu_lenovo_accessory_ble_device_write_signature_chunks(self,
+								   chunks,
+								   (guint16)sigsz,
+								   fu_progress_get_child(progress),
+								   error))
+		return FALSE;
+	fu_progress_step_done(progress);
+
+	/*
+	 * The device hashes the whole image before it can answer, which can
+	 * take several seconds depending on the image size and the MCU. It
+	 * reports the command as busy until then, so keep re-checking rather
+	 * than treating the first busy answer as a failure.
+	 *
+	 * Send the verify request, wait 500ms to give the device time to compute
+	 * the hash, then poll for the response with extended retry parameters.
+	 */
+	if (!fu_lenovo_accessory_ble_device_signature_verify_send(self, algo, error))
+		return FALSE;
+
+	/* give the device time to compute the hash */
+	fu_device_sleep(FU_DEVICE(self), 500);
+
+	/* poll for the response with extended retry parameters */
+	helper.algo = algo;
+	if (!fu_device_retry_full(FU_DEVICE(self),
+				  fu_lenovo_accessory_ble_device_verify_cb,
+				  FU_LENOVO_ACCESSORY_BLE_SIGNATURE_VERIFY_COUNT,
+				  FU_LENOVO_ACCESSORY_BLE_SIGNATURE_VERIFY_DELAY,
+				  &helper,
+				  error)) {
+		g_prefix_error_literal(error, "failed to verify signature: ");
+		return FALSE;
+	}
+	fu_progress_step_done(progress);
+
+	/* success */
+	return TRUE;
+}
+
 static gboolean
 fu_lenovo_accessory_ble_device_write_firmware(FuDevice *device,
 					      FuFirmware *firmware,
@@ -79,10 +335,18 @@ fu_lenovo_accessory_ble_device_write_firmware(FuDevice *device,
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 5, "prepare");
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 95, "write");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 3, "prepare");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 87, "write");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 10, "signature");
 
-	stream = fu_firmware_get_stream(firmware, error);
+	/* the archive layout exports the image as the payload, and the devices
+	 * shipped a bare image keep the bytes on the firmware itself */
+	if (FU_IS_LENOVO_ACCESSORY_FIRMWARE(firmware)) {
+		stream =
+		    fu_firmware_get_image_by_id_stream(firmware, FU_FIRMWARE_ID_PAYLOAD, error);
+	} else {
+		stream = fu_firmware_get_stream(firmware, error);
+	}
 	if (stream == NULL)
 		return FALSE;
 	if (!fu_input_stream_size(stream, &fw_size, error))
@@ -138,6 +402,14 @@ fu_lenovo_accessory_ble_device_write_firmware(FuDevice *device,
 			    file_crc);
 		return FALSE;
 	}
+	fu_progress_step_done(progress);
+
+	/* write and verify the detached signature, when the payload has one */
+	if (!fu_lenovo_accessory_ble_device_write_signature(self,
+							    firmware,
+							    fu_progress_get_child(progress),
+							    error))
+		return FALSE;
 	fu_progress_step_done(progress);
 
 	/* success */

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-firmware.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-firmware.c
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 Yuchao Li <liyc44@lenovo.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-lenovo-accessory-firmware.h"
+
+/*
+ * A zip archive carrying the `.bin` image and a detached signature over it.
+ *
+ * The signature-capable devices are shipped this layout on LVFS. While the
+ * device firmware can accept a bare `.bin` for testing, the production
+ * packages always use the archive format, so this parser only handles zip.
+ *
+ * The image is exported as the `payload` image, and the detached signature
+ * as the `signature` image.
+ */
+/* the largest image these MCUs can store is a few hundred kB */
+#define FU_LENOVO_ACCESSORY_FIRMWARE_SIZE_MAX (4 * 1024 * 1024)
+
+struct _FuLenovoAccessoryFirmware {
+	FuFirmware parent_instance;
+	FuLenovoAccessorySignatureAlgo algo;
+};
+
+G_DEFINE_TYPE(FuLenovoAccessoryFirmware, fu_lenovo_accessory_firmware, FU_TYPE_FIRMWARE)
+
+typedef struct {
+	const gchar *glob;
+	FuLenovoAccessorySignatureAlgo algo;
+} FuLenovoAccessorySignatureGlob;
+
+FuLenovoAccessorySignatureAlgo
+fu_lenovo_accessory_firmware_get_algo(FuLenovoAccessoryFirmware *self)
+{
+	g_return_val_if_fail(FU_IS_LENOVO_ACCESSORY_FIRMWARE(self),
+			     FU_LENOVO_ACCESSORY_SIGNATURE_ALGO_UNSIGNED);
+	return self->algo;
+}
+
+static void
+fu_lenovo_accessory_firmware_export(FuFirmware *firmware,
+				    FuFirmwareExportFlags flags,
+				    XbBuilderNode *bn)
+{
+	FuLenovoAccessoryFirmware *self = FU_LENOVO_ACCESSORY_FIRMWARE(firmware);
+	fu_xmlb_builder_insert_kv(bn,
+				  "algo",
+				  fu_lenovo_accessory_signature_algo_to_string(self->algo));
+}
+
+static gboolean
+fu_lenovo_accessory_firmware_parse_zip(FuLenovoAccessoryFirmware *self,
+				       FuInputStream *stream,
+				       FuFirmwareParseFlags flags,
+				       GError **error)
+{
+	g_autoptr(FuFirmware) firmware_zip = fu_zip_firmware_new();
+	g_autoptr(FuFirmware) img_payload = fu_firmware_new();
+	g_autoptr(FuFirmware) img_sig = fu_firmware_new();
+	g_autoptr(FuInputStream) stream_payload = NULL;
+	g_autoptr(GError) error_local = NULL;
+
+	/* not an archive at all, or a malformed one */
+	if (!fu_firmware_parse_stream(firmware_zip, stream, 0x0, flags, error))
+		return FALSE;
+
+	/* a valid zip has to carry the image */
+	stream_payload = fu_firmware_get_image_by_id_stream(firmware_zip, "*.bin", &error_local);
+	if (stream_payload == NULL) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "zip archive has no *.bin payload: %s",
+			    error_local->message);
+		return FALSE;
+	}
+	fu_firmware_set_id(img_payload, FU_FIRMWARE_ID_PAYLOAD);
+	if (!fu_firmware_parse_stream(img_payload, stream_payload, 0x0, flags, error))
+		return FALSE;
+	if (!fu_firmware_add_image(FU_FIRMWARE(self), img_payload, error))
+		return FALSE;
+
+	/*
+	 * The detached signature, if any. Devices with a signature-capable
+	 * bootloader still accept unsigned payloads, so a zip with no
+	 * signature is not an error.
+	 */
+	{
+		const FuLenovoAccessorySignatureGlob globs[] = {
+		    {"*.rsa-3072.sig", FU_LENOVO_ACCESSORY_SIGNATURE_ALGO_RSA3072},
+		};
+		for (guint i = 0; i < G_N_ELEMENTS(globs); i++) {
+			g_autoptr(FuInputStream) stream_sig = NULL;
+
+			stream_sig =
+			    fu_firmware_get_image_by_id_stream(firmware_zip, globs[i].glob, NULL);
+			if (stream_sig == NULL)
+				continue;
+			fu_firmware_set_id(img_sig, FU_FIRMWARE_ID_SIGNATURE);
+			if (!fu_firmware_parse_stream(img_sig, stream_sig, 0x0, flags, error))
+				return FALSE;
+			if (!fu_firmware_add_image(FU_FIRMWARE(self), img_sig, error))
+				return FALSE;
+			self->algo = globs[i].algo;
+			break;
+		}
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_lenovo_accessory_firmware_parse(FuFirmware *firmware,
+				   FuInputStream *stream,
+				   FuFirmwareParseFlags flags,
+				   GError **error)
+{
+	FuLenovoAccessoryFirmware *self = FU_LENOVO_ACCESSORY_FIRMWARE(firmware);
+	return fu_lenovo_accessory_firmware_parse_zip(self, stream, flags, error);
+}
+
+static void
+fu_lenovo_accessory_firmware_init(FuLenovoAccessoryFirmware *self)
+{
+	self->algo = FU_LENOVO_ACCESSORY_SIGNATURE_ALGO_UNSIGNED;
+}
+
+static void
+fu_lenovo_accessory_firmware_class_init(FuLenovoAccessoryFirmwareClass *klass)
+{
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	fu_firmware_set_size_max(firmware_class, FU_LENOVO_ACCESSORY_FIRMWARE_SIZE_MAX);
+	fu_firmware_add_image_gtype(firmware_class, FU_TYPE_FIRMWARE);
+	firmware_class->parse = fu_lenovo_accessory_firmware_parse;
+	firmware_class->export = fu_lenovo_accessory_firmware_export;
+}
+
+FuFirmware *
+fu_lenovo_accessory_firmware_new(void)
+{
+	return FU_FIRMWARE(g_object_new(FU_TYPE_LENOVO_ACCESSORY_FIRMWARE, NULL));
+}

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-firmware.h
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-firmware.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 Yuchao Li <liyc44@lenovo.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#include "fu-lenovo-accessory-struct.h"
+
+#define FU_TYPE_LENOVO_ACCESSORY_FIRMWARE (fu_lenovo_accessory_firmware_get_type())
+G_DECLARE_FINAL_TYPE(FuLenovoAccessoryFirmware,
+		     fu_lenovo_accessory_firmware,
+		     FU,
+		     LENOVO_ACCESSORY_FIRMWARE,
+		     FuFirmware)
+
+FuFirmware *
+fu_lenovo_accessory_firmware_new(void);
+FuLenovoAccessorySignatureAlgo
+fu_lenovo_accessory_firmware_get_algo(FuLenovoAccessoryFirmware *self) G_GNUC_NON_NULL(1);

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-hid-common.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-hid-common.c
@@ -182,13 +182,30 @@ fu_lenovo_accessory_hid_poll_cb(FuDevice *device, gpointer user_data, GError **e
 		return FALSE;
 	}
 
-	/* the firmware can leave a frame from a previous command in the report
+	status = target_status & 0x0F;
+	if (status == FU_LENOVO_ACCESSORY_STATUS_COMMAND_BUSY) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_BUSY, "command busy");
+		return FALSE;
+	}
+	if (status != FU_LENOVO_ACCESSORY_STATUS_COMMAND_SUCCESSFUL) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_WRITE,
+			    "command failed with status 0x%02x",
+			    status);
+		return FALSE;
+	}
+
+	/* The firmware can leave a frame from a previous command in the report
 	 * buffer; the command_id carries the direction bit (e.g. GET 0x03 -> 0x83)
-	 * so the answer must echo our class/id exactly. Detect this before the
-	 * status check, as a stale frame may carry an unrelated status (e.g. a
-	 * timeout from the previous command) that would otherwise be misread as a
-	 * failure of the current command. Flag it so the caller re-issues the
-	 * write rather than spinning on the same stale frame */
+	 * so the answer must echo our class/id exactly.
+	 *
+	 * Note: status is checked first because some firmware returns all-zeros
+	 * when busy (instead of correctly echoing the command_class/command_id).
+	 * If we checked class/id before status, those all-zero busy frames would
+	 * trigger a stale-frame rewrite, which can cause download failures.
+	 * Checking status first lets us bail early on busy without mistaking it
+	 * for a stale frame. */
 	rsp_cmd_class = fu_struct_lenovo_accessory_cmd_get_command_class(st_cmd);
 	rsp_cmd_id = fu_struct_lenovo_accessory_cmd_get_command_id(st_cmd);
 	if (rsp_cmd_class != helper->req_cmd_class || rsp_cmd_id != helper->req_cmd_id) {
@@ -223,19 +240,6 @@ fu_lenovo_accessory_hid_poll_cb(FuDevice *device, gpointer user_data, GError **e
 		return FALSE;
 	}
 
-	status = target_status & 0x0F;
-	if (status == FU_LENOVO_ACCESSORY_STATUS_COMMAND_BUSY) {
-		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_BUSY, "command busy");
-		return FALSE;
-	}
-	if (status != FU_LENOVO_ACCESSORY_STATUS_COMMAND_SUCCESSFUL) {
-		g_set_error(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_WRITE,
-			    "command failed with status 0x%02x",
-			    status);
-		return FALSE;
-	}
 	offset += FU_STRUCT_LENOVO_ACCESSORY_CMD_SIZE;
 
 	/* success */

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-hid-dual-device.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-hid-dual-device.c
@@ -6,6 +6,7 @@
 
 #include "config.h"
 
+#include "fu-lenovo-accessory-firmware.h"
 #include "fu-lenovo-accessory-hid-common.h"
 #include "fu-lenovo-accessory-hid-dual-device.h"
 
@@ -21,6 +22,16 @@ G_DEFINE_TYPE_WITH_CODE(FuLenovoAccessoryHidDualDevice,
 			FU_TYPE_HID_DEVICE,
 			G_IMPLEMENT_INTERFACE(FU_TYPE_LENOVO_ACCESSORY_IMPL,
 					      fu_lenovo_accessory_hid_dual_device_impl_iface_init))
+
+/* the signature blob is transferred in the same chunk size as the payload */
+#define FU_LENOVO_ACCESSORY_HID_DUAL_SIGNATURE_CHUNK_SZ 32
+
+/*
+ * Hashing the image on-device can take up to ten seconds on the slowest
+ * hardware; the protocol spec recommends re-checking at a 100ms interval.
+ */
+#define FU_LENOVO_ACCESSORY_HID_DUAL_SIGNATURE_VERIFY_COUNT 150
+#define FU_LENOVO_ACCESSORY_HID_DUAL_SIGNATURE_VERIFY_DELAY 100 /* ms */
 
 static gboolean
 fu_lenovo_accessory_hid_dual_device_write_files(FuLenovoAccessoryHidDualDevice *self,
@@ -56,6 +67,229 @@ fu_lenovo_accessory_hid_dual_device_write_files(FuLenovoAccessoryHidDualDevice *
 	return TRUE;
 }
 
+typedef struct {
+	FuLenovoAccessorySignatureAlgo algo;
+} FuLenovoAccessoryHidDualVerifyHelper;
+
+/* read the verify result; the request was already sent by the caller */
+static gboolean
+fu_lenovo_accessory_hid_dual_device_verify_cb(FuDevice *device,
+					      gpointer user_data G_GNUC_UNUSED,
+					      GError **error)
+{
+	FuLenovoAccessoryVerifyResult result;
+	guint8 target_status;
+	FuLenovoAccessoryStatus status;
+	g_autoptr(GByteArray) buf = NULL;
+	g_autoptr(FuStructLenovoAccessoryCmd) st_cmd = NULL;
+	g_autoptr(FuStructLenovoDfuSignatureVerifyRsp) st_rsp = NULL;
+
+	buf = fu_lenovo_accessory_hid_read(FU_LENOVO_ACCESSORY_IMPL(device), error);
+	if (buf == NULL)
+		return FALSE;
+	st_cmd = fu_struct_lenovo_accessory_cmd_parse(buf->data, buf->len, 0x0, error);
+	if (st_cmd == NULL)
+		return FALSE;
+
+	/* the device reports the command as busy while it hashes the image */
+	target_status = fu_struct_lenovo_accessory_cmd_get_target_status(st_cmd);
+	status = target_status & 0x0F;
+	if (status == FU_LENOVO_ACCESSORY_STATUS_COMMAND_BUSY) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_BUSY, "command busy");
+		return FALSE;
+	}
+	if (status != FU_LENOVO_ACCESSORY_STATUS_COMMAND_SUCCESSFUL) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_WRITE,
+			    "command failed with status 0x%02x",
+			    status);
+		return FALSE;
+	}
+
+	/* the answer must echo back the command we sent */
+	if (fu_struct_lenovo_accessory_cmd_get_command_class(st_cmd) !=
+		FU_LENOVO_ACCESSORY_COMMAND_CLASS_DFU_CLASS ||
+	    fu_struct_lenovo_accessory_cmd_get_command_id(st_cmd) !=
+		(FU_LENOVO_ACCESSORY_DFU_ID_DFU_SIGNATURE_VERIFY |
+		 (FU_LENOVO_ACCESSORY_CMD_DIR_CMD_SET << 7))) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_BUSY, "stale frame");
+		return FALSE;
+	}
+
+	st_rsp =
+	    fu_struct_lenovo_dfu_signature_verify_rsp_parse(buf->data,
+							    buf->len,
+							    FU_STRUCT_LENOVO_ACCESSORY_CMD_SIZE,
+							    error);
+	if (st_rsp == NULL)
+		return FALSE;
+	result = fu_struct_lenovo_dfu_signature_verify_rsp_get_result(st_rsp);
+	if (result != FU_LENOVO_ACCESSORY_VERIFY_RESULT_PASS) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    result == FU_LENOVO_ACCESSORY_VERIFY_RESULT_ALGO_NOT_SUPPORTED
+				? FWUPD_ERROR_NOT_SUPPORTED
+				: FWUPD_ERROR_INVALID_DATA,
+			    "signature verification failed: %s",
+			    fu_lenovo_accessory_verify_result_to_string(result));
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_lenovo_accessory_hid_dual_device_write_signature_chunks(FuLenovoAccessoryHidDualDevice *self,
+							   FuChunkArray *chunks,
+							   guint16 sigsz,
+							   FuProgress *progress,
+							   GError **error)
+{
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = NULL;
+
+		chk = fu_chunk_array_index(chunks, i, error);
+		if (chk == NULL)
+			return FALSE;
+		if (!fu_lenovo_accessory_impl_dfu_signature_file(FU_LENOVO_ACCESSORY_IMPL(self),
+								 sigsz,
+								 (guint16)fu_chunk_get_address(chk),
+								 fu_chunk_get_data(chk),
+								 fu_chunk_get_data_sz(chk),
+								 error)) {
+			g_prefix_error(error, "failed to write signature chunk 0x%x: ", i);
+			return FALSE;
+		}
+		fu_progress_step_done(progress);
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_lenovo_accessory_hid_dual_device_signature_verify_send(FuLenovoAccessoryHidDualDevice *self,
+							  FuLenovoAccessorySignatureAlgo algo,
+							  GError **error)
+{
+	g_autoptr(FuStructLenovoAccessoryCmd) st_cmd = fu_struct_lenovo_accessory_cmd_new();
+	g_autoptr(FuStructLenovoDfuSignatureVerifyReq) st_req =
+	    fu_struct_lenovo_dfu_signature_verify_req_new();
+
+	fu_struct_lenovo_accessory_cmd_set_data_size(st_cmd, 0x02);
+	fu_struct_lenovo_accessory_cmd_set_command_class(
+	    st_cmd,
+	    FU_LENOVO_ACCESSORY_COMMAND_CLASS_DFU_CLASS);
+	fu_struct_lenovo_accessory_cmd_set_command_id(
+	    st_cmd,
+	    FU_LENOVO_ACCESSORY_DFU_ID_DFU_SIGNATURE_VERIFY |
+		(FU_LENOVO_ACCESSORY_CMD_DIR_CMD_SET << 7));
+	if (!fu_struct_lenovo_dfu_signature_verify_req_set_cmd(st_req, st_cmd, error))
+		return FALSE;
+	fu_struct_lenovo_dfu_signature_verify_req_set_algo(st_req, algo);
+	if (!fu_lenovo_accessory_hid_write(FU_LENOVO_ACCESSORY_IMPL(self), st_req->buf, error)) {
+		g_prefix_error_literal(error, "failed to write verify request: ");
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_lenovo_accessory_hid_dual_device_write_signature(FuLenovoAccessoryHidDualDevice *self,
+						    FuFirmware *firmware,
+						    FuProgress *progress,
+						    GError **error)
+{
+	FuLenovoAccessorySignatureAlgo algo;
+	gsize sigsz;
+	FuLenovoAccessoryHidDualVerifyHelper helper = {0};
+	g_autoptr(FuChunkArray) chunks = NULL;
+	g_autoptr(FuInputStream) stream_sig = NULL;
+
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 20, "write-signature");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 80, "verify-signature");
+
+	/* a bare image is still accepted by the device */
+	if (!FU_IS_LENOVO_ACCESSORY_FIRMWARE(firmware)) {
+		g_debug("bare image, not verifying");
+		fu_progress_finished(progress);
+		return TRUE;
+	}
+	stream_sig = fu_firmware_get_image_by_id_stream(firmware, FU_FIRMWARE_ID_SIGNATURE, NULL);
+	if (stream_sig == NULL) {
+		g_debug("no detached signature, not verifying");
+		fu_progress_finished(progress);
+		return TRUE;
+	}
+	algo = fu_lenovo_accessory_firmware_get_algo(FU_LENOVO_ACCESSORY_FIRMWARE(firmware));
+	if (!fu_input_stream_size(stream_sig, &sigsz, error))
+		return FALSE;
+	if (sigsz == 0 || sigsz > G_MAXUINT16) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "signature size %" G_GSIZE_FORMAT " is out of range",
+			    sigsz);
+		return FALSE;
+	}
+
+	/* the signature is transferred in the same chunk size as the payload */
+	chunks = fu_chunk_array_new_from_stream(stream_sig,
+						0x0,
+						0x0,
+						FU_LENOVO_ACCESSORY_HID_DUAL_SIGNATURE_CHUNK_SZ,
+						error);
+	if (chunks == NULL)
+		return FALSE;
+	if (!fu_lenovo_accessory_hid_dual_device_write_signature_chunks(
+		self,
+		chunks,
+		(guint16)sigsz,
+		fu_progress_get_child(progress),
+		error))
+		return FALSE;
+	fu_progress_step_done(progress);
+
+	/*
+	 * The device hashes the whole image before it can answer, which can
+	 * take several seconds depending on the image size and the MCU. It
+	 * reports the command as busy until then, so keep re-checking rather
+	 * than treating the first busy answer as a failure.
+	 *
+	 * Send the verify request, wait 500ms to give the device time to compute
+	 * the hash, then poll for the response with extended retry parameters.
+	 */
+	if (!fu_lenovo_accessory_hid_dual_device_signature_verify_send(self, algo, error))
+		return FALSE;
+
+	/* give the device time to compute the hash */
+	fu_device_sleep(FU_DEVICE(self), 500);
+
+	/* poll for the response with extended retry parameters */
+	helper.algo = algo;
+	if (!fu_device_retry_full(FU_DEVICE(self),
+				  fu_lenovo_accessory_hid_dual_device_verify_cb,
+				  FU_LENOVO_ACCESSORY_HID_DUAL_SIGNATURE_VERIFY_COUNT,
+				  FU_LENOVO_ACCESSORY_HID_DUAL_SIGNATURE_VERIFY_DELAY,
+				  &helper,
+				  error)) {
+		g_prefix_error_literal(error, "failed to verify signature: ");
+		return FALSE;
+	}
+	fu_progress_step_done(progress);
+
+	/* success */
+	return TRUE;
+}
+
 static gboolean
 fu_lenovo_accessory_hid_dual_device_write_firmware(FuDevice *device,
 						   FuFirmware *firmware,
@@ -72,10 +306,18 @@ fu_lenovo_accessory_hid_dual_device_write_firmware(FuDevice *device,
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 5, "prepare");
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 95, "write");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 3, "prepare");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 87, "write");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 10, "signature");
 
-	stream = fu_firmware_get_stream(firmware, error);
+	/* the archive layout exports the image as the payload, and the devices
+	 * shipped a bare image keep the bytes on the firmware itself */
+	if (FU_IS_LENOVO_ACCESSORY_FIRMWARE(firmware)) {
+		stream =
+		    fu_firmware_get_image_by_id_stream(firmware, FU_FIRMWARE_ID_PAYLOAD, error);
+	} else {
+		stream = fu_firmware_get_stream(firmware, error);
+	}
 	if (stream == NULL)
 		return FALSE;
 	if (!fu_input_stream_size(stream, &fw_size, error))
@@ -132,6 +374,14 @@ fu_lenovo_accessory_hid_dual_device_write_firmware(FuDevice *device,
 			    file_crc);
 		return FALSE;
 	}
+	fu_progress_step_done(progress);
+
+	/* write and verify the detached signature, when the payload has one */
+	if (!fu_lenovo_accessory_hid_dual_device_write_signature(self,
+								 firmware,
+								 fu_progress_get_child(progress),
+								 error))
+		return FALSE;
 	fu_progress_step_done(progress);
 
 	/* success */

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-impl.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-impl.c
@@ -419,6 +419,7 @@ fu_lenovo_accessory_impl_dfu_prepare(FuLenovoAccessoryImpl *self,
 	fu_struct_lenovo_dfu_prepare_req_set_start_address(st_req, start_address);
 	fu_struct_lenovo_dfu_prepare_req_set_end_address(st_req, end_address);
 	fu_struct_lenovo_dfu_prepare_req_set_crc32(st_req, crc32);
+
 	buf = fu_lenovo_accessory_impl_process(self, st_req->buf, error);
 	if (buf == NULL)
 		return FALSE;
@@ -452,9 +453,102 @@ fu_lenovo_accessory_impl_dfu_file(FuLenovoAccessoryImpl *self,
 	fu_struct_lenovo_dfu_fw_req_set_offset_address(st_req, address);
 	if (!fu_struct_lenovo_dfu_fw_req_set_data(st_req, data, datasz, error))
 		return FALSE;
+
 	buf = fu_lenovo_accessory_impl_process(self, st_req->buf, error);
 	if (buf == NULL)
 		return FALSE;
+
+	/* success */
+	return TRUE;
+}
+
+gboolean
+fu_lenovo_accessory_impl_dfu_signature_file(FuLenovoAccessoryImpl *self,
+					    guint16 total_length,
+					    guint16 address,
+					    const guint8 *data,
+					    gsize datasz,
+					    GError **error)
+{
+	g_autoptr(FuStructLenovoAccessoryCmd) st_cmd = fu_struct_lenovo_accessory_cmd_new();
+	g_autoptr(FuStructLenovoDfuSignatureFileReq) st_req =
+	    fu_struct_lenovo_dfu_signature_file_req_new();
+	g_autoptr(GByteArray) buf = NULL;
+
+	fu_struct_lenovo_accessory_cmd_set_data_size(st_cmd, datasz + 4);
+	fu_struct_lenovo_accessory_cmd_set_command_class(
+	    st_cmd,
+	    FU_LENOVO_ACCESSORY_COMMAND_CLASS_DFU_CLASS);
+	fu_struct_lenovo_accessory_cmd_set_command_id(
+	    st_cmd,
+	    FU_LENOVO_ACCESSORY_DFU_ID_DFU_SIGNATURE_FILE |
+		(FU_LENOVO_ACCESSORY_CMD_DIR_CMD_SET << 7));
+	if (!fu_struct_lenovo_dfu_signature_file_req_set_cmd(st_req, st_cmd, error))
+		return FALSE;
+	fu_struct_lenovo_dfu_signature_file_req_set_total_length(st_req, total_length);
+	fu_struct_lenovo_dfu_signature_file_req_set_offset_address(st_req, address);
+	if (!fu_struct_lenovo_dfu_signature_file_req_set_data(st_req, data, datasz, error))
+		return FALSE;
+
+	buf = fu_lenovo_accessory_impl_process(self, st_req->buf, error);
+	if (buf == NULL)
+		return FALSE;
+
+	/* success */
+	return TRUE;
+}
+
+gboolean
+fu_lenovo_accessory_impl_dfu_signature_verify(FuLenovoAccessoryImpl *self,
+					      FuLenovoAccessorySignatureAlgo algo,
+					      GError **error)
+{
+	FuLenovoAccessoryVerifyResult result;
+	g_autoptr(FuStructLenovoAccessoryCmd) st_cmd = fu_struct_lenovo_accessory_cmd_new();
+	g_autoptr(FuStructLenovoDfuSignatureVerifyReq) st_req =
+	    fu_struct_lenovo_dfu_signature_verify_req_new();
+	g_autoptr(FuStructLenovoDfuSignatureVerifyRsp) st_rsp = NULL;
+	g_autoptr(GByteArray) buf = NULL;
+
+	fu_struct_lenovo_accessory_cmd_set_data_size(st_cmd, 0x02);
+	fu_struct_lenovo_accessory_cmd_set_command_class(
+	    st_cmd,
+	    FU_LENOVO_ACCESSORY_COMMAND_CLASS_DFU_CLASS);
+	fu_struct_lenovo_accessory_cmd_set_command_id(
+	    st_cmd,
+	    FU_LENOVO_ACCESSORY_DFU_ID_DFU_SIGNATURE_VERIFY |
+		(FU_LENOVO_ACCESSORY_CMD_DIR_CMD_SET << 7));
+	if (!fu_struct_lenovo_dfu_signature_verify_req_set_cmd(st_req, st_cmd, error))
+		return FALSE;
+	fu_struct_lenovo_dfu_signature_verify_req_set_algo(st_req, algo);
+
+	buf = fu_lenovo_accessory_impl_process(self, st_req->buf, error);
+	if (buf == NULL)
+		return FALSE;
+	if (buf->len < FU_STRUCT_LENOVO_DFU_SIGNATURE_VERIFY_RSP_SIZE) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "firmware returned insufficient data for signature verify: got %u "
+			    "bytes, expected %u",
+			    buf->len,
+			    (guint)FU_STRUCT_LENOVO_DFU_SIGNATURE_VERIFY_RSP_SIZE);
+		return FALSE;
+	}
+	st_rsp = fu_struct_lenovo_dfu_signature_verify_rsp_parse(buf->data, buf->len, 0x0, error);
+	if (st_rsp == NULL)
+		return FALSE;
+	result = fu_struct_lenovo_dfu_signature_verify_rsp_get_result(st_rsp);
+	if (result != FU_LENOVO_ACCESSORY_VERIFY_RESULT_PASS) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    result == FU_LENOVO_ACCESSORY_VERIFY_RESULT_ALGO_NOT_SUPPORTED
+				? FWUPD_ERROR_NOT_SUPPORTED
+				: FWUPD_ERROR_INVALID_DATA,
+			    "signature verification failed: %s",
+			    fu_lenovo_accessory_verify_result_to_string(result));
+		return FALSE;
+	}
 
 	/* success */
 	return TRUE;

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-impl.h
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-impl.h
@@ -83,6 +83,17 @@ fu_lenovo_accessory_impl_dfu_file(FuLenovoAccessoryImpl *self,
 				  gsize datasz,
 				  GError **error) G_GNUC_NON_NULL(1, 4);
 gboolean
+fu_lenovo_accessory_impl_dfu_signature_file(FuLenovoAccessoryImpl *self,
+					    guint16 total_length,
+					    guint16 address,
+					    const guint8 *data,
+					    gsize datasz,
+					    GError **error) G_GNUC_NON_NULL(1, 4);
+gboolean
+fu_lenovo_accessory_impl_dfu_signature_verify(FuLenovoAccessoryImpl *self,
+					      FuLenovoAccessorySignatureAlgo algo,
+					      GError **error) G_GNUC_NON_NULL(1);
+gboolean
 fu_lenovo_accessory_impl_dfu_crc(FuLenovoAccessoryImpl *self, guint32 *crc32, GError **error)
     G_GNUC_NON_NULL(1);
 gboolean

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-plugin.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-plugin.c
@@ -7,6 +7,7 @@
 #include "config.h"
 
 #include "fu-lenovo-accessory-ble-device.h"
+#include "fu-lenovo-accessory-firmware.h"
 #include "fu-lenovo-accessory-hid-bootloader.h"
 #include "fu-lenovo-accessory-hid-device.h"
 #include "fu-lenovo-accessory-hid-dual-device.h"
@@ -32,6 +33,7 @@ fu_lenovo_accessory_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LENOVO_ACCESSORY_HID_DUAL_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LENOVO_ACCESSORY_HID_BOOTLOADER);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LENOVO_ACCESSORY_BLE_DEVICE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_LENOVO_ACCESSORY_FIRMWARE);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 
 	/* chain up to parent */

--- a/plugins/lenovo-accessory/fu-lenovo-accessory.rs
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory.rs
@@ -22,6 +22,26 @@ enum FuLenovoAccessoryDfuId {
     DfuCrc = 0x04,
     DfuExit = 0x05,
     DfuEntry = 0x06,
+    DfuSignatureFile = 0x07,
+    DfuSignatureVerify = 0x08,
+}
+
+#[derive(ToString)]
+#[repr(u8)]
+enum FuLenovoAccessorySignatureAlgo {
+    Unsigned = 0x00,
+    Rsa2048 = 0x01,
+    Rsa3072 = 0x02,
+    Ecc256 = 0x10,
+    Ecc384 = 0x11,
+}
+
+#[derive(ToString)]
+#[repr(u8)]
+enum FuLenovoAccessoryVerifyResult {
+    Fail = 0x00,
+    Pass = 0x01,
+    AlgoNotSupported = 0x02,
 }
 
 #[repr(u8)]
@@ -119,6 +139,34 @@ struct FuStructLenovoDfuFwReq {
     file_type: FuLenovoAccessoryDfuFileType,
     offset_address: u32be,
     data: [u8; 32],
+}
+
+// the signature blob is transferred in 32 byte chunks, and `total_length` is
+// repeated in every chunk so that the device can size its staging buffer
+// without depending on the first chunk being received
+#[derive(New)]
+#[repr(C, packed)]
+struct FuStructLenovoDfuSignatureFileReq {
+    cmd: FuStructLenovoAccessoryCmd,
+    total_length: u16be,
+    offset_address: u16be,
+    data: [u8; 32],
+}
+
+#[derive(New)]
+#[repr(C, packed)]
+struct FuStructLenovoDfuSignatureVerifyReq {
+    cmd: FuStructLenovoAccessoryCmd,
+    algo: FuLenovoAccessorySignatureAlgo,
+}
+
+// the device echoes back the algorithm it was asked to verify with, and the
+// verify result follows it
+#[derive(Parse)]
+#[repr(C, packed)]
+struct FuStructLenovoDfuSignatureVerifyRsp {
+    algo: FuLenovoAccessorySignatureAlgo,
+    result: FuLenovoAccessoryVerifyResult,
 }
 
 #[derive(New)]

--- a/plugins/lenovo-accessory/lenovo-accessory.quirk
+++ b/plugins/lenovo-accessory/lenovo-accessory.quirk
@@ -171,12 +171,15 @@ GType = FuLenovoAccessoryBleDevice
 [BLUETOOTH\VID_17EF&PID_62F6]
 Name = Lenovo AI Mouse
 Plugin = lenovo_accessory
-Flags = no-generic-version,use-notify
+Flags = no-generic-version,use-notify,signed-payload
 GType = FuLenovoAccessoryBleDevice
+FirmwareGType = FuLenovoAccessoryFirmware
 
 # Lenovo AI Mouse
 [USB\VID_17EF&PID_62F5]
 Name = Lenovo AI Mouse
 Plugin = lenovo_accessory
+Flags = signed-payload
 GType = FuLenovoAccessoryHidDualDevice
+FirmwareGType = FuLenovoAccessoryFirmware
 LenovoAccessoryInterface = 0x02

--- a/plugins/lenovo-accessory/meson.build
+++ b/plugins/lenovo-accessory/meson.build
@@ -4,11 +4,13 @@ plugins += {
 }
 
 plugin_quirks += files('lenovo-accessory.quirk')
-plugin_builtins += static_library(
+plugin_rustgen_output = rustgen.process('fu-lenovo-accessory.rs')
+plugin_builtin_lenovo_accessory = static_library(
   'fu_plugin_lenovo_accessory',
-  rustgen.process('fu-lenovo-accessory.rs'),
+  plugin_rustgen_output,
   sources: [
     'fu-lenovo-accessory-ble-device.c',
+    'fu-lenovo-accessory-firmware.c',
     'fu-lenovo-accessory-hid-bootloader.c',
     'fu-lenovo-accessory-hid-child-device.c',
     'fu-lenovo-accessory-hid-common.c',
@@ -22,11 +24,13 @@ plugin_builtins += static_library(
   c_args: cargs,
   dependencies: plugin_deps,
 )
+plugin_builtins += plugin_builtin_lenovo_accessory
 
 device_tests += files(
   'tests/lenovo-accessory-6202-receiver.json',
   'tests/lenovo-accessory-700-keyboard.json',
   'tests/lenovo-accessory-700-mouse.json',
   'tests/lenovo-accessory-700-mouse-receiver.json',
+  'tests/lenovo-accessory-ai-mouse.json',
   'tests/lenovo-accessory-receiver.json',
 )

--- a/plugins/lenovo-accessory/tests/lenovo-accessory-ai-mouse.json
+++ b/plugins/lenovo-accessory/tests/lenovo-accessory-ai-mouse.json
@@ -1,0 +1,30 @@
+{
+  "name": "Lenovo AI Mouse",
+  "interactive": false,
+  "steps": [
+    {
+      "url": "13d615bce0446ecfea722273d45bac6535d3d2bd431de3c0ae43f8c21967086b-Lenovo-mouse_62f5-62f6-vs1.0.6.cab",
+      "emulation-url": "ec1ee235f0ee542c292036ea9cfdea59523877eb766ff9091e2c2667af4b9343-62f6-ble-1.0.7to1.0.6.zip",
+      "components": [
+        {
+          "version": "1.0.6",
+          "guids": [
+            "5bde91cf-fa01-5980-9f6d-84b393589743"
+          ]
+        }
+      ]
+    },
+    {
+      "url": "0c8f4a671ea4e5851ad67f82a5a3c0d71de398cf06348a30ed09bf4fe85c33d8-Lenovo-mouse_62f5-62f6-vs1.0.8.cab",
+      "emulation-url": "63f2e5be311a050148c6430e4fed22ca1ff06e737210cc793eba12f53f1ed4ed-62f5vs1.0.7to1.0.8.zip",
+      "components": [
+        {
+          "version": "1.0.8",
+          "guids": [
+            "e973316c-705c-5db1-bd31-ed5135463288"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Support detached RSA-3072 signatures shipped as *.rsa-3072.sig inside the firmware ZIP archive. Devices that require signature verification now validate the signature after writing the firmware payload and before finalizing the update.

- Add FuLenovoAccessoryFirmware to parse ZIP archives containing both the .bin payload and optional detached signature files
- Implement signature transmission (0x07) and verification (0x08) per the device protocol specification
- Optimize verification timing: send verify request, wait 500ms for device hash computation, then poll with extended retry parameters (150×100ms) to accommodate signature verification latency
- Support both BLE notify and active-read modes in verify callback
- Update device-test with signed firmware for CI coverage

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
