### PR TITLE
uefi-capsule: Support Heads capsule-on-disk updates

### DIFF
--- a/libfwupdplugin/fu-device-metadata.h
+++ b/libfwupdplugin/fu-device-metadata.h
@@ -46,4 +46,25 @@ G_BEGIN_DECLS
  */
 #define FU_DEVICE_METADATA_UEFI_CAPSULE_FLAGS "UefiCapsuleFlags"
 
+/**
+ * FU_DEVICE_METADATA_UEFI_CAPSULE_ON_DISK:
+ *
+ * If set to %TRUE, use Capsule-on-Disk for a proxy UEFI capsule device even
+ * when native firmware discovery selected another update method.
+ *
+ * Since: 2.2.2
+ **/
+#define FU_DEVICE_METADATA_UEFI_CAPSULE_ON_DISK "UefiCapsuleOnDisk"
+
+/**
+ * FU_DEVICE_METADATA_UEFI_CAPSULE_NO_RT_SET_VARIABLE:
+ *
+ * If set to %TRUE, do not set `OsIndications` after staging a proxy capsule.
+ * This is used when a bootloader consumes Capsule-on-Disk updates without EFI
+ * runtime services.
+ *
+ * Since: 2.2.2
+ **/
+#define FU_DEVICE_METADATA_UEFI_CAPSULE_NO_RT_SET_VARIABLE "UefiCapsuleNoRtSetVariable"
+
 G_END_DECLS

--- a/plugins/starlabs-coreboot/fu-self-test.c
+++ b/plugins/starlabs-coreboot/fu-self-test.c
@@ -17,8 +17,18 @@ fu_test_bios_plugin_device_added_cb(FuPlugin *plugin, FuDevice *device, gpointer
 	*device_added = device;
 }
 
+static void
+fu_test_bios_plugin_device_register_cb(FuPlugin *plugin, FuDevice *device, gpointer user_data)
+{
+	FuDevice **device_registered = (FuDevice **)user_data;
+	*device_registered = g_object_ref(device);
+}
+
 static FuPlugin *
