### PR TITLE
ci: Group testing output

### DIFF
--- a/contrib/ci/arch-test.sh
+++ b/contrib/ci/arch-test.sh
@@ -1,13 +1,24 @@
 #!/bin/sh
 set -ex
 
+group() {
+    { echo "${CI:+::group::}🔵 $*"; } 2>/dev/null
+}
+
+endgroup() {
+    { [ -n "${CI:-}" ] && echo "::endgroup::" || true; } 2>/dev/null
+}
+
+group "Update system and install dependencies"
 pacman -Sy --noconfirm qt5-base gcovr python-flask swtpm tpm2-tools
 pacman -U --noconfirm dist/*.pkg.*
+endgroup
 
-# run custom redfish simulator
+group "Run custom redfish simulator"
 plugins/redfish/tests/redfish.py &
+endgroup
 
-# run custom snapd simulator
+group "Run custom snapd simulator"
 rm -f /tmp/mock-snapd-test.sock
 plugins/snapd-uefi/tests/snapd.py --datadir /usr/share/installed-tests/fwupd/tests &
 # wait for the socket to show up
@@ -19,8 +30,9 @@ if [ ! -S /tmp/mock-snapd-test.sock ]; then
     echo "error: mock snapd socket /tmp/mock-snapd-test.sock not found"
     exit 1
 fi
+endgroup
 
-# run TPM simulator
+group "Run TPM simulator"
 export TPM2TOOLS_TCTI=swtpm:host=127.0.0.1,port=2321
 swtpm socket --tpm2 --server port=2321 --ctrl type=tcp,port=2322 --flags not-need-init,startup-clear --tpmstate "dir=$PWD" &
 SWTPM_PID=$!
@@ -28,30 +40,50 @@ trap 'kill $SWTPM_PID' EXIT
 # extend a PCR0 value for test suite
 sleep 2
 tpm2_pcrextend 0:sha1=f1d2d2f924e986ac86fdf7b36c94bcdf32beec15 0:sha256=722961af9796ab090ace25e9c341aa3177bf2fd7b411c65c661599a84e5feef8 0:sha384=6b38548127fa865ff6fa81cbee64f3b18c7fa01490c700a66e4c8acc4a197db30d83dbb4d4dbb61099baf14490c7681d 0:sha512=d636e21e2eb4b1effd3cc6e3bb40ddf01bb1ecef7e43c8b0e480ba887a12780f70f0e0b7342f1d3c7e4e87849ecd5810930822560ad8e02d7cad8a206df12e1d
+endgroup
 
-#run the CI tests for Qt5
+group "Run the CI tests for Qt5"
 meson qt5-thread-test contrib/ci/qt5-thread-test --werror -Db_coverage=true
 ninja -C qt5-thread-test test
+endgroup
 
-#get the test firmware
+group "Get the test firmware"
 ./contrib/ci/get_test_firmware.sh /usr/share/installed-tests/fwupd/
+endgroup
 
+group "Set up PolicyKit and D-Bus to run the daemon"
 # gnome-desktop-testing is missing, so manually run these tests
 export G_TEST_SRCDIR=/usr/share/installed-tests/fwupd G_TEST_BUILDDIR=/usr/share/installed-tests/fwupd
 mkdir -p /run/dbus
 /usr/bin/dbus-daemon --system
 /usr/lib/polkit-1/polkitd &
 sleep 5
+endgroup
 
+group "Enable test devices"
 fwupdtool enable-test-devices
+endgroup
+
 # tag test device for emulation before starting daemon
 fwupdtool emulation-tag 08d460be0f1f9f128413f816022a6439e0078018
 NO_COLOR=1 G_DEBUG=fatal-criticals /usr/lib/fwupd/fwupd --verbose --no-timestamp >fwupd.txt 2>&1 &
 sleep 10
+
+group "Run fwupdmgr.sh installed test"
 /usr/share/installed-tests/fwupd/fwupdmgr.sh
+endgroup
+
+group "Run fwupd.sh installed test"
 /usr/share/installed-tests/fwupd/fwupd.sh
+endgroup
+
+group "Run fwupdtool.sh installed test"
 /usr/share/installed-tests/fwupd/fwupdtool.sh
+endgroup
+
+group "Run fwupdtool-efiboot.sh installed test"
 /usr/share/installed-tests/fwupd/fwupdtool-efiboot.sh
+endgroup
 
 # generate coverage report
 ./contrib/ci/coverage.sh

--- a/contrib/ci/centos-test.sh
+++ b/contrib/ci/centos-test.sh
@@ -1,16 +1,26 @@
 #!/bin/sh
-set -e
+set -ex
 
-#install RPM packages
+group() {
+    { echo "${CI:+::group::}🔵 $*"; } 2>/dev/null
+}
+
+endgroup() {
+    { [ -n "${CI:-}" ] && echo "::endgroup::" || true; } 2>/dev/null
+}
+
+group "Install RPM packages"
 dnf install -y dist/*.rpm
+endgroup
 
-# set up enough PolicyKit and D-Bus to run the daemon
+group "Set up PolicyKit and D-Bus to run the daemon"
 mkdir -p /run/dbus
 mkdir -p /var
 ln -s /var/run /run
 dbus-daemon --system --fork
 /usr/lib/polkit-1/polkitd &
 sleep 5
+endgroup
 
 # run the daemon startup to check it can start
 /usr/libexec/fwupd/fwupd --immediate-exit --verbose

--- a/contrib/ci/debian-test.sh
+++ b/contrib/ci/debian-test.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euox pipefail
+
+group() {
+    { echo "${CI:+::group::}🔵 $*"; } 2>/dev/null
+}
+
+endgroup() {
+    { [ -n "${CI:-}" ] && echo "::endgroup::" || true; } 2>/dev/null
+}
 
 # Set up fatal-criticals systemd override
 SYSTEMD_OVERRIDE="/etc/systemd/system/fwupd.service.d"
@@ -9,20 +17,30 @@ cat >"$SYSTEMD_OVERRIDE/override.conf" <<EOF
 Environment="G_DEBUG=fatal-criticals"
 EOF
 
-# install
+group "Update system and install dependencies"
 apt update -qq
 apt install -qq -y gcovr ./dist/*.deb
+endgroup
 
+group "Enable test devices"
 fwupdtool enable-test-devices
+endgroup
+
 fwupdtool emulation-tag 08d460be0f1f9f128413f816022a6439e0078018
 
-# run tests
+group "Get the test firmware"
 ./contrib/ci/get_test_firmware.sh /usr/share/installed-tests/fwupd/
+endgroup
+
 service dbus restart
+
+group "Run the tests via gnome-desktop-testing-runner"
 gnome-desktop-testing-runner --timeout=2400 fwupd
+endgroup
 
 # generate coverage report
 ./contrib/ci/coverage.sh
 
-# cleanup
+group "Clean up"
 apt purge -y fwupd fwupd-doc libfwupd3 libfwupd-dev
+endgroup

--- a/contrib/ci/fedora-test.sh
+++ b/contrib/ci/fedora-test.sh
@@ -1,22 +1,34 @@
 #!/bin/sh
-set -e
+set -ex
+
+group() {
+    { echo "${CI:+::group::}🔵 $*"; } 2>/dev/null
+}
+
+endgroup() {
+    { [ -n "${CI:-}" ] && echo "::endgroup::" || true; } 2>/dev/null
+}
 
 # workaround dnf bug
 export FORCE_COLUMNS=100
 
-#install RPM packages
+group "Update system and install dependencies"
 dnf install -y dist/*.rpm
 dnf install -y gcovr
+endgroup
 
+group "Enable test devices"
 fwupdtool enable-test-devices
+endgroup
 
-# set up enough PolicyKit and D-Bus to run the daemon
+group "Set up PolicyKit and D-Bus to run the daemon"
 mkdir -p /run/dbus
 mkdir -p /var
 ln -s /var/run /run
 dbus-daemon --system --fork
 /usr/lib/polkit-1/polkitd &
 sleep 5
+endgroup
 
 # Enable testing capturing emulation data
 fwupdtool emulation-tag 08d460be0f1f9f128413f816022a6439e0078018
@@ -27,7 +39,10 @@ fwupdtool emulation-tag 08d460be0f1f9f128413f816022a6439e0078018
 # run the installed tests whilst the daemon debugging
 NO_COLOR=1 G_DEBUG=fatal-criticals /usr/libexec/fwupd/fwupd --verbose --no-timestamp >fwupd.txt 2>&1 &
 sleep 10
+
+group "Run the tests via gnome-desktop-testing-runner"
 gnome-desktop-testing-runner --timeout=2400 fwupd
+endgroup
 
 # generate coverage report
 ./contrib/ci/coverage.sh


### PR DESCRIPTION
Makes it a lot easier to find anything in the thousands of lines of output.

Currently on for arch, will switch out of draft once it looks correct on all.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
