### PR TITLE
Fix a file descriptor leak in GetDetails

### DIFF
--- a/src/fu-engine-test.c
+++ b/src/fu-engine-test.c
@@ -992,6 +992,54 @@ fu_engine_get_details_missing_func(void)
 }
 
 static void
+fu_engine_get_details_refcount_func(void)
+{
+	FuDevice *device_tmp;
+	FwupdRelease *release_tmp;
+	GPtrArray *devices;
+	gboolean ret;
+	g_autofree gchar *filename = NULL;
+	g_autoptr(FuContext) ctx = fu_context_new_full(FU_CONTEXT_FLAG_NO_QUIRKS);
+	g_autoptr(FuEngine) engine = fu_engine_new(ctx);
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new(NULL);
+	g_autoptr(FuInputStream) stream = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(XbSilo) silo_empty = xb_silo_new();
+
+	/* no metadata in daemon */
+	fu_engine_set_silo(engine, silo_empty);
+
+	/* load engine to get FuConfig set up */
+	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, progress, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* get details */
+	filename =
+	    g_test_build_filename(G_TEST_BUILT, "tests", "missing-hwid", "hwid-1.2.3.cab", NULL);
+	stream = fu_input_stream_from_path(filename, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(stream);
+	devices = fu_engine_get_details(engine, request, stream, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(devices);
+	g_assert_cmpint(devices->len, ==, 1);
+	device_tmp = g_ptr_array_index(devices, 0);
+	release_tmp = fu_device_get_release_default(device_tmp);
+	g_assert_nonnull(release_tmp);
+
+	/* the release only has a weak reference on the device, so unreferencing
+	 * the device also destroys the release -- and the stream it holds, which
+	 * was built from the client file descriptor */
+	g_object_add_weak_pointer(G_OBJECT(device_tmp), (gpointer *)&device_tmp);
+	g_object_add_weak_pointer(G_OBJECT(release_tmp), (gpointer *)&release_tmp);
+	g_ptr_array_unref(devices);
+	g_assert_null(device_tmp);
+	g_assert_null(release_tmp);
+}
+
+static void
 fu_engine_version_highest_func(void)
 {
 	FwupdRelease *rel;
@@ -3565,6 +3613,7 @@ main(int argc, char **argv)
 	g_test_add_func("/fwupd/engine/plugin/module", fu_engine_plugin_module_func);
 	g_test_add_func("/fwupd/engine/get-details-added", fu_engine_get_details_added_func);
 	g_test_add_func("/fwupd/engine/get-details-missing", fu_engine_get_details_missing_func);
+	g_test_add_func("/fwupd/engine/get-details-refcount", fu_engine_get_details_refcount_func);
 	g_test_add_func("/fwupd/engine/device-unlock", fu_engine_device_unlock_func);
 	g_test_add_func("/fwupd/engine/device-equivalent", fu_engine_device_equivalent_func);
 	g_test_add_func("/fwupd/engine/device-md-set-flags", fu_engine_device_md_set_flags_func);

--- a/src/fu-release.c
+++ b/src/fu-release.c
@@ -1356,7 +1356,7 @@ const gchar *
 fu_release_get_action_id(FuRelease *self)
 {
 	/* relax authentication checks for removable devices */
-	if (!fu_device_has_flag(self->device, FWUPD_DEVICE_FLAG_INTERNAL)) {
+	if (self->device != NULL && !fu_device_has_flag(self->device, FWUPD_DEVICE_FLAG_INTERNAL)) {
 		if (fu_release_has_flag(self, FWUPD_RELEASE_FLAG_IS_DOWNGRADE)) {
 			if (fu_release_has_flag(self, FWUPD_RELEASE_FLAG_TRUSTED_PAYLOAD))
 				return "org.freedesktop.fwupd.downgrade-hotplug-trusted";

--- a/src/fu-release.c
+++ b/src/fu-release.c
@@ -24,7 +24,7 @@
 struct _FuRelease {
 	FwupdRelease parent_instance;
 	FuEngineRequest *request;
-	FuDevice *device;
+	FuDevice *device; /* no ref */
 	FwupdRemote *remote;
 	FuConfig *config;
 	FuInputStream *stream;
@@ -148,20 +148,30 @@ fu_release_set_device_version_old(FuRelease *self, const gchar *device_version_o
 /**
  * fu_release_set_device:
  * @self: a #FuRelease
- * @device: (nullable): a #FuDevice
+ * @device: (not nullable): a #FuDevice
  *
  * Sets the device this release should use when checking requirements.
+ *
+ * NOTE: No reference is taken on @device, as the device typically owns the release.
  **/
 void
 fu_release_set_device(FuRelease *self, FuDevice *device)
 {
 	g_return_if_fail(FU_IS_RELEASE(self));
+	g_return_if_fail(FU_IS_DEVICE(device));
+
+	if (self->device == device)
+		return;
 
 	/* make tests easier */
 	fu_device_convert_instance_ids(device);
-
-	g_set_object(&self->device, device);
 	fu_release_set_device_version_old(self, fu_device_get_version(device));
+
+	/* there is no ref on device to prevent a loop */
+	if (self->device != NULL)
+		g_object_remove_weak_pointer(G_OBJECT(self->device), (gpointer *)&self->device);
+	g_object_add_weak_pointer(G_OBJECT(device), (gpointer *)&self->device);
+	self->device = device;
 }
 
 /**
@@ -169,6 +179,8 @@ fu_release_set_device(FuRelease *self, FuDevice *device)
  * @self: a #FuRelease
  *
  * Gets the device this release was loaded for.
+ *
+ * NOTE: This is a weak reference, and may be %NULL if the device has been destroyed.
  *
  * Returns: (transfer none) (nullable): device
  **/
@@ -1429,7 +1441,7 @@ fu_release_finalize(GObject *obj)
 	if (self->request != NULL)
 		g_object_unref(self->request);
 	if (self->device != NULL)
-		g_object_unref(self->device);
+		g_object_remove_weak_pointer(G_OBJECT(self->device), (gpointer *)&self->device);
 	if (self->remote != NULL)
 		g_object_unref(self->remote);
 	if (self->config != NULL)

--- a/src/fu-release.h
+++ b/src/fu-release.h
@@ -75,7 +75,7 @@ fu_release_get_firmware_basename(FuRelease *self) G_GNUC_NON_NULL(1);
 void
 fu_release_set_request(FuRelease *self, FuEngineRequest *request) G_GNUC_NON_NULL(1);
 void
-fu_release_set_device(FuRelease *self, FuDevice *device) G_GNUC_NON_NULL(1);
+fu_release_set_device(FuRelease *self, FuDevice *device) G_GNUC_NON_NULL(1, 2);
 void
 fu_release_set_remote(FuRelease *self, FwupdRemote *remote) G_GNUC_NON_NULL(1);
 void


### PR DESCRIPTION
FuRelease holds a strong reference on FuDevice, and the device holds one on the release, so neither is ever freed. The release also owns the stream built from the client file descriptor, which is therefore never closed: the daemon runs out of descriptors after about a thousand GetDetails calls, and glib then aborts the next time anything builds a GUnixInputStream.
    
The device owns the release, so the release does not need to own the device. Make the back-reference weak, as FuDevice already does for ->proxy and ->backend.

No caller passes a NULL device, so drop the (nullable) annotation too.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