-fu_starlabs_coreboot_plugin_new(const gchar *manufacturer, const gchar *bios_version)
+fu_starlabs_coreboot_plugin_new(const gchar *manufacturer,
+				const gchar *product,
+				const gchar *family,
+				const gchar *bios_version)
 {
 	g_autoptr(FuContext) ctx = fu_context_new_full(FU_CONTEXT_FLAG_NO_QUIRKS);
 	g_autoptr(FuPlugin) plugin = NULL;
@@ -27,7 +37,9 @@ fu_starlabs_coreboot_plugin_new(const gchar *manufacturer, const gchar *bios_ver
 	fu_context_add_flag(ctx, FU_CONTEXT_FLAG_LOADED_HWINFO);
 	fu_hwids_add_value(hwids, FU_HWIDS_KEY_BIOS_VENDOR, "coreboot");
 	fu_hwids_add_value(hwids, FU_HWIDS_KEY_MANUFACTURER, manufacturer);
-	fu_hwids_add_value(hwids, FU_HWIDS_KEY_PRODUCT_NAME, "StarBook");
+	fu_hwids_add_value(hwids, FU_HWIDS_KEY_PRODUCT_NAME, product);
+	if (family != NULL)
+		fu_hwids_add_value(hwids, FU_HWIDS_KEY_FAMILY, family);
 	if (bios_version != NULL)
 		fu_hwids_add_value(hwids, FU_HWIDS_KEY_BIOS_VERSION, bios_version);
 
@@ -42,7 +54,8 @@ fu_bios_plugin_starlabs_coreboot_legacy_func(void)
 	gboolean ret;
 	gulong added_id;
 	FuDevice *device_added = NULL;
-	g_autoptr(FuPlugin) plugin = fu_starlabs_coreboot_plugin_new("Star Labs", "CBET4000 25.01");
+	g_autoptr(FuPlugin) plugin =
+	    fu_starlabs_coreboot_plugin_new("Star Labs", "StarBook", "B6-I", "CBET4000 25.01");
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
 
@@ -79,7 +92,7 @@ fu_bios_plugin_starlabs_coreboot_supported_func(void)
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
 
-	plugin = fu_starlabs_coreboot_plugin_new("Star Labs", "CBET4000 26.02");
+	plugin = fu_starlabs_coreboot_plugin_new("Star Labs", "StarBook", "B6-I", "CBET4000 26.02");
 	ret = fu_plugin_runner_startup(plugin, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -88,6 +101,81 @@ fu_bios_plugin_starlabs_coreboot_supported_func(void)
 	g_assert_false(ret);
 	devices = fu_plugin_get_devices(plugin);
 	g_assert_cmpint(devices->len, ==, 0);
+}
+
+static void
+fu_bios_plugin_starlabs_coreboot_heads_func(void)
+{
+	gboolean ret;
+	gulong registered_id;
+	FuDevice *device_registered = NULL;
+	g_autofree gchar *expected_guid = NULL;
+	g_autofree gchar *wrong_family_guid = NULL;
+	g_autoptr(FuPlugin) plugin = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	g_autoptr(GError) error = NULL;
+
+	plugin = fu_starlabs_coreboot_plugin_new("Star Labs",
+						 "starlabs_qemu",
+						 "QEMU",
+						 "CBET4000 Heads-v0.2.0-42-g1234567");
+	registered_id = g_signal_connect(plugin,
+					 "device-register",
+					 G_CALLBACK(fu_test_bios_plugin_device_register_cb),
+					 &device_registered);
+	ret = fu_plugin_runner_startup(plugin, progress, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	ret = fu_plugin_runner_coldplug(plugin, progress, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_nonnull(device_registered);
+	g_assert_cmpstr(fu_device_get_name(device_registered), ==, "Heads System Firmware");
+	g_assert_cmpstr(fu_device_get_version(device_registered), ==, "v0.2.0-42-g1234567");
+	g_assert_cmpstr(fu_device_get_branch(device_registered), ==, "heads");
+	g_assert_true(fu_device_has_vendor_id(device_registered, "DMI:Star Labs"));
+	g_assert_true(fu_device_get_metadata_boolean(device_registered,
+						     FU_DEVICE_METADATA_UEFI_CAPSULE_ON_DISK));
+	g_assert_true(
+	    fu_device_get_metadata_boolean(device_registered,
+					   FU_DEVICE_METADATA_UEFI_CAPSULE_NO_RT_SET_VARIABLE));
+	expected_guid =
+	    fwupd_guid_hash_string("STARLABS\\PRODUCT_starlabs_qemu&FAMILY_QEMU&BRANCH_HEADS");
+	wrong_family_guid =
+	    fwupd_guid_hash_string("STARLABS\\PRODUCT_starlabs_qemu&FAMILY_B6-I&BRANCH_HEADS");
+	g_assert_true(fwupd_device_has_guid(FWUPD_DEVICE(device_registered), expected_guid));
+	g_assert_false(fwupd_device_has_guid(FWUPD_DEVICE(device_registered), wrong_family_guid));
+	g_assert_true(fu_device_has_flag(device_registered, FWUPD_DEVICE_FLAG_UPDATABLE));
+	g_signal_handler_disconnect(plugin, registered_id);
+	g_object_unref(device_registered);
+}
+
+static void
+fu_bios_plugin_starlabs_coreboot_heads_physical_func(void)
+{
+	gboolean ret;
+	FuDevice *device_registered = NULL;
+	gulong registered_id;
+	g_autoptr(FuPlugin) plugin =
+	    fu_starlabs_coreboot_plugin_new("Star Labs",
+					    "StarBook",
+					    "B7-U",
+					    "CBET4000 Heads-v0.2.0-42-g1234567");
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	g_autoptr(GError) error = NULL;
+
+	registered_id = g_signal_connect(plugin,
+					 "device-register",
+					 G_CALLBACK(fu_test_bios_plugin_device_register_cb),
+					 &device_registered);
+	ret = fu_plugin_runner_startup(plugin, progress, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	ret = fu_plugin_runner_coldplug(plugin, progress, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_null(device_registered);
+	g_signal_handler_disconnect(plugin, registered_id);
 }
 
 int
@@ -99,5 +187,9 @@ main(int argc, char **argv)
 			fu_bios_plugin_starlabs_coreboot_legacy_func);
 	g_test_add_func("/fwupd/plugin/bios/starlabs/coreboot-supported",
 			fu_bios_plugin_starlabs_coreboot_supported_func);
+	g_test_add_func("/fwupd/plugin/bios/starlabs/coreboot-heads",
+			fu_bios_plugin_starlabs_coreboot_heads_func);
+	g_test_add_func("/fwupd/plugin/bios/starlabs/coreboot-heads-physical",
+			fu_bios_plugin_starlabs_coreboot_heads_physical_func);
 	return g_test_run();
 }

--- a/plugins/starlabs-coreboot/fu-starlabs-coreboot-plugin.c
+++ b/plugins/starlabs-coreboot/fu-starlabs-coreboot-plugin.c
@@ -16,6 +16,74 @@ struct _FuStarlabsCorebootPlugin {
 
 G_DEFINE_TYPE(FuStarlabsCorebootPlugin, fu_starlabs_coreboot_plugin, FU_TYPE_PLUGIN)
 
+static const gchar *
+fu_starlabs_coreboot_plugin_get_heads_version(FuContext *ctx)
+{
+	const gchar *version = fu_context_get_hwid_value(ctx, FU_HWIDS_KEY_BIOS_VERSION);
+
+	if (version == NULL)
+		return NULL;
+	if (strlen(version) > 9 && g_str_has_prefix(version, "CBET"))
+		version += 9;
+	if (!g_str_has_prefix(version, "Heads-"))
+		return NULL;
+	return version + strlen("Heads-");
+}
+
+static gboolean
+fu_starlabs_coreboot_plugin_register_heads(FuPlugin *plugin, const gchar *version, GError **error)
+{
+	FuContext *ctx = fu_plugin_get_context(plugin);
+	const gchar *product = fu_context_get_hwid_value(ctx, FU_HWIDS_KEY_PRODUCT_NAME);
+	const gchar *family = fu_context_get_hwid_value(ctx, FU_HWIDS_KEY_FAMILY);
+	g_autofree gchar *guid = NULL;
+	g_autofree gchar *instance_id = NULL;
+	g_autoptr(FuDevice) device = fu_device_new(ctx);
+
+	if (product == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "Heads firmware has no SMBIOS product name");
+		return FALSE;
+	}
+	if (family == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "Heads firmware has no SMBIOS family");
+		return FALSE;
+	}
+
+	fu_device_set_id(device, "star-labs-heads-system-firmware");
+	fu_device_set_vendor(device, "Star Labs");
+	fu_device_build_vendor_id(device, "DMI", "Star Labs");
+	fu_device_set_name(device, "Heads System Firmware");
+	fu_device_set_summary(device, "Coreboot and Heads system firmware");
+	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_PLAIN);
+	fu_device_set_version(device, version);
+	fu_device_set_branch(device, "heads");
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_INTERNAL);
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_REQUIRE_AC);
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_AFFECTS_FDE);
+	fu_device_add_icon(device, FU_DEVICE_ICON_COMPUTER);
+	fu_device_add_private_flag(device, FU_DEVICE_PRIVATE_FLAG_HOST_FIRMWARE);
+	instance_id =
+	    g_strdup_printf("STARLABS\\PRODUCT_%s&FAMILY_%s&BRANCH_HEADS", product, family);
+	guid = fwupd_guid_hash_string(instance_id);
+	fwupd_device_add_instance_id(FWUPD_DEVICE(device), instance_id);
+	fwupd_device_add_guid(FWUPD_DEVICE(device), guid);
+	fu_device_set_metadata(device, FU_DEVICE_METADATA_UEFI_DEVICE_KIND, "system-firmware");
+	fu_device_set_metadata_boolean(device, FU_DEVICE_METADATA_UEFI_CAPSULE_ON_DISK, TRUE);
+	fu_device_set_metadata_boolean(device,
+				       FU_DEVICE_METADATA_UEFI_CAPSULE_NO_RT_SET_VARIABLE,
+				       TRUE);
+	fu_plugin_device_register(plugin, device);
+	return TRUE;
+}
+
 static void
 fu_starlabs_coreboot_plugin_init(FuStarlabsCorebootPlugin *self)
 {
@@ -27,6 +95,7 @@ fu_starlabs_coreboot_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_STARLABS_COREBOOT_DEVICE);
+	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_RUN_AFTER, "uefi_capsule");
 
 	/* chain up to parent */
 	G_OBJECT_CLASS(fu_starlabs_coreboot_plugin_parent_class)->constructed(obj);
