### PR TITLE
modem-manager: add Rolling RW101 fastboot support via MBIM

### DIFF
--- a/plugins/modem-manager/README.md
+++ b/plugins/modem-manager/README.md
@@ -33,6 +33,15 @@ Firehose program file to use during the QCDM switch to EDL (Emergency Download) 
 
 Since: 1.8.10
 
+### ModemManagerMbimDetachMethod
+
+The quirk key specifies which detach method the MBIM device should use when transitioning the
+modem from MBIM mode into bootloader mode for firmware update.
+
+Possible values are `fibocom` or `qdu-quectel` (the default).
+
+Since: 2.2.1
+
 ### `Flags=use-branch`
 
 Use the carrier (e.g. `VODAFONE`) as the device branch name so that `fwupdmgr sync` can downgrade

--- a/plugins/modem-manager/fu-mm-mbim-device.c
+++ b/plugins/modem-manager/fu-mm-mbim-device.c
@@ -8,9 +8,11 @@
 #include "config.h"
 
 #include "fu-mm-mbim-device.h"
+#include "fu-mm-mbim-struct.h"
 
 typedef struct {
 	FuMmDevice parent_instance;
+	FuMmMbimDetachMethod detach_method;
 	MbimDevice *mbim_device;
 	GMainContext *main_ctx;
 } FuMmMbimDevicePrivate;
@@ -437,9 +439,8 @@ fu_mm_mbim_device_command_sync(FuMmMbimDevice *self,
 }
 
 static gboolean
-fu_mm_mbim_device_detach(FuDevice *device, FuProgress *progress, GError **error)
+fu_mm_mbim_device_detach_qdu_quectel(FuMmMbimDevice *self, GError **error)
 {
-	FuMmMbimDevice *self = FU_MM_MBIM_DEVICE(device);
 	FuMmMbimDevicePrivate *priv = GET_PRIVATE(self);
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(MbimMessage) request = NULL;
@@ -459,18 +460,102 @@ fu_mm_mbim_device_detach(FuDevice *device, FuProgress *progress, GError **error)
 	}
 
 	/* success */
