### PR TITLE
Disable the python deprecation warning yet again

### DIFF
--- a/data/tests/meson.build
+++ b/data/tests/meson.build
@@ -162,6 +162,7 @@ if umockdev.found()
         'GI_TYPELIB_PATH': join_paths(meson.project_build_root(), 'libfwupd'),
         'LD_LIBRARY_PATH': join_paths(meson.project_build_root(), 'libfwupd'),
         'STATE_DIRECTORY': join_paths(meson.project_build_root(), 'state'),
+        'PYTHONWARNINGS': 'ignore::DeprecationWarning:gi.events',
       },
     )
   endforeach


### PR DESCRIPTION
DeprecationWarning: 'asyncio.AbstractEventLoopPolicy' is deprecated and slated for removal in Python 3.16

Removes over 430k lines of log spam. Reproducible via
   `meson test VeryBasicTest.test_properties`

Identical to
commits f020f6b75792 ("contrib: Disable Python deprecation warnings in test-venv.sh") commits ecffbdb3da5d ("ci: Suppress asyncio DeprecationWarning")

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
