### PR TITLE
ci: Fix skipped jobs during forced container rebuild

### DIFF
--- a/.github/workflows/create_containers.yml
+++ b/.github/workflows/create_containers.yml
@@ -122,7 +122,7 @@ jobs:
           exit 1
       # Steps below here are skipped for pull requests because we don't have permission anyway
       - name: Generate Dockerfile
-        if: steps.should_we.outputs.run == 'true' && ((github.event_name == 'workflow_call' && inputs.force_rebuild) || (steps.check_container.outputs.exists != 'true' && github.event_name != 'pull_request'))
+        if: steps.should_we.outputs.run == 'true' && (inputs.force_rebuild || (steps.check_container.outputs.exists != 'true' && github.event_name != 'pull_request'))
         run: >-
           ./contrib/ci/generate_docker.py
           --distro "${{ matrix.distros.DISTRO }}"
@@ -131,10 +131,10 @@ jobs:
           ${{ matrix.distros.VARIANT && format('--variant "{0}"', matrix.distros.VARIANT) || '' }};
           cat Dockerfile
       - name: Set up Docker Buildx
-        if: steps.should_we.outputs.run == 'true' && ((github.event_name == 'workflow_call' && inputs.force_rebuild) || (steps.check_container.outputs.exists != 'true' && github.event_name != 'pull_request'))
+        if: steps.should_we.outputs.run == 'true' && (inputs.force_rebuild || (steps.check_container.outputs.exists != 'true' && github.event_name != 'pull_request'))
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       - name: Push to GitHub Packages
-        if: steps.should_we.outputs.run == 'true' && ((github.event_name == 'workflow_call' && inputs.force_rebuild) || (steps.check_container.outputs.exists != 'true' && github.event_name != 'pull_request'))
+        if: steps.should_we.outputs.run == 'true' && (inputs.force_rebuild || (steps.check_container.outputs.exists != 'true' && github.event_name != 'pull_request'))
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .


### PR DESCRIPTION
During a scheduled rebuild the event name isn't workflow_call but 'schedule' (or maybe 'workflow_dispatch'?) so we ended up checking the container but not rebuilding it.

Fix this by dropping the event name check - if force-rebuild is set we want to always rebuild, regardless what triggers the pipeline.

Fixes: f2c153a5ac8a ("ci: Add a forced rebuild of the arch container on schedule")

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
