### PR TITLE
trivial: Don't set default codeowners for "all" files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,9 +2,6 @@
 # Format: [path pattern] [space-separated list of owners]
 # Order is important: last matching pattern takes precedence
 
-# Default owners for everything
-* @superm1 @hughsie
-
 # Plugin-specific owners
 plugins/algoltek-usb/ @MasonLyu
 plugins/amd-gpu/ @superm1


### PR DESCRIPTION
At least for me this totally breaks being able to look at what needs my review and is a DoS notification hell.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [x] Documentation
