### PR TITLE
reconsider declare_bitflags! use of `const`

### DIFF
--- a/rust/fwupd/src/bitflags.rs
+++ b/rust/fwupd/src/bitflags.rs
@@ -32,39 +32,39 @@ use std::ops::{BitAnd, BitOr};
 /// declare_bitflags! {
 ///     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 ///     pub struct MyFlags / MyFlag : u32 {
-///         const READ = 1 << 0;
-///         const WRITE = 1 << 1;
-///         const EXECUTE = 1 << 2;
+///         const Read = 1 << 0;
+///         const Write = 1 << 1;
+///         const Execute = 1 << 2;
 ///     }
 /// }
 ///
 /// // convert a single flag to a bitmask
-/// let mask = MyFlag::READ.as_mask();
-/// assert!(mask.contains(MyFlag::READ));
+/// let mask = MyFlag::Read.as_mask();
+/// assert!(mask.contains(MyFlag::Read));
 ///
 /// // combine flags with `|`
-/// let mask = MyFlag::READ | MyFlag::WRITE;
+/// let mask = MyFlag::Read | MyFlag::Write;
 ///
 /// // check whether a single flag is set
-/// assert!(mask.contains(MyFlag::READ));
-/// assert!(!mask.contains(MyFlag::EXECUTE));
+/// assert!(mask.contains(MyFlag::Read));
+/// assert!(!mask.contains(MyFlag::Execute));
 ///
 /// // check whether any/all of several flags are set
-/// assert!(mask.any(MyFlag::READ | MyFlag::EXECUTE));
-/// assert!(mask.all(MyFlag::READ | MyFlag::WRITE));
-/// assert!(!mask.all(MyFlag::READ | MyFlag::EXECUTE));
+/// assert!(mask.any(MyFlag::Read | MyFlag::Execute));
+/// assert!(mask.all(MyFlag::Read | MyFlag::Write));
+/// assert!(!mask.all(MyFlag::Read | MyFlag::Execute));
 ///
 /// // iterate over set flags
 /// let flags: Vec<MyFlag> = mask.iter().collect();
-/// assert_eq!(flags, vec![MyFlag::READ, MyFlag::WRITE]);
+/// assert_eq!(flags, vec![MyFlag::Read, MyFlag::Write]);
 ///
 /// // access the raw bits
 /// assert_eq!(mask.bits(), 0b011);
 ///
 /// // create a bitmask from raw bits (undefined bits are masked off)
 /// let mask = MyFlags::from_bits(0b011);
-/// assert!(mask.contains(MyFlag::READ));
-/// assert!(mask.contains(MyFlag::WRITE));
+/// assert!(mask.contains(MyFlag::Read));
+/// assert!(mask.contains(MyFlag::Write));
 /// let mask = MyFlags::from_bits(0xFF);
 /// assert_eq!(mask.bits(), 0b111);
 ///
@@ -79,11 +79,11 @@ use std::ops::{BitAnd, BitOr};
 /// declare_bitflags! {
 ///     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 ///     pub struct MyFlags / MyFlag : u32 {
-///         const READ = 0x1;
-///         const WRITE = 0x2;
-///         const EXECUTE = 0x4;
+///         const Read = 0x1;
+///         const Write = 0x2;
+///         const Execute = 0x4;
 ///         // Multiple bits and an alias to two other flags
-///         const READWRITE = 0x3;
+///         const ReadWrite = 0x3;
 ///     }
 /// }
 /// ```
@@ -134,17 +134,17 @@ where
     /// Returns `true` if all bits of the given flag are set.
     ///
     /// ```ignore
-    /// let mask = MyFlag::READ | MyFlag::WRITE;
-    /// assert!(mask.contains(MyFlag::READ));
-    /// assert!(!mask.contains(MyFlag::EXECUTE));
+    /// let mask = MyFlag::Read | MyFlag::Write;
+    /// assert!(mask.contains(MyFlag::Read));
+    /// assert!(!mask.contains(MyFlag::Execute));
     /// ```
     /// This function operates on the underlying bits, a flag
     /// may have multiple bits set:
     /// ```ignore
