### PR TITLE
tpm: Fix buffer indirection for Esys_FirmwareRead

### DIFF
--- a/plugins/tpm/fu-tpm-v2-device.c
+++ b/plugins/tpm/fu-tpm-v2-device.c
@@ -464,7 +464,7 @@ fu_tpm_v2_device_dump_firmware(FuDevice *device, FuProgress *progress, GError **
 				       ESYS_TR_NONE,
 				       ESYS_TR_NONE,
 				       i /* seqnum */,
-				       (TPM2B_MAX_BUFFER **)&data);
+				       data);
 		if (rc == TPM2_RC_COMMAND_CODE ||
 		    (rc == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_RC_LAYER)) ||
 		    (rc == (TPM2_RC_COMMAND_CODE | TSS2_RESMGR_TPM_RC_LAYER))) {

--- a/plugins/tpm/fu-tpm-v2-device.c
+++ b/plugins/tpm/fu-tpm-v2-device.c
@@ -482,8 +482,10 @@ fu_tpm_v2_device_dump_firmware(FuDevice *device, FuProgress *progress, GError **
 					    "no data returned");
 			return NULL;
 		}
-		if (data[0]->size == 0)
+		if (data[0]->size == 0) {
+			Esys_Free(data[0]);
 			break;
+		}
 
 		/* yes, the blocks are returned in reverse order */
 		g_byte_array_prepend(buf, data[0]->buffer, data[0]->size);


### PR DESCRIPTION
The last parameter is a TPM2B_MAX_BUFFER **, which ESYS populates by allocating a buffer and writing the pointer into it. Passing &data (a TPM2B_MAX_BUFFER ***, with the cast hiding the type mismatch) overwrote the local pointer variable instead of data[0], leaking the g_new0 block and leaving data[0] pointing into the struct contents as garbage.

Pass data directly so ESYS writes into data[0] as the rest of the loop expects.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
