### PR TITLE
wacom-usb: Fix a read past the end of the checksum array

### DIFF
--- a/plugins/wacom-usb/fu-wacom-usb-device.c
+++ b/plugins/wacom-usb/fu-wacom-usb-device.c
@@ -164,6 +164,11 @@ fu_wacom_usb_device_ensure_flash_descriptors(FuWacomUsbDevice *self, GError **er
 	gsize sz = 0;
 	g_autofree guint8 *buf = NULL;
 
+	/* the device changed the block count, so invalidate the cache */
+	if (self->flash_descriptors->len > 0 &&
+	    self->flash_descriptors->len != self->nr_flash_blocks)
+		g_ptr_array_set_size(self->flash_descriptors, 0);
+
 	/* already done */
 	if (self->flash_descriptors->len > 0)
 		return TRUE;

--- a/plugins/wacom-usb/fu-wacom-usb-device.c
+++ b/plugins/wacom-usb/fu-wacom-usb-device.c
@@ -273,7 +273,7 @@ fu_wacom_usb_device_ensure_checksums(FuWacomUsbDevice *self, GError **error)
 		g_debug("checksum block %02u: 0x%08x", i, (guint)csum);
 		g_array_append_val(self->checksums, csum);
 	}
-	g_debug("added %u checksums", self->flash_descriptors->len);
+	g_debug("added %u checksums", self->checksums->len);
 
 	return TRUE;
 }

--- a/plugins/wacom-usb/fu-wacom-usb-device.c
+++ b/plugins/wacom-usb/fu-wacom-usb-device.c
@@ -645,6 +645,15 @@ fu_wacom_usb_device_write_firmware(FuDevice *device,
 			continue;
 
 		/* check checksum matches */
+		if (i >= self->checksums->len) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "checksum index %u out of range, got %u",
+				    i,
+				    self->checksums->len);
+			return FALSE;
+		}
 		csum_rom = g_array_index(self->checksums, guint32, i);
 		if (csum_rom != csum_local[i]) {
 			g_set_error(error,


### PR DESCRIPTION
Hello,

This fixes an issue where the plugin can read past the end of its checksum array and those bytes end up in the error it returns to the caller, plus two minor issues discovered while investigating this.

Please see more details in the commit messages.

Thanks,
Adrian

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