-    /// let mask = MyFlag::READWRITE;
-    /// assert!(mask.contains(MyFlag::READ));
-    /// assert!(mask.contains(MyFlag::WRITE));
-    /// assert!(mask.contains(MyFlag::READWRITE));
+    /// let mask = MyFlag::ReadWrite;
+    /// assert!(mask.contains(MyFlag::Read));
+    /// assert!(mask.contains(MyFlag::Write));
+    /// assert!(mask.contains(MyFlag::ReadWrite));
     /// ```
     fn contains(self, flag: Self::Flag) -> bool {
         let flag_bits = Self::flag_bits(flag);
@@ -157,13 +157,13 @@ where
     /// is set if any of the flag's bits are set.
     ///
     /// ```ignore
-    /// let mask = MyFlag::READ | MyFlag::WRITE;
-    /// assert!(mask.any(MyFlag::READ | MyFlag::EXECUTE));
-    /// assert!(!mask.any(MyFlag::EXECUTE.as_mask()));
+    /// let mask = MyFlag::Read | MyFlag::Write;
+    /// assert!(mask.any(MyFlag::Read | MyFlag::Execute));
+    /// assert!(!mask.any(MyFlag::Execute.as_mask()));
     ///
     /// // A single bit of a multi-bit flag is enough
-    /// let mask = MyFlag::READ.as_mask();
-    /// assert!(mask.any(MyFlag::READWRITE.as_mask()));
+    /// let mask = MyFlag::Read.as_mask();
+    /// assert!(mask.any(MyFlag::ReadWrite.as_mask()));
     /// ```
     fn any(self, other: Self) -> bool {
         self.bits() & other.bits() != Self::Bits::default()
@@ -175,9 +175,9 @@ where
     /// is set if all of the flag's bits are set.
     ///
     /// ```ignore
-    /// let mask = MyFlag::READ | MyFlag::WRITE;
-    /// assert!(mask.all(MyFlag::READ | MyFlag::WRITE));
-    /// assert!(!mask.all(MyFlag::READ | MyFlag::EXECUTE));
+    /// let mask = MyFlag::Read | MyFlag::Write;
+    /// assert!(mask.all(MyFlag::Read | MyFlag::Write));
+    /// assert!(!mask.all(MyFlag::Read | MyFlag::Execute));
     /// ```
     fn all(self, other: Self) -> bool {
         self.bits() & other.bits() == other.bits()
@@ -188,23 +188,23 @@ where
     /// Yields each defined flag whose bit is set, **in declaration order**.
     ///
     /// ```ignore
-    /// let mask = MyFlag::READ | MyFlag::EXECUTE;
+    /// let mask = MyFlag::Read | MyFlag::Execute;
     /// let flags: Vec<MyFlag> = mask.iter().collect();
-    /// assert_eq!(flags, vec![MyFlag::READ, MyFlag::EXECUTE]);
+    /// assert_eq!(flags, vec![MyFlag::Read, MyFlag::Execute]);
     /// ```
     /// Care must be taken for flags that alias other flags as they may
     /// yield flags not explicitly set:
     ///
     /// ```ignore
-    /// let mask = MyFlag::READWRITE | MyFlag::WRITE;
+    /// let mask = MyFlag::ReadWrite | MyFlag::Write;
     /// let flags: Vec<MyFlag> = mask.iter().collect();
-    /// // The READ flag is present even though it was not explicitly set
-    /// assert_eq!(flags, vec![MyFlag::READ, MyFlag::WRITE, MyFlag::READWRITE]);
+    /// // The Read flag is present even though it was not explicitly set
+    /// assert_eq!(flags, vec![MyFlag::Read, MyFlag::Write, MyFlag::ReadWrite]);
     ///
-    /// let mask = MyFlag::READ | MyFlag::WRITE;
+    /// let mask = MyFlag::Read | MyFlag::Write;
     /// let flags: Vec<MyFlag> = mask.iter().collect();
-    /// // The READWRITE flag is present even though it was not explicitly set
-    /// assert_eq!(flags, vec![MyFlag::READ, MyFlag::WRITE, MyFlag::READWRITE]);
+    /// // The ReadWrite flag is present even though it was not explicitly set
+    /// assert_eq!(flags, vec![MyFlag::Read, MyFlag::Write, MyFlag::ReadWrite]);
     /// ```
     fn iter(self) -> BitflagIter<Self> {
         BitflagIter {
@@ -260,11 +260,11 @@ where
 ///     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 ///     pub struct MyFlags / MyFlag : u32 {
 ///         /// Read permission.
-///         const READ = 1 << 0;
+///         const Read = 1 << 0;
 ///         /// Write permission.
-///         const WRITE = 1 << 1;
+///         const Write = 1 << 1;
 ///         /// Execute permission.
-///         const EXECUTE = 1 << 2;
+///         const Execute = 1 << 2;
 ///     }
 /// }
 /// ```
@@ -309,9 +309,9 @@ macro_rules! declare_bitflags {
             /// const and method-chain contexts.
             ///
             /// ```ignore
-            /// let mask = MyFlag::READ.as_mask();
-            /// assert!(mask.contains(MyFlag::READ));
-            /// assert!(!mask.contains(MyFlag::WRITE));
+            /// let mask = MyFlag::Read.as_mask();
+            /// assert!(mask.contains(MyFlag::Read));
+            /// assert!(!mask.contains(MyFlag::Write));
             /// ```
             #[inline]
             $vis const fn as_mask(self) -> $Mask {

--- a/rust/fwupd/src/bitflags.rs
+++ b/rust/fwupd/src/bitflags.rs
@@ -408,114 +408,113 @@ macro_rules! declare_bitflags {
 }
 
 #[cfg(test)]
-#[allow(clippy::upper_case_acronyms)]
 mod tests {
     use super::*;
 
     declare_bitflags! {
         #[derive(Debug, Clone, Copy, PartialEq, Eq)]
         pub struct TestFlags / TestFlag : u32 {
-            const READ = 1 << 0;
-            const WRITE = 1 << 1;
-            const EXECUTE = 1 << 2;
+            const Read = 1 << 0;
+            const Write = 1 << 1;
+            const Execute = 1 << 2;
 
-            const READWRITE = 0x3;
+            const ReadWrite = 0x3;
         }
     }
 
     #[test]
     fn single_flag_into_mask() {
-        let mask: TestFlags = TestFlag::READ.into();
-        assert!(mask.contains(TestFlag::READ));
-        assert!(!mask.contains(TestFlag::WRITE));
+        let mask: TestFlags = TestFlag::Read.into();
+        assert!(mask.contains(TestFlag::Read));
+        assert!(!mask.contains(TestFlag::Write));
     }
 
     #[test]
     fn as_mask() {
-        let mask = TestFlag::WRITE.as_mask();
-        assert!(mask.contains(TestFlag::WRITE));
-        assert!(!mask.contains(TestFlag::READ));
-        assert_eq!(mask.bits(), TestFlag::WRITE.bits());
+        let mask = TestFlag::Write.as_mask();
+        assert!(mask.contains(TestFlag::Write));
+        assert!(!mask.contains(TestFlag::Read));
+        assert_eq!(mask.bits(), TestFlag::Write.bits());
     }
 
     #[test]
     fn aliases() {
-        let mask = TestFlag::READWRITE.as_mask();
-        assert!(mask.contains(TestFlag::READ));
-        assert!(mask.contains(TestFlag::WRITE));
-        assert!(!mask.contains(TestFlag::EXECUTE));
+        let mask = TestFlag::ReadWrite.as_mask();
+        assert!(mask.contains(TestFlag::Read));
+        assert!(mask.contains(TestFlag::Write));
+        assert!(!mask.contains(TestFlag::Execute));
     }
 
     #[test]
     fn combine_flags() {
-        let mask = TestFlag::READ | TestFlag::WRITE;
-        assert!(mask.contains(TestFlag::READ));
-        assert!(mask.contains(TestFlag::WRITE));
-        assert!(!mask.contains(TestFlag::EXECUTE));
+        let mask = TestFlag::Read | TestFlag::Write;
+        assert!(mask.contains(TestFlag::Read));
+        assert!(mask.contains(TestFlag::Write));
+        assert!(!mask.contains(TestFlag::Execute));
 
-        let mask = TestFlag::READWRITE | TestFlag::WRITE;
-        assert!(mask.contains(TestFlag::READ));
-        assert!(mask.contains(TestFlag::WRITE));
-        assert!(!mask.contains(TestFlag::EXECUTE));
+        let mask = TestFlag::ReadWrite | TestFlag::Write;
+        assert!(mask.contains(TestFlag::Read));
+        assert!(mask.contains(TestFlag::Write));
+        assert!(!mask.contains(TestFlag::Execute));
     }
 
     #[test]
     fn bitor_assign_flag() {
         let mut mask = TestFlags::empty();
-        mask |= TestFlag::READ;
-        mask |= TestFlag::EXECUTE;
-        assert!(mask.contains(TestFlag::READ));
-        assert!(!mask.contains(TestFlag::WRITE));
-        assert!(mask.contains(TestFlag::EXECUTE));
+        mask |= TestFlag::Read;
+        mask |= TestFlag::Execute;
+        assert!(mask.contains(TestFlag::Read));
+        assert!(!mask.contains(TestFlag::Write));
+        assert!(mask.contains(TestFlag::Execute));
     }
 
     #[test]
     fn mask_or_flag() {
-        let mask = TestFlag::READ | TestFlag::WRITE;
-        let mask2 = mask | TestFlag::EXECUTE;
-        assert!(mask2.contains(TestFlag::EXECUTE));
+        let mask = TestFlag::Read | TestFlag::Write;
+        let mask2 = mask | TestFlag::Execute;
+        assert!(mask2.contains(TestFlag::Execute));
     }
 
     #[test]
     fn flag_or_mask() {
-        let mask = TestFlag::READ | TestFlag::WRITE;
-        let mask2 = TestFlag::EXECUTE | mask;
-        assert!(mask2.contains(TestFlag::READ));
-        assert!(mask2.contains(TestFlag::EXECUTE));
+        let mask = TestFlag::Read | TestFlag::Write;
+        let mask2 = TestFlag::Execute | mask;
+        assert!(mask2.contains(TestFlag::Read));
+        assert!(mask2.contains(TestFlag::Execute));
     }
 
     #[test]
     fn any_flags() {
-        let mask = TestFlag::READ | TestFlag::WRITE;
-        assert!(mask.any(TestFlag::READ | TestFlag::EXECUTE));
-        assert!(!mask.any(TestFlag::EXECUTE.into()));
+        let mask = TestFlag::Read | TestFlag::Write;
+        assert!(mask.any(TestFlag::Read | TestFlag::Execute));
+        assert!(!mask.any(TestFlag::Execute.into()));
 
-        let mask = TestFlag::READ.as_mask();
-        assert!(mask.any(TestFlag::READWRITE.as_mask()));
+        let mask = TestFlag::Read.as_mask();
+        assert!(mask.any(TestFlag::ReadWrite.as_mask()));
 
-        let mask = TestFlag::READWRITE.as_mask();
-        assert!(mask.any(TestFlag::READ | TestFlag::EXECUTE));
-        assert!(!mask.any(TestFlag::EXECUTE.into()));
+        let mask = TestFlag::ReadWrite.as_mask();
+        assert!(mask.any(TestFlag::Read | TestFlag::Execute));
+        assert!(!mask.any(TestFlag::Execute.into()));
     }
 
     #[test]
     fn all_flags() {
-        let mask = TestFlag::READ | TestFlag::WRITE;
-        assert!(mask.all(TestFlag::READ | TestFlag::WRITE));
-        assert!(!mask.all(TestFlag::READ | TestFlag::EXECUTE));
+        let mask = TestFlag::Read | TestFlag::Write;
+        assert!(mask.all(TestFlag::Read | TestFlag::Write));
+        assert!(!mask.all(TestFlag::Read | TestFlag::Execute));
 
-        let mask = TestFlag::READWRITE.as_mask();
-        assert!(mask.all(TestFlag::READ | TestFlag::WRITE));
-        assert!(!mask.all(TestFlag::READ | TestFlag::EXECUTE));
+        let mask = TestFlag::ReadWrite.as_mask();
+        assert!(mask.all(TestFlag::Read | TestFlag::Write));
+        assert!(!mask.all(TestFlag::Read | TestFlag::Execute));
     }
 
     #[test]
     fn empty_and_is_empty() {
         let mask = TestFlags::empty();
         assert!(mask.is_empty());
-        assert!(!mask.contains(TestFlag::READ));
+        assert!(!mask.contains(TestFlag::Read));
 
-        let mask2: TestFlags = TestFlag::READ.into();
+        let mask2: TestFlags = TestFlag::Read.into();
         assert!(!mask2.is_empty());
     }
 
@@ -527,41 +526,41 @@ mod tests {
 
     #[test]
     fn iter_single() {
-        let mask: TestFlags = TestFlag::WRITE.into();
+        let mask: TestFlags = TestFlag::Write.into();
         let flags: Vec<TestFlag> = mask.iter().collect();
-        assert_eq!(flags, vec![TestFlag::WRITE]);
+        assert_eq!(flags, vec![TestFlag::Write]);
     }
 
     #[test]
     fn iter_combined() {
-        let mask = TestFlag::READ | TestFlag::EXECUTE;
+        let mask = TestFlag::Read | TestFlag::Execute;
         let flags: Vec<TestFlag> = mask.iter().collect();
-        assert_eq!(flags, vec![TestFlag::READ, TestFlag::EXECUTE]);
+        assert_eq!(flags, vec![TestFlag::Read, TestFlag::Execute]);
 
-        let mask = TestFlag::READWRITE | TestFlag::EXECUTE;
+        let mask = TestFlag::ReadWrite | TestFlag::Execute;
         let flags: Vec<TestFlag> = mask.iter().collect();
         assert_eq!(
             flags,
             vec![
-                TestFlag::READ,
-                TestFlag::WRITE,
-                TestFlag::EXECUTE,
-                TestFlag::READWRITE
+                TestFlag::Read,
+                TestFlag::Write,
+                TestFlag::Execute,
+                TestFlag::ReadWrite
             ]
         );
     }
 
     #[test]
     fn iter_all() {
-        let mask = TestFlag::READ | TestFlag::WRITE | TestFlag::EXECUTE;
+        let mask = TestFlag::Read | TestFlag::Write | TestFlag::Execute;
         let flags: Vec<TestFlag> = mask.iter().collect();
         assert_eq!(
             flags,
             vec![
-                TestFlag::READ,
-                TestFlag::WRITE,
-                TestFlag::EXECUTE,
-                TestFlag::READWRITE
+                TestFlag::Read,
+                TestFlag::Write,
+                TestFlag::Execute,
+                TestFlag::ReadWrite
             ]
         );
     }
@@ -575,21 +574,21 @@ mod tests {
 
     #[test]
     fn mask_or_mask() {
-        let m1 = TestFlag::READ | TestFlag::WRITE;
-        let m2: TestFlags = TestFlag::EXECUTE.into();
+        let m1 = TestFlag::Read | TestFlag::Write;
+        let m2: TestFlags = TestFlag::Execute.into();
         let m3 = m1 | m2;
-        assert!(m3.contains(TestFlag::READ));
-        assert!(m3.contains(TestFlag::WRITE));
-        assert!(m3.contains(TestFlag::EXECUTE));
+        assert!(m3.contains(TestFlag::Read));
+        assert!(m3.contains(TestFlag::Write));
+        assert!(m3.contains(TestFlag::Execute));
     }
 
     #[test]
     fn bitor_assign_mask() {
-        let mut m1: TestFlags = TestFlag::READ.into();
-        let m2 = TestFlag::WRITE | TestFlag::EXECUTE;
+        let mut m1: TestFlags = TestFlag::Read.into();
+        let m2 = TestFlag::Write | TestFlag::Execute;
         m1 |= m2;
-        assert!(m1.contains(TestFlag::READ));
-        assert!(m1.contains(TestFlag::WRITE));
-        assert!(m1.contains(TestFlag::EXECUTE));
+        assert!(m1.contains(TestFlag::Read));
+        assert!(m1.contains(TestFlag::Write));
+        assert!(m1.contains(TestFlag::Execute));
     }
 }

--- a/rust/fwupd/src/bitflags.rs
+++ b/rust/fwupd/src/bitflags.rs
@@ -32,9 +32,9 @@ use std::ops::{BitAnd, BitOr};
 /// declare_bitflags! {
 ///     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 ///     pub struct MyFlags / MyFlag : u32 {
-///         const Read = 1 << 0;
-///         const Write = 1 << 1;
-///         const Execute = 1 << 2;
+///         Read = 1 << 0;
+///         Write = 1 << 1;
+///         Execute = 1 << 2;
 ///     }
 /// }
 ///
@@ -79,11 +79,11 @@ use std::ops::{BitAnd, BitOr};
 /// declare_bitflags! {
 ///     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 ///     pub struct MyFlags / MyFlag : u32 {
-///         const Read = 0x1;
-///         const Write = 0x2;
-///         const Execute = 0x4;
+///         Read = 0x1;
+///         Write = 0x2;
+///         Execute = 0x4;
 ///         // Multiple bits and an alias to two other flags
-///         const ReadWrite = 0x3;
+///         ReadWrite = 0x3;
 ///     }
 /// }
 /// ```
@@ -260,11 +260,11 @@ where
 ///     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 ///     pub struct MyFlags / MyFlag : u32 {
 ///         /// Read permission.
-///         const Read = 1 << 0;
+///         Read = 1 << 0;
 ///         /// Write permission.
-///         const Write = 1 << 1;
+///         Write = 1 << 1;
 ///         /// Execute permission.
-///         const Execute = 1 << 2;
+///         Execute = 1 << 2;
 ///     }
 /// }
 /// ```
@@ -277,7 +277,7 @@ macro_rules! declare_bitflags {
         $vis:vis struct $Mask:ident / $Flag:ident : $T:ty {
             $(
                 $(#[$inner:meta])*
-                const $NAME:ident = $value:expr;
+                $NAME:ident = $value:expr;
             )*
         }
     ) => {
@@ -414,11 +414,11 @@ mod tests {
     declare_bitflags! {
         #[derive(Debug, Clone, Copy, PartialEq, Eq)]
         pub struct TestFlags / TestFlag : u32 {
-            const Read = 1 << 0;
-            const Write = 1 << 1;
-            const Execute = 1 << 2;
+            Read = 1 << 0;
+            Write = 1 << 1;
+            Execute = 1 << 2;
 
-            const ReadWrite = 0x3;
+            ReadWrite = 0x3;
         }
     }
 


### PR DESCRIPTION
I think the warning emitted by clippy for this actually points to a reasonable question about this macro and whether the use of the faux `const` keyword within the macro is not actually misleading.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
