### PR TITLE
trivial: Disable python deprecation warnings with a larger hammer

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -183,6 +183,7 @@ add_test_setup(
     'LSAN_OPTIONS': 'suppressions=@0@'.format(
       meson.current_source_dir() / 'data' / 'tests' / 'lsan-suppressions.txt'
     ),
+    'PYTHONWARNINGS': 'ignore::DeprecationWarning:gi.events',
   },
   is_default: true,
 )


### PR DESCRIPTION
Adding it to the default meson test setup hopefully covers more cases.

See commit 806b15ff6b44 ("Disable the python deprecation warning yet again") for another example of this.


... such a whack-a-mole task

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