-	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 	return TRUE;
+}
+
+static gboolean
+fu_mm_mbim_device_detach_fibocom(FuMmMbimDevice *self, GError **error)
+{
+	const gchar *at = "AT\r\n";
+	const gchar *detach_at = "AT+SYSCMD=sys_reboot bootloader";
+	const guint8 *resp_data = NULL;
+	guint32 resp_size = 0;
+	g_autofree gchar *cmd_crlf = NULL;
+	g_autoptr(GError) error_local = NULL;
+	g_autoptr(MbimMessage) request1 = NULL;
+	g_autoptr(MbimMessage) request2 = NULL;
+	g_autoptr(MbimMessage) response1 = NULL;
+	g_autoptr(MbimMessage) response2 = NULL;
+
+	request1 = mbim_message_fibocom_at_command_set_new(strlen(at), (const guint8 *)at, error);
+	if (request1 == NULL)
+		return FALSE;
+	response1 = fu_mm_mbim_device_command_sync(self, request1, 10 * 1000, error);
+	if (response1 == NULL) {
+		g_prefix_error_literal(error, "AT channel pre-check transaction failed: ");
+		return FALSE;
+	}
+	if (!mbim_message_fibocom_at_command_response_parse(response1,
+							    &resp_size,
+							    &resp_data,
+							    error)) {
+		g_prefix_error_literal(error, "AT cmd pre-check response parse failed: ");
+		return FALSE;
+	}
+	if (g_strrstr_len((const gchar *)resp_data, resp_size, "\r\nOK\r\n") == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "AT pre-check did not contain 'OK'");
+		return FALSE;
+	}
+
+	cmd_crlf = g_strdup_printf("%s\r\n", detach_at);
+	if (cmd_crlf == NULL) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "Out of memory");
+		return FALSE;
+	}
+
+	/* send detach at command,
+	 * and modem need reboot, so ignore response */
+	request2 = mbim_message_fibocom_at_command_set_new(strlen(cmd_crlf),
+							   (const guint8 *)cmd_crlf,
+							   error);
+	if (request2 == NULL)
+		return FALSE;
+	response2 = fu_mm_mbim_device_command_sync(self, request2, 10 * 1000, &error_local);
+	if (response2 == NULL)
+		g_debug("detach AT command transaction failed: %s", error_local->message);
+
+	/* success */
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
+	return TRUE;
+}
+
+static gboolean
+fu_mm_mbim_device_detach(FuDevice *device, FuProgress *progress, GError **error)
+{
+	FuMmMbimDevice *self = FU_MM_MBIM_DEVICE(device);
+	FuMmMbimDevicePrivate *priv = GET_PRIVATE(self);
+
+	if (priv->detach_method == FU_MM_MBIM_DETACH_METHOD_QDU_QUECTEL)
+		return fu_mm_mbim_device_detach_qdu_quectel(self, error);
+	if (priv->detach_method == FU_MM_MBIM_DETACH_METHOD_FIBOCOM)
+		return fu_mm_mbim_device_detach_fibocom(self, error);
+
+	/* not supported */
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no detach method");
+	return FALSE;
 }
 
 static gboolean
 fu_mm_mbim_device_probe(FuDevice *device, GError **error)
 {
 	FuMmMbimDevice *self = FU_MM_MBIM_DEVICE(device);
-	fu_device_add_protocol(device, "com.qualcomm.firehose");
-	fu_device_add_instance_id_full(device,
-				       "USB\\VID_05C6&PID_9008",
-				       FU_DEVICE_INSTANCE_FLAG_COUNTERPART);
+	FuMmMbimDevicePrivate *priv = GET_PRIVATE(self);
+
+	if (priv->detach_method == FU_MM_MBIM_DETACH_METHOD_QDU_QUECTEL) {
+		fu_device_add_protocol(device, "com.qualcomm.firehose");
+		fu_device_add_instance_id_full(device,
+					       "USB\\VID_05C6&PID_9008",
+					       FU_DEVICE_INSTANCE_FLAG_COUNTERPART);
+	}
+	if (priv->detach_method == FU_MM_MBIM_DETACH_METHOD_FIBOCOM) {
+		fu_device_add_protocol(device, "com.google.fastboot");
+		fu_device_set_remove_delay(device, 20000);
+		fu_device_add_private_flag(device, FU_DEVICE_PRIVATE_FLAG_REPLUG_MATCH_GUID);
+	}
 	return fu_mm_device_set_device_file(FU_MM_DEVICE(self), MM_MODEM_PORT_TYPE_MBIM, error);
 }
 
@@ -533,6 +618,36 @@ fu_mm_mbim_device_cleanup(FuDevice *device,
 	return fu_mm_device_set_autosuspend_delay(FU_MM_DEVICE(self), 2000, error);
 }
 
+static gboolean
+fu_mm_mbim_device_set_quirk_kv(FuDevice *device,
+			       const gchar *key,
+			       const gchar *value,
+			       GError **error)
+{
+	FuMmMbimDevice *self = FU_MM_MBIM_DEVICE(device);
+	FuMmMbimDevicePrivate *priv = GET_PRIVATE(self);
+
+	if (g_strcmp0(key, "ModemManagerMbimDetachMethod") == 0) {
+		priv->detach_method = fu_mm_mbim_detach_method_from_string(value);
+		if (priv->detach_method == FU_MM_MBIM_DETACH_METHOD_UNKNOWN) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "detach method %s not supported",
+				    value);
+			return FALSE;
+		}
+		return TRUE;
+	}
+
+	/* failed */
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
+	return FALSE;
+}
+
 static void
 fu_mm_mbim_device_set_progress(FuDevice *device, FuProgress *progress)
 {
@@ -557,6 +672,7 @@ fu_mm_mbim_device_init(FuMmMbimDevice *self)
 	/* we must only use one context per device because MBIM messages are only delivered to the
 	 * main context which the device is opened with */
 	priv->main_ctx = g_main_context_new();
+	priv->detach_method = FU_MM_MBIM_DETACH_METHOD_QDU_QUECTEL;
 }
 
 static void
