### PR TITLE
trivial: fix CI locale for debian-based distros

### DIFF
--- a/contrib/ci/Dockerfile-debian-tartan.in
+++ b/contrib/ci/Dockerfile-debian-tartan.in
@@ -20,6 +20,7 @@ RUN set -euxo pipefail; \
 %%%DEPENDENCIES%%%; \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*
+RUN echo "en_US.UTF-8 UTF-8" >>/etc/locale.gen && locale-gen
 RUN set -euxo pipefail; \
     update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100; \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 100; \

--- a/contrib/ci/Dockerfile-debian.in
+++ b/contrib/ci/Dockerfile-debian.in
@@ -16,4 +16,5 @@ RUN set -euxo pipefail; \
 %%%DEPENDENCIES%%%; \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*
+RUN echo "en_US.UTF-8 UTF-8" >>/etc/locale.gen && locale-gen
 WORKDIR /github/workspace

--- a/contrib/ci/Dockerfile-ubuntu.in
+++ b/contrib/ci/Dockerfile-ubuntu.in
@@ -18,5 +18,6 @@ RUN set -euxo pipefail; \
     sudo \
 %%%DEPENDENCIES%%%; \
     apt-get clean
+RUN echo "en_US.UTF-8 UTF-8" >>/etc/locale.gen && locale-gen
 WORKDIR /github/workspace
 %%%RUSTUP%%%


### PR DESCRIPTION
Installing `locales` on Debian doesn't make all of them available by default. The desired locales need to be selected and compiled. See manpages.debian.org/locale-gen

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
