### PR TITLE
Cleanup in dependencies.xml

### DIFF
--- a/.github/workflows/create_containers.yml
+++ b/.github/workflows/create_containers.yml
@@ -27,10 +27,10 @@ env:
   # The Arch container is force-rebuilt on schedule so we always run against the
   # latest one.
   ARCH_CONTAINER_TAG: "latest"
-  CENTOS_CONTAINER_TAG: "2026-09-10.2"
-  DEBIAN_CONTAINER_TAG: "2026-09-10.2"
-  UBUNTU_CONTAINER_TAG: "2026-09-10.2"
-  FEDORA_CONTAINER_TAG: "2026-09-10.2"
+  CENTOS_CONTAINER_TAG: "2026-09-10.3"
+  DEBIAN_CONTAINER_TAG: "2026-09-10.3"
+  UBUNTU_CONTAINER_TAG: "2026-09-10.3"
+  FEDORA_CONTAINER_TAG: "2026-09-10.3"
 
 jobs:
   find_or_create_container:

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -15,8 +15,11 @@
   <!ELEMENT control (version?, inclusive*, exclusive*)>
 
   <!ELEMENT version (#PCDATA)>
-  <!ELEMENT inclusive (#PCDATA)>
-  <!ELEMENT exclusive (#PCDATA)>
+  <!ELEMENT inclusive EMPTY>
+  <!ATTLIST inclusive arch (amd64 | arm64 | armhf | i386 | ia64 ) #REQUIRED>
+
+  <!ELEMENT exclusive EMPTY>
+  <!ATTLIST exclusive arch (amd64 | arm64 | armhf | i386 | ia64 ) #REQUIRED>
 
   <!ELEMENT native EMPTY>
   <!ELEMENT multi-arch EMPTY>
@@ -101,10 +104,10 @@
   <dependency id="fwupd-unsigned-dev">
     <distro id="debian">
       <control>
-        <inclusive>amd64</inclusive>
-        <inclusive>arm64</inclusive>
-        <inclusive>armhf</inclusive>
-        <inclusive>i386</inclusive>
+        <inclusive arch="amd64"/>
+        <inclusive arch="arm64"/>
+        <inclusive arch="armhf"/>
+        <inclusive arch="i386"/>
       </control>
       <package variant="aarch64" />
       <package variant="i386" />
@@ -464,13 +467,13 @@
   <dependency id="libjaylink-dev">
     <distro id="debian">
       <control>
-        <exclusive>ia64</exclusive>
+        <exclusive arch="ia64"/>
       </control>
       <multi-arch />
     </distro>
     <distro id="ubuntu">
       <control>
-        <exclusive>ia64</exclusive>
+        <exclusive arch="ia64"/>
       </control>
       <package variant="x86_64" />
       <package variant="aarch64" />
@@ -517,10 +520,10 @@
     </distro>
     <distro id="debian">
       <control>
-        <inclusive>amd64</inclusive>
-        <inclusive>arm64</inclusive>
-        <inclusive>armhf</inclusive>
-        <inclusive>i386</inclusive>
+        <inclusive arch="amd64"/>
+        <inclusive arch="arm64"/>
+        <inclusive arch="armhf"/>
+        <inclusive arch="i386"/>
       </control>
       <multi-arch />
       <package variant="aarch64">gnu-efi</package>
@@ -529,10 +532,10 @@
     </distro>
     <distro id="ubuntu">
       <control>
-        <inclusive>amd64</inclusive>
-        <inclusive>arm64</inclusive>
-        <inclusive>armhf</inclusive>
-        <inclusive>i386</inclusive>
+        <inclusive arch="amd64"/>
+        <inclusive arch="arm64"/>
+        <inclusive arch="armhf"/>
+        <inclusive arch="i386"/>
       </control>
       <package variant="x86_64">gnu-efi</package>
       <package variant="i386">gnu-efi</package>
@@ -997,18 +1000,18 @@
     </distro>
     <distro id="debian">
       <control>
-        <inclusive>amd64</inclusive>
-        <inclusive>arm64</inclusive>
-        <inclusive>armhf</inclusive>
-        <inclusive>i386</inclusive>
+        <inclusive arch="amd64"/>
+        <inclusive arch="arm64"/>
+        <inclusive arch="armhf"/>
+        <inclusive arch="i386"/>
       </control>
     </distro>
     <distro id="ubuntu">
       <control>
-        <inclusive>amd64</inclusive>
-        <inclusive>arm64</inclusive>
-        <inclusive>armhf</inclusive>
-        <inclusive>i386</inclusive>
+        <inclusive arch="amd64"/>
+        <inclusive arch="arm64"/>
+        <inclusive arch="armhf"/>
+        <inclusive arch="i386"/>
       </control>
       <package variant="x86_64" />
     </distro>
@@ -1695,10 +1698,10 @@
     </distro>
     <distro id="ubuntu">
       <control>
-        <inclusive>amd64</inclusive>
-        <inclusive>arm64</inclusive>
-        <inclusive>armhf</inclusive>
-        <inclusive>i386</inclusive>
+        <inclusive arch="amd64"/>
+        <inclusive arch="arm64"/>
+        <inclusive arch="armhf"/>
+        <inclusive arch="i386"/>
       </control>
       <package variant="x86_64" />
       <package variant="aarch64" />

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -10,7 +10,7 @@
   <!ATTLIST distro id CDATA #REQUIRED>
 
   <!ELEMENT package (#PCDATA)>
-  <!ATTLIST package variant CDATA #IMPLIED>
+  <!ATTLIST package variant (android | aarch64 | i386 | mingw64 | s390x | x86_64 ) #IMPLIED>
 
   <!ELEMENT control (version?, inclusive*, exclusive*)>
 

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -4,7 +4,7 @@
 
   <!ELEMENT dependency (distro*)>
   <!ATTLIST dependency id   CDATA #REQUIRED
-                       type CDATA #IMPLIED>
+                       type (build) #IMPLIED>
 
   <!ELEMENT distro (control | build-target | package)*>
   <!ATTLIST distro id CDATA #REQUIRED>

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -6,7 +6,7 @@
   <!ATTLIST dependency id   CDATA #REQUIRED
                        type CDATA #IMPLIED>
 
-  <!ELEMENT distro (control | native | multi-arch | build-indep | package)*>
+  <!ELEMENT distro (control | build-target | package)*>
   <!ATTLIST distro id CDATA #REQUIRED>
 
   <!ELEMENT package (#PCDATA)>
@@ -21,9 +21,8 @@
   <!ELEMENT exclusive EMPTY>
   <!ATTLIST exclusive arch (amd64 | arm64 | armhf | i386 | ia64 ) #REQUIRED>
 
-  <!ELEMENT native EMPTY>
-  <!ELEMENT multi-arch EMPTY>
-  <!ELEMENT build-indep EMPTY>
+  <!ELEMENT build-target EMPTY >
+  <!ATTLIST build-target mode (native | multi-arch | build-indep) #REQUIRED>
 ]>
 <dependencies>
   <dependency id="hwdata">
@@ -53,7 +52,7 @@
   <dependency id="7zip">
     <distro id="debian">
       <control />
-      <native />
+      <build-target mode="native" />
     </distro>
     <distro id="ubuntu">
       <control />
@@ -112,7 +111,7 @@
       <package variant="aarch64" />
       <package variant="i386" />
       <package variant="x86_64" />
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
   </dependency>
   <dependency type="build" id="noto-fonts-cjk">
@@ -202,7 +201,7 @@
     </distro>
     <distro id="debian">
       <control />
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control />
@@ -220,7 +219,7 @@
     </distro>
     <distro id="debian">
       <control />
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control />
@@ -241,7 +240,7 @@
     </distro>
     <distro id="debian">
       <control />
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control />
@@ -262,7 +261,7 @@
     </distro>
     <distro id="debian">
       <control />
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <package variant="x86_64" />
@@ -285,7 +284,7 @@
     </distro>
     <distro id="debian">
       <control />
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control />
@@ -415,7 +414,7 @@
     </distro>
     <distro id="debian">
       <control />
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control />
@@ -434,7 +433,7 @@
     </distro>
     <distro id="debian">
       <control />
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control />
@@ -469,7 +468,7 @@
       <control>
         <exclusive arch="ia64"/>
       </control>
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control>
@@ -525,7 +524,7 @@
         <inclusive arch="armhf"/>
         <inclusive arch="i386"/>
       </control>
-      <multi-arch />
+      <build-target mode="multi-arch" />
       <package variant="aarch64">gnu-efi</package>
       <package variant="i386">gnu-efi</package>
       <package variant="x86_64">gnu-efi</package>
@@ -579,7 +578,7 @@
       <control>
         <version>(>= 2.68.0)</version>
       </control>
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control>
@@ -620,7 +619,7 @@
       <control>
         <version>(>= 1.80)</version>
       </control>
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control>
@@ -659,7 +658,7 @@
       <control>
         <version>(>= 3.6.0)</version>
       </control>
-      <multi-arch />
+      <build-target mode="multi-arch" />
       <package variant="aarch64">libgnutls28-dev</package>
       <package variant="i386">libgnutls28-dev</package>
       <package variant="s390x">libgnutls28-dev</package>
@@ -732,7 +731,7 @@
       <control>
         <version>(>= 0.3.19)</version>
       </control>
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control>
@@ -763,7 +762,7 @@
     </distro>
     <distro id="debian">
       <control />
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control />
@@ -781,7 +780,7 @@
     </distro>
     <distro id="debian">
       <control />
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control />
@@ -795,7 +794,7 @@
     </distro>
     <distro id="debian">
       <control />
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
   </dependency>
   <dependency id="libgirepository1.0-dev">
@@ -822,7 +821,7 @@
       <control>
         <version>(>= 1.0.27)</version>
       </control>
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control>
@@ -834,12 +833,12 @@
   </dependency>
   <dependency id="libicu-dev">
     <distro id="debian">
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
   </dependency>
   <dependency id="libidn2-0-dev">
     <distro id="debian">
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
   </dependency>
   <dependency id="libcurl4-gnutls-dev">
@@ -861,7 +860,7 @@
       <control>
         <version>(>= 7.62.0)</version>
       </control>
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control>
@@ -884,7 +883,7 @@
   <dependency id="libumockdev-dev">
     <distro id="debian">
       <control />
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control />
@@ -913,7 +912,7 @@
   <dependency id="locales">
     <distro id="debian">
       <control />
-      <native />
+      <build-target mode="native" />
     </distro>
     <distro id="ubuntu">
       <control />
@@ -959,7 +958,7 @@
       <package variant="x86_64" />
     </distro>
     <distro id="debian">
-      <native />
+      <build-target mode="native" />
       <package />
     </distro>
     <distro id="fedora">
@@ -982,7 +981,7 @@
   </dependency>
   <dependency id="libstd-rust-dev">
     <distro id="debian">
-      <multi-arch />
+      <build-target mode="multi-arch" />
       <package />
     </distro>
   </dependency>
@@ -1019,7 +1018,7 @@
   <dependency id="gir1.2-gio-2.0-dev">
     <distro id="debian">
       <control />
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control />
@@ -1028,7 +1027,7 @@
   <dependency id="gir1.2-glib-2.0-dev">
     <distro id="debian">
       <control />
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control />
@@ -1039,7 +1038,7 @@
   <dependency id="gir1.2-gobject-2.0-dev">
     <distro id="debian">
       <control />
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control />
@@ -1055,7 +1054,7 @@
     </distro>
     <distro id="debian">
       <control />
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control />
@@ -1125,7 +1124,7 @@
     </distro>
     <distro id="debian">
       <control />
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control />
@@ -1146,7 +1145,7 @@
     </distro>
     <distro id="debian">
       <control />
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control />
@@ -1164,7 +1163,7 @@
     </distro>
     <distro id="debian">
       <control />
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control />
@@ -1182,7 +1181,7 @@
     </distro>
     <distro id="debian">
       <control />
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control />
@@ -1193,7 +1192,7 @@
   <dependency id="libqrtr-glib-dev">
     <distro id="debian">
       <control />
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
   </dependency>
   <dependency id="libpolkit-gobject-1-dev">
@@ -1211,7 +1210,7 @@
       <control>
         <version>(>= 0.103)</version>
       </control>
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control>
@@ -1252,7 +1251,7 @@
   <dependency id="python3-dbus">
     <distro id="debian">
       <control />
-      <native />
+      <build-target mode="native" />
     </distro>
     <distro id="arch">
       <package variant="x86_64">python-dbus</package>
@@ -1294,7 +1293,7 @@
     </distro>
     <distro id="debian">
       <control />
-      <native />
+      <build-target mode="native" />
     </distro>
     <distro id="ubuntu">
       <control />
@@ -1305,7 +1304,7 @@
   <dependency id="python3-gi">
     <distro id="debian">
       <control />
-      <native />
+      <build-target mode="native" />
     </distro>
     <distro id="arch">
       <package variant="x86_64">python-gobject</package>
@@ -1339,7 +1338,7 @@
     </distro>
     <distro id="debian">
       <control />
-      <native />
+      <build-target mode="native" />
     </distro>
     <distro id="ubuntu">
       <control />
@@ -1410,7 +1409,7 @@
       <package variant="android" />
     </distro>
     <distro id="debian">
-      <build-indep />
+      <build-target mode="build-indep" />
     </distro>
     <distro id="freebsd">
       <package>py312-gi-docgen</package>
@@ -1505,7 +1504,7 @@
     </distro>
     <distro id="debian">
       <control />
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control />
@@ -1564,7 +1563,7 @@
     </distro>
     <distro id="debian">
       <control />
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control />
@@ -1620,7 +1619,7 @@
     </distro>
     <distro id="debian">
       <control />
-      <native />
+      <build-target mode="native" />
     </distro>
     <distro id="ubuntu">
       <control />
@@ -1694,7 +1693,7 @@
     </distro>
     <distro id="debian">
       <control />
-      <multi-arch />
+      <build-target mode="multi-arch" />
     </distro>
     <distro id="ubuntu">
       <control>

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -6,7 +6,7 @@
   <!ATTLIST dependency id CDATA #REQUIRED>
 
   <!ELEMENT distro (control?, build-target?, package*)>
-  <!ATTLIST distro id CDATA #REQUIRED>
+  <!ATTLIST distro id (arch | centos | darwin | debian | fedora | freebsd | ubuntu) #REQUIRED>
 
   <!ELEMENT package (#PCDATA)>
   <!ATTLIST package variant (android | aarch64 | i386 | mingw64 | s390x | x86_64 ) #IMPLIED>

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -1105,7 +1105,7 @@
       <package variant="x86_64" />
       <package variant="aarch64" />
     </distro>
-    <distro id="polkit">
+    <distro id="freebsd">
       <package>polkit</package>
     </distro>
   </dependency>

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -5,7 +5,7 @@
   <!ELEMENT dependency (distro*)>
   <!ATTLIST dependency id CDATA #REQUIRED>
 
-  <!ELEMENT distro (control | build-target | package)*>
+  <!ELEMENT distro (control?, build-target?, package*)>
   <!ATTLIST distro id CDATA #REQUIRED>
 
   <!ELEMENT package (#PCDATA)>
@@ -107,10 +107,10 @@
         <inclusive arch="armhf"/>
         <inclusive arch="i386"/>
       </control>
+      <build-target mode="multi-arch" />
       <package variant="aarch64" />
       <package variant="i386" />
       <package variant="x86_64" />
-      <build-target mode="multi-arch" />
     </distro>
   </dependency>
   <dependency id="noto-fonts-cjk">

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -1772,7 +1772,7 @@
       <package variant="x86_64" />
     </distro>
   </dependency>
-  <dependency id="build-essential" type="build">
+  <dependency type="build" id="build-essential">
     <distro id="debian" />
     <distro id="ubuntu" />
   </dependency>

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -3,8 +3,7 @@
   <!ELEMENT dependencies (dependency*)>
 
   <!ELEMENT dependency (distro*)>
-  <!ATTLIST dependency id   CDATA #REQUIRED
-                       type (build) #IMPLIED>
+  <!ATTLIST dependency id CDATA #REQUIRED>
 
   <!ELEMENT distro (control | build-target | package)*>
   <!ATTLIST distro id CDATA #REQUIRED>
@@ -114,7 +113,7 @@
       <build-target mode="multi-arch" />
     </distro>
   </dependency>
-  <dependency type="build" id="noto-fonts-cjk">
+  <dependency id="noto-fonts-cjk">
     <distro id="arch">
       <package variant="x86_64" />
     </distro>
@@ -318,12 +317,12 @@
       <package>noto-sans</package>
     </distro>
   </dependency>
-  <dependency type="build" id="dh-sequence-cruft">
+  <dependency id="dh-sequence-cruft">
     <distro id="debian">
       <control />
     </distro>
   </dependency>
-  <dependency type="build" id="dh-sequence-gir">
+  <dependency id="dh-sequence-gir">
     <distro id="debian">
       <control />
     </distro>
@@ -1772,7 +1771,7 @@
       <package variant="x86_64" />
     </distro>
   </dependency>
-  <dependency type="build" id="build-essential">
+  <dependency id="build-essential">
     <distro id="debian" />
     <distro id="ubuntu" />
   </dependency>

--- a/contrib/ci/fwupd_setup_helpers.py
+++ b/contrib/ci/fwupd_setup_helpers.py
@@ -194,7 +194,14 @@ def parse_dependencies(OS, variant, add_control, cross: bool = False):
                 continue
             control = ""
             version = ""
-            is_build_indep = bool(distro.findall("build-indep"))
+            build_target = distro.find("build-target")
+            if build_target is not None:
+                if "mode" not in build_target.attrib:
+                    continue
+                build_target = build_target.attrib.get("mode")
+            else:
+                build_target = None
+            is_build_indep = build_target == "build-indep"
             if add_control:
                 inclusive = []
                 exclusive = []
@@ -219,12 +226,12 @@ def parse_dependencies(OS, variant, add_control, cross: bool = False):
                         exclusive = f"!{exclusive}"
                     control = f" [{inclusive}{exclusive}]"
 
-            if cross and distro.findall("multi-arch"):
+            if cross and build_target == "multi-arch":
                 deb_arch = {v: k for k, v in ARCH_TO_DEPS_MAP.items()}.get(
                     variant, variant
                 )
                 arch_suffix = f":{deb_arch}"
-            elif distro.findall("native"):
+            elif build_target == "native":
                 arch_suffix = ":native"
             else:
                 arch_suffix = ""

--- a/contrib/ci/fwupd_setup_helpers.py
+++ b/contrib/ci/fwupd_setup_helpers.py
@@ -202,9 +202,13 @@ def parse_dependencies(OS, variant, add_control, cross: bool = False):
                     continue
                 for control_parent in distro.findall("control"):
                     for obj in control_parent.findall("inclusive"):
-                        inclusive.append(obj.text)
+                        if "arch" not in obj.attrib:
+                            continue
+                        inclusive.append(obj.attrib["arch"])
                     for obj in control_parent.findall("exclusive"):
-                        exclusive.append(obj.text)
+                        if "arch" not in obj.attrib:
+                            continue
+                        exclusive.append(obj.attrib["arch"])
                     for obj in control_parent.findall("version"):
                         if obj.text:
                             version = f" {obj.text}"


### PR DESCRIPTION
One cleanup and 2 patches to make the XML less ad-hoc and more robust to validation. I don't know much about debian packaging and afaict the `<control>` is debian-only right now, hence the debian-only arch names.

A few comments here:
- really not happy with the `build-target` tag in the last commit but can't come up with anything better
- mixing debian arches, uname machine names, and sort-of free-form strings as `variant=` will (need to) be fixed in a follow-up PR somewhen


Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