@@ -36,7 +105,17 @@ static gboolean
 fu_starlabs_coreboot_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	FuContext *ctx = fu_plugin_get_context(plugin);
+	const gchar *heads_version = fu_starlabs_coreboot_plugin_get_heads_version(ctx);
+	const gchar *product = fu_context_get_hwid_value(ctx, FU_HWIDS_KEY_PRODUCT_NAME);
+	const gchar *family = fu_context_get_hwid_value(ctx, FU_HWIDS_KEY_FAMILY);
 	g_autoptr(FuDevice) device = NULL;
+
+	/* the consumer is only enabled for the QEMU fixture at present */
+	if (heads_version != NULL && g_strcmp0(product, "starlabs_qemu") == 0 &&
+	    g_strcmp0(family, "QEMU") == 0)
+		return fu_starlabs_coreboot_plugin_register_heads(plugin, heads_version, error);
+	if (heads_version != NULL)
+		return TRUE;
 
 	device = g_object_new(FU_TYPE_STARLABS_COREBOOT_DEVICE, "context", ctx, NULL);
 	if (fu_version_compare(fu_device_get_version(device),

--- a/plugins/uefi-capsule/README.md
+++ b/plugins/uefi-capsule/README.md
@@ -113,6 +113,13 @@ indicated by the current *BootOrder*.
 Note that this will be always needed if your firmware doesn't support
 *SetVariable* at runtime (even if *BootNext* functionality is added).
 
+Another plugin can register a virtual UEFI capsule device with
+`UefiCapsuleOnDisk=true`. This selects Capsule-on-Disk for that proxy without
+changing the method used by native ESRT devices. A bootloader which consumes
+the file without EFI runtime services can additionally set
+`UefiCapsuleNoRtSetVariable=true`. The plugin remains available for proxy
+devices when native UEFI discovery is unavailable.
+
 ### Runtime capsule updates
 
 The firmware is deployed when the OS is running, but it is only written when the

--- a/plugins/uefi-capsule/fu-self-test.c
+++ b/plugins/uefi-capsule/fu-self-test.c
@@ -482,6 +482,111 @@ fu_uefi_capsule_no_cod_func(void)
 	g_assert_cmpint(device_gtype, ==, FU_TYPE_UEFI_NVRAM_DEVICE);
 }
 
+static gboolean
+fu_uefi_capsule_esp_file_exists(FuVolume *esp, const gchar *filename);
+
+static void
+fu_uefi_capsule_proxy_cod_func(void)
+{
+	gboolean ret;
+	g_autofree gchar *testdatadir = NULL;
+	g_autoptr(GBytes) blob = g_bytes_new_static("GUIDGUIDGUIDGUID", 16);
+	g_autoptr(FuContext) ctx = fu_context_new_full(FU_CONTEXT_FLAG_DUMMY_EFIVARS);
+	g_autoptr(FuDevice) source = fu_device_new(ctx);
+	g_autoptr(FuDevice) source_disabled = fu_device_new(ctx);
+	g_autoptr(FuFirmware) firmware = fu_firmware_new_from_bytes(blob);
+	g_autoptr(FuPlugin) plugin = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	g_autoptr(FuTemporaryDirectory) tmpdir = NULL;
+	g_autoptr(FuVolume) esp = NULL;
+	g_autoptr(GError) error = NULL;
+	FuDevice *device;
+	GPtrArray *devices;
+
+	testdatadir = g_test_build_filename(G_TEST_DIST, "tests", NULL);
+	fu_context_set_path(ctx, FU_PATH_KIND_DATADIR_QUIRKS, testdatadir);
+	fu_context_add_flag(ctx, FU_CONTEXT_FLAG_NO_CACHE);
+	ret = fu_context_load(ctx, progress, FU_CONTEXT_LOAD_FLAG_HWID_CONFIG, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	tmpdir = fu_temporary_directory_new("uefi-capsule-proxy-esp", &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(tmpdir);
+	fu_context_set_path(ctx, FU_PATH_KIND_SYSFSDIR_FW, fu_temporary_directory_get_path(tmpdir));
+	esp = fu_uefi_capsule_fake_esp_new(tmpdir);
+	fu_context_add_esp_volume(ctx, esp);
+
+	plugin =
+	    g_object_new(FU_TYPE_UEFI_CAPSULE_PLUGIN, "context", ctx, "name", "uefi_capsule", NULL);
+	ret = fu_plugin_runner_startup(plugin, progress, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	ret = fu_plugin_runner_coldplug(plugin, progress, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	fu_device_set_id(source, "proxy-source");
+	fwupd_device_add_guid(FWUPD_DEVICE(source), "cc4cbfa9-bf9d-540b-b92b-172ce31013c1");
+	fu_device_set_metadata(source, FU_DEVICE_METADATA_UEFI_DEVICE_KIND, "system-firmware");
+	fu_device_set_metadata_boolean(source, FU_DEVICE_METADATA_UEFI_CAPSULE_ON_DISK, TRUE);
+	fu_device_set_metadata_boolean(source,
+				       FU_DEVICE_METADATA_UEFI_CAPSULE_NO_RT_SET_VARIABLE,
+				       TRUE);
+	fu_plugin_runner_device_register(plugin, source);
+
+	devices = fu_plugin_get_devices(plugin);
+	g_assert_cmpuint(devices->len, ==, 1);
+	device = g_ptr_array_index(devices, 0);
+	g_assert_true(FU_IS_UEFI_COD_DEVICE(device));
+	g_assert_true(
+	    fu_device_has_private_flag(device, FU_UEFI_CAPSULE_DEVICE_FLAG_NO_RT_SET_VARIABLE));
+
+	/* stage the capsule without touching EFI runtime variables */
+	fu_device_add_private_flag(device, FU_UEFI_CAPSULE_DEVICE_FLAG_NO_UX_CAPSULE);
+	ret = fu_plugin_runner_write_firmware(plugin,
+					      device,
+					      firmware,
+					      progress,
+					      FWUPD_INSTALL_FLAG_NONE,
+					      &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_true(fu_uefi_capsule_esp_file_exists(
+	    esp,
+	    "EFI/UpdateCapsule/fwupd-cc4cbfa9-bf9d-540b-b92b-172ce31013c1.cap"));
+	g_assert_false(fu_efivars_exists(fu_context_get_efivars(ctx),
+					 FU_EFIVARS_GUID_EFI_GLOBAL,
+					 "OsIndications"));
+
+	/* heads reports completion through the installed version, not EFI variables */
+	ret = fu_device_get_results(device, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	ret = fu_plugin_runner_reboot_cleanup(plugin, device, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_true(fu_uefi_capsule_esp_file_exists(
+	    esp,
+	    "EFI/UpdateCapsule/fwupd-cc4cbfa9-bf9d-540b-b92b-172ce31013c1.cap"));
+
+	/* the global Capsule-on-Disk switch also applies to proxy devices */
+	fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_TEST_ONLY);
+	ret = fu_plugin_set_config_value(plugin, "DisableCapsuleUpdateOnDisk", "true", &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	fu_device_set_id(source_disabled, "proxy-source-disabled");
+	fwupd_device_add_guid(FWUPD_DEVICE(source_disabled),
+			      "0d063fe8-e15d-5a25-b09e-1445568ee097");
+	fu_device_set_metadata(source_disabled,
+			       FU_DEVICE_METADATA_UEFI_DEVICE_KIND,
+			       "system-firmware");
+	fu_device_set_metadata_boolean(source_disabled,
+				       FU_DEVICE_METADATA_UEFI_CAPSULE_ON_DISK,
+				       TRUE);
+	fu_plugin_runner_device_register(plugin, source_disabled);
+	g_assert_cmpuint(devices->len, ==, 1);
+}
+
 static void
 fu_uefi_capsule_no_flashes_func(void)
 {
@@ -1064,6 +1169,7 @@ main(int argc, char **argv)
 	g_test_add_func("/uefi-capsule/nvram", fu_uefi_capsule_nvram_func);
 	g_test_add_func("/uefi-capsule/cod", fu_uefi_capsule_cod_func);
 	g_test_add_func("/uefi-capsule/no-cod", fu_uefi_capsule_no_cod_func);
+	g_test_add_func("/uefi-capsule/proxy-cod", fu_uefi_capsule_proxy_cod_func);
 	g_test_add_func("/uefi-capsule/grub", fu_uefi_capsule_grub_func);
 	return g_test_run();
 }

--- a/plugins/uefi-capsule/fu-uefi-capsule-backend.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-backend.c
@@ -7,6 +7,7 @@
 #include "config.h"
 
 #include "fu-uefi-capsule-backend.h"
+#include "fu-uefi-cod-device.h"
 #include "fu-uefi-nvram-device.h"
 
 typedef struct {
@@ -45,13 +46,16 @@ fu_uefi_capsule_backend_device_new_from_dev(FuUefiCapsuleBackend *self, FuDevice
 {
 	FuUefiCapsuleDevice *device;
 	FuUefiCapsuleBackendPrivate *priv = GET_PRIVATE(self);
+	GType device_gtype = priv->device_gtype;
 	const gchar *tmp;
 
 	g_return_val_if_fail(fu_device_get_guid_default(dev) != NULL, NULL);
 
 	tmp = fu_device_get_metadata(dev, FU_DEVICE_METADATA_UEFI_DEVICE_KIND);
+	if (fu_device_get_metadata_boolean(dev, FU_DEVICE_METADATA_UEFI_CAPSULE_ON_DISK))
+		device_gtype = FU_TYPE_UEFI_COD_DEVICE;
 	device =
-	    g_object_new(priv->device_gtype,
+	    g_object_new(device_gtype,
 			 "fw-class",
 			 fu_device_get_guid_default(dev),
 			 "kind",

--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -28,6 +28,7 @@ struct _FuUefiCapsulePlugin {
 	FuFirmware *acpi_uefi; /* optional */
 	FuVolume *esp;
 	FuBackend *backend;
+	gboolean native_backend_available;
 	guint32 screen_width;
 	guint32 screen_height;
 	GFile *fwupd_efi_file;
@@ -656,9 +657,20 @@ fu_uefi_capsule_plugin_register_proxy_device(FuPlugin *plugin, FuDevice *device)
 	g_autoptr(FuUefiCapsuleDevice) dev = NULL;
 	g_autoptr(GError) error_local = NULL;
 
+	if (fu_device_get_metadata_boolean(device, FU_DEVICE_METADATA_UEFI_CAPSULE_ON_DISK) &&
+	    fu_plugin_get_config_value_boolean(plugin, "DisableCapsuleUpdateOnDisk")) {
+		g_debug("ignoring proxy device because Capsule-on-Disk is disabled");
+		return;
+	}
+
 	/* load all configuration variables */
 	dev = fu_uefi_capsule_backend_device_new_from_dev(FU_UEFI_CAPSULE_BACKEND(self->backend),
 							  device);
+	if (fu_device_get_metadata_boolean(device,
+					   FU_DEVICE_METADATA_UEFI_CAPSULE_NO_RT_SET_VARIABLE)) {
+		fu_device_add_private_flag(FU_DEVICE(dev),
+					   FU_UEFI_CAPSULE_DEVICE_FLAG_NO_RT_SET_VARIABLE);
+	}
 	fu_uefi_capsule_plugin_load_config(plugin, FU_DEVICE(dev));
 	if (self->esp == NULL) {
 		self->esp = fu_context_get_default_esp(fu_plugin_get_context(plugin), &error_local);
@@ -916,8 +928,10 @@ fu_uefi_capsule_plugin_startup(FuPlugin *plugin, FuProgress *progress, GError **
 		fu_plugin_add_report_metadata(plugin, "BootMgrDesc", "legacy");
 
 	/* some platforms have broken SMBIOS data */
-	if (fu_context_has_hwid_flag(ctx, "uefi-force-enable"))
+	if (fu_context_has_hwid_flag(ctx, "uefi-force-enable")) {
+		self->native_backend_available = TRUE;
 		return TRUE;
+	}
 
 	/* use GRUB to load updates */
 	if (fu_plugin_get_config_value_boolean(plugin, "EnableGrubChainLoad")) {
@@ -927,6 +941,11 @@ fu_uefi_capsule_plugin_startup(FuPlugin *plugin, FuProgress *progress, GError **
 
 	/* check we can use this backend */
 	if (!fu_backend_setup(self->backend, FU_BACKEND_SETUP_FLAG_NONE, progress, &error_local)) {
+		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
+			g_debug("native UEFI capsule backend unavailable: %s",
+				error_local->message);
+			return TRUE;
+		}
 		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_WRITE)) {
 			fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_EFIVAR_NOT_MOUNTED);
 			fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_CLEAR_UPDATABLE);
@@ -935,6 +954,7 @@ fu_uefi_capsule_plugin_startup(FuPlugin *plugin, FuProgress *progress, GError **
 		g_propagate_error(error, g_steal_pointer(&error_local));
 		return FALSE;
 	}
+	self->native_backend_available = TRUE;
 
 	/* get the fallback screen size for the UX capsule from fwupd.conf */
 	if (!fu_uefi_capsule_plugin_ensure_screen_size_config(self, error))
@@ -951,8 +971,16 @@ fu_uefi_capsule_plugin_startup(FuPlugin *plugin, FuProgress *progress, GError **
 	}
 
 	/* are the EFI dirs set up so we can update each device */
-	if (!fu_efivars_supported(efivars, error))
+	if (!fu_efivars_supported(efivars, &error_local)) {
+		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
+			self->native_backend_available = FALSE;
+			g_debug("native UEFI capsule backend unavailable: %s",
+				error_local->message);
+			return TRUE;
+		}
+		g_propagate_error(error, g_steal_pointer(&error_local));
 		return FALSE;
+	}
 
 	/* we use this both for quirking the CoD implementation sanity and the CoD filename */
 	self->acpi_uefi = fu_uefi_capsule_plugin_parse_acpi_uefi(self, &error_acpi_uefi);
@@ -1071,23 +1099,15 @@ fu_uefi_capsule_plugin_bootloader_supports_fwupd(FuContext *ctx)
 }
 
 static gboolean
-fu_uefi_capsule_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
+fu_uefi_capsule_plugin_coldplug_native(FuPlugin *plugin,
+				       FuProgress *progress,
+				       gboolean bootloader_supports_fwupd,
+				       GError **error)
 {
 	FuUefiCapsulePlugin *self = FU_UEFI_CAPSULE_PLUGIN(plugin);
 	FuContext *ctx = fu_plugin_get_context(plugin);
-	const gchar *str;
-	gboolean bootloader_supports_fwupd = fu_uefi_capsule_plugin_bootloader_supports_fwupd(ctx);
-	g_autoptr(GError) error_local = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
 
-	/* progress */
-	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_add_step(progress, FWUPD_STATUS_LOADING, 1, "check-cod");
-	fu_progress_add_step(progress, FWUPD_STATUS_LOADING, 72, "coldplug");
-	fu_progress_add_step(progress, FWUPD_STATUS_LOADING, 26, "add-devices");
-	fu_progress_add_step(progress, FWUPD_STATUS_LOADING, 1, "setup-bgrt");
-
-	/* firmware may lie */
 	if (!fu_plugin_get_config_value_boolean(plugin, "DisableCapsuleUpdateOnDisk") &&
 	    !fu_context_has_hwid_flag(ctx, "no-capsule-on-disk")) {
 		g_autoptr(GError) error_cod = NULL;
@@ -1149,6 +1169,37 @@ fu_uefi_capsule_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError *
 		fu_plugin_add_device(plugin, FU_DEVICE(dev));
 	}
 	fu_progress_step_done(progress);
+
+	return TRUE;
+}
+
+static gboolean
+fu_uefi_capsule_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
+{
+	FuUefiCapsulePlugin *self = FU_UEFI_CAPSULE_PLUGIN(plugin);
+	FuContext *ctx = fu_plugin_get_context(plugin);
+	const gchar *str;
+	gboolean bootloader_supports_fwupd = fu_uefi_capsule_plugin_bootloader_supports_fwupd(ctx);
+	g_autoptr(GError) error_local = NULL;
+
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_LOADING, 1, "check-cod");
+	fu_progress_add_step(progress, FWUPD_STATUS_LOADING, 72, "coldplug");
+	fu_progress_add_step(progress, FWUPD_STATUS_LOADING, 26, "add-devices");
+	fu_progress_add_step(progress, FWUPD_STATUS_LOADING, 1, "setup-bgrt");
+
+	if (self->native_backend_available) {
+		if (!fu_uefi_capsule_plugin_coldplug_native(plugin,
+							    progress,
+							    bootloader_supports_fwupd,
+							    error))
+			return FALSE;
+	} else {
+		fu_progress_step_done(progress);
+		fu_progress_step_done(progress);
+		fu_progress_step_done(progress);
+	}
 
 	/* for debugging problems later */
 	fu_uefi_capsule_plugin_test_secure_boot(plugin);
@@ -1250,6 +1301,9 @@ fu_uefi_capsule_plugin_reboot_cleanup(FuPlugin *plugin, FuDevice *device, GError
 
 	/* provide an escape hatch for debugging */
 	if (!fu_plugin_get_config_value_boolean(plugin, "RebootCleanup"))
+		return TRUE;
+	if (FU_IS_UEFI_CAPSULE_DEVICE(device) &&
+	    fu_device_has_private_flag(device, FU_UEFI_CAPSULE_DEVICE_FLAG_NO_RT_SET_VARIABLE))
 		return TRUE;
 
 	/* delete capsules */

--- a/plugins/uefi-capsule/fu-uefi-cod-device.c
+++ b/plugins/uefi-capsule/fu-uefi-cod-device.c
@@ -160,6 +160,9 @@ fu_uefi_cod_device_get_results(FuDevice *device, GError **error)
 	FuUefiCodDevice *self = FU_UEFI_COD_DEVICE(device);
 	guint capsule_last = 1024;
 
+	if (fu_device_has_private_flag(device, FU_UEFI_CAPSULE_DEVICE_FLAG_NO_RT_SET_VARIABLE))
+		return TRUE;
+
 	/* tell us where to stop */
 	if (!fu_uefi_cod_device_get_variable_idx(self, "CapsuleLast", &capsule_last, error))
 		return FALSE;


### PR DESCRIPTION
## Draft / RFC

Heads does not provide the UEFI runtime services used by the normal capsule update path, but it can consume capsules staged on the EFI system partition.

Allow a proxy device to select capsule-on-disk and suppress the `OsIndications` write. Keep the UEFI capsule plugin available when native UEFI discovery is unavailable so that another plugin can register such a proxy.

For the current proof of concept, expose Star Labs systems running Heads through a Heads-specific firmware GUID and branch. Discovery is deliberately restricted to the QEMU fixture until production consumers exist.

## Runtime validation

- Exercised proxy registration without native UEFI discovery and staged the capsule in `EFI/UpdateCapsule` without creating `OsIndications`.
- Exercised QEMU-only discovery, vendor identity, capsule-on-disk disable policy, and EFI-less result and cleanup behavior.
- Completed the fwupd-to-ESP-to-Heads handoff under QEMU/TCG with swtpm; the Heads consumer authenticated the package, invoked its mock writer, and removed the request.

## WIP follow-up

Physical systems remain disabled. Production support still requires an agreed persistent completion/failure result contract, signed generation/version coupling, production keys and writers, and protected-flash hardware validation.

Companion Heads Draft PR: linuxboot/heads#2191.