### PR TITLE
mtd: Fix memleak on re-probe

### DIFF
--- a/plugins/mtd/fu-mtd-device.c
+++ b/plugins/mtd/fu-mtd-device.c
@@ -624,6 +624,17 @@ fu_mtd_device_open(FuDevice *device, GError **error)
 	return TRUE;
 }
 
+static void
+fu_mtd_device_set_mtd_type(FuMtdDevice *self, const gchar *mtd_type)
+{
+	FuMtdDevicePrivate *priv = GET_PRIVATE(self);
+	g_autofree gchar *mtd_type_safe = NULL;
+
+	if (mtd_type != NULL)
+		mtd_type_safe = fu_strstrip(mtd_type);
+	g_set_str(&priv->mtd_type, mtd_type_safe);
+}
+
 static gboolean
 fu_mtd_device_probe(FuDevice *device, GError **error)
 {
@@ -677,8 +688,7 @@ fu_mtd_device_probe(FuDevice *device, GError **error)
 					      "type",
 					      FU_UDEV_DEVICE_ATTR_READ_TIMEOUT_DEFAULT,
 					      NULL);
-	if (attr_type != NULL)
-		priv->mtd_type = fu_strstrip(attr_type);
+	fu_mtd_device_set_mtd_type(self, attr_type);
 
 	/* MTD devices backed by PCI should use that for identification */
 	parent_device = fu_device_get_backend_parent_with_subsystem(device, "pci", NULL);


### PR DESCRIPTION
If the device is probed twice, `priv->mtd_type` is overwritten without the old value being released.
```
================================================================= ==746925==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 4 byte(s) in 1 object(s) allocated from:
    #0 0x7f2b388ef41f in malloc (/lib64/libasan.so.8+0xef41f) (BuildId: 5395ec74f54d9ec7bf97c06583dd39a96c230822)
    #1 0x7f2b37ee3579 in g_malloc (/lib64/libglib-2.0.so.0+0x45579) (BuildId: a55397c41cae330fee603dd8a00cf8cd2ac399ca)
    #2 0x7f2b37f0308e in g_strndup (/lib64/libglib-2.0.so.0+0x6508e) (BuildId: a55397c41cae330fee603dd8a00cf8cd2ac399ca)
    #3 0x7f2b36884b3a in fu_strstrip ../../libfwupdplugin/fu-string.c:292
    #4 0x00000041e020 in fu_mtd_device_probe ../../plugins/mtd/fu-mtd-device.c:684
    #5 0x7f2b36654587 in fu_device_probe ../../libfwupdplugin/fu-device.c:6308
    #6 0x00000040960d in fu_test_mtd_find_mtdram ../../plugins/mtd/fu-self-test.c:59
    #7 0x000000412587 in fu_test_mtd_device_ifd_func ../../plugins/mtd/fu-self-test.c:578
    #8 0x7f2b37f13f7d in g_test_run_suite_internal (/lib64/libglib-2.0.so.0+0x75f7d) (BuildId: a55397c41cae330fee603dd8a00cf8cd2ac399ca)
    [...]
```
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