@@ -583,4 +699,5 @@ fu_mm_mbim_device_class_init(FuMmMbimDeviceClass *klass)
 	device_class->prepare = fu_mm_mbim_device_prepare;
 	device_class->cleanup = fu_mm_mbim_device_cleanup;
 	device_class->set_progress = fu_mm_mbim_device_set_progress;
+	device_class->set_quirk_kv = fu_mm_mbim_device_set_quirk_kv;
 }

--- a/plugins/modem-manager/fu-mm-mbim.rs
+++ b/plugins/modem-manager/fu-mm-mbim.rs
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2024 TDT AG <development@tdt.de>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#[derive(ToString, FromString)]
+enum FuMmMbimDetachMethod {
+    Unknown,
+    QduQuectel,
+    Fibocom,
+}

--- a/plugins/modem-manager/meson.build
+++ b/plugins/modem-manager/meson.build
@@ -10,7 +10,7 @@ libqmi_glib = dependency(
 )
 libmbim_glib = dependency(
   'mbim-glib',
-  version: '>= 1.28.0',
+  version: '>= 1.31.2',
   required: get_option('plugin_modem_manager'),
 )
 
@@ -30,6 +30,7 @@ plugin_quirks += files('modem-manager.quirk')
 shared_module(
   'fu_plugin_modem_manager',
   rustgen.process('fu-mm-fdl.rs'),
+  rustgen.process('fu-mm-mbim.rs'),
   sources: [
     'fu-mm-backend.c',
     'fu-mm-common.c',
@@ -63,10 +64,12 @@ device_tests += files(
   'tests/lenovo-em061kgl-mbim.json',
   'tests/foxconn-t99w373-mbim.json',
   'tests/qc-eg25ggc-fastboot.json',
+  'tests/qc-rw101r-fastboot.json',
 )
 enumeration_data += files(
   'tests/foxconn-t99w373-mbim-setup.json',
   'tests/qc-eg25ggc-fastboot-setup.json',
+  'tests/qc-rw101r-fastboot-setup.json',
 )
 
 if get_option('tests')

--- a/plugins/modem-manager/modem-manager.quirk
+++ b/plugins/modem-manager/modem-manager.quirk
@@ -215,28 +215,32 @@ Flags = disable-zlp
 
 # Rolling RW101
 [USB\VID_33F8&PID_0301]
-GType = FuMmFastbootDevice
+GType = FuMmMbimDevice
 Summary = Rolling RW101-GL Module
+ModemManagerMbimDetachMethod = fibocom
 Flags = uninhibit-modemmanager-after-fastboot-reboot,detach-at-fastboot-has-no-response
 CounterpartGuid = USB\VID_33F8&PID_D00D
 
 # Rolling RW101-CAT12
 [USB\VID_33F8&PID_0302]
-GType = FuMmFastbootDevice
+GType = FuMmMbimDevice
 Summary = Rolling RW101-GL Module
+ModemManagerMbimDetachMethod = fibocom
 Flags = uninhibit-modemmanager-after-fastboot-reboot,detach-at-fastboot-has-no-response
 CounterpartGuid = USB\VID_33F8&PID_D00D
 
 # Rolling RW101 Debug
 [USB\VID_33F8&PID_01A8]
-GType = FuMmFastbootDevice
+GType = FuMmMbimDevice
 Summary = Rolling RW101-GL Module
+ModemManagerMbimDetachMethod = fibocom
 Flags = uninhibit-modemmanager-after-fastboot-reboot,detach-at-fastboot-has-no-response
 CounterpartGuid = USB\VID_33F8&PID_D00D
 
 # Rolling RW101-CAT12 Debug
 [USB\VID_33F8&PID_01A9]
-GType = FuMmFastbootDevice
+GType = FuMmMbimDevice
 Summary = Rolling RW101-GL-12 Module
+ModemManagerMbimDetachMethod = fibocom
 Flags = uninhibit-modemmanager-after-fastboot-reboot,detach-at-fastboot-has-no-response
 CounterpartGuid = USB\VID_33F8&PID_D00D

--- a/plugins/modem-manager/tests/qc-rw101r-fastboot-setup.json
+++ b/plugins/modem-manager/tests/qc-rw101r-fastboot-setup.json
@@ -1,0 +1,36 @@
+{
+  "FwupdVersion": "2.2.1",
+  "UsbDevices": [
+    {
+      "Created": "2026-08-26T08:22:03.013775Z",
+      "GType": "FuMmMbimDevice",
+      "BackendId": "/sys/devices/pci0000:00/0000:00:14.0/usb4/4-4",
+      "DeviceFile": "/dev/cdc-wdm0",
+      "Vendor": 13304,
+      "Model": 424,
+      "Version": "19512.0000.00.11.03.01_6167.0001.001.304.010_E47",
+      "PhysicalId": "/sys/devices/pci0000:00/0000:00:14.0/usb4/4-4",
+      "DeviceIds": [
+        "USB\\VID_33F8&PID_01A8",
+        "USB\\VID_33F8&PID_01A8&REV_0504",
+        "USB\\VID_33F8&PID_01A8&CARRIER_VOLTE_OPENMKT-COMMERCIAL-CMCC",
+        "USB\\VID_33F8&PID_01A8&REV_0504&CARRIER_VOLTE_OPENMKT-COMMERCIAL-CMCC",
+        "USB\\VID_33F8"
+      ],
+      "Ports": {
+        "mbim": "/dev/cdc-wdm0",
+        "at": "/dev/ttyUSB1",
+        "gps": "/dev/ttyUSB2",
+        "net": "/dev/wwp0s20f0u4"
+      },
+      "Events": [
+        {
+          "Id": "MbimDeviceNew:Path=/dev/cdc-wdm0"
+        },
+        {
+          "Id": "MbimDeviceOpen"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/modem-manager/tests/qc-rw101r-fastboot.json
+++ b/plugins/modem-manager/tests/qc-rw101r-fastboot.json
@@ -1,0 +1,18 @@
+{
+  "name": "Rolling RW101R (Fastboot)",
+  "interactive": false,
+  "steps": [
+    {
+      "emulation-file": "@enumeration_datadir@/qc-rw101r-fastboot-setup.json",
+      "components": [
+        {
+          "version": "19512.0000.00.11.03.01_6167.0001.001.304.010_E47",
+          "protocol": "com.google.fastboot",
+          "guids": [
+            "5f7386c4-8fd5-569d-ad01-beb359697db7"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION

This PR adds support for Rolling RW101 series modules to be updated via fastboot, using the MBIM interface. The implementation is now placed in `fu-mm-mbim-device.c` instead of `fu-mm-fastboot-device.c`, as suggested by upstream.

1. **Move fastboot support to MBIM device**
   - `fu-mm-mbim-device.c` now handles the `com.google.fastboot` protocol for Rolling devices.
   - The detach method `FU_MM_MBIM_DETACH_METHOD_FIBOCOM` is added to invoke the Fibocom AT command for rebooting the modem into EDL mode.

2. **Add device flags and delays for replug handling**
- Add FuMmMbimDetachMethod enum with QDU_QUECTEL and FIBOCOM methods
- Split detach function into qdu_quectel and fibocom implementations
- Set WAIT_FOR_REPLUG with 20s remove_delay and REPLUG_MATCH_GUID
- Add set_quirk_kv callback to parse ModemManagerMbimDetachMethod

3. **Update modem-manager.quirk**
- Update modem-manager.quirk to use FuMmMbimDevice for Rolling VID/PIDs
- Set `ModemManagerMbimDetachMethod=rolling` and appropriate flags.

4.**Code organization**
   - All logic is self-contained within the `ROLLING` branch of `fu_mm_mbim_device_detach()`, avoiding global pollution.

## Testing

- Verified on real Rolling RW101 hardware.
- The modem reboots into EDL, enters fastboot mode, and the update proceeds successfully.
- The `WAIT_FOR_REPLUG` flag correctly handles the device re-enumeration.

## Notes

- This PR is based on the upstream branch `hughsie/rw101` (commit xxx), with additional fixes.
- It is intended to replace the previous PR (link if any).

Please review and let me know if any further adjustments are needed.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [*] Feature
- [ ] Documentation
