### PR TITLE
Disable more python deprecation warnings

### DIFF
--- a/data/tests/fwupd.sh
+++ b/data/tests/fwupd.sh
@@ -38,6 +38,7 @@ run_umockdev_test() {
 }
 
 export LSAN_OPTIONS="suppressions=@installedtestsdatadir@/lsan-suppressions.txt"
+export PYTHONWARNINGS="ignore::DeprecationWarning:gi.events"
 
 if [ -d @installedtestsbindir@ ]; then
     for f in @installedtestsbindir@/*-test; do

--- a/data/tests/fwupdtool.sh
+++ b/data/tests/fwupdtool.sh
@@ -7,6 +7,7 @@ TMPDIR="$(mktemp -d)"
 trap 'rm -rf -- "$TMPDIR"' EXIT
 
 export NO_COLOR=1
+export PYTHONWARNINGS="ignore::DeprecationWarning:gi.events"
 CAB=fakedevice124.cab
 INPUT="@installedtestsdir@/fakedevice124.bin \
        @installedtestsdir@/fakedevice124.jcat \


### PR DESCRIPTION
Another 20k lines of log spam in fwupd.sh, let's add it to fwupdtool.sh too in case that too triggers the log spam.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
