### PR TITLE
ci: All ubuntu containers need pip installed

### DIFF
--- a/.github/actions/find-container/action.yml
+++ b/.github/actions/find-container/action.yml
@@ -1,0 +1,57 @@
+name: 'Find Container Image'
+description: 'Finds the container image URI from the container LUT and verifies it exists. See create_containers.yml for the LUT Creation.'
+
+inputs:
+  distro:
+    description: 'The distribution name (e.g., debian, fedora, ubuntu)'
+    required: true
+  arch:
+    description: 'The architecture (e.g., amd64, arm64)'
+    required: true
+  variant:
+    description: 'Optional variant suffix'
+    required: false
+    default: ''
+  container:
+    description: 'Optional container override (if set, uses this instead of distro-arch-variant)'
+    required: false
+    default: ''
+  container_lut:
+    description: 'JSON lookup table mapping identifiers to container URIs'
+    required: true
+
+outputs:
+  container_uri:
+    description: 'The resolved container URI'
+    value: ${{ steps.find_container.outputs.container_uri }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Find container image
+      id: find_container
+      shell: bash
+      env:
+        DISTRO: ${{ inputs.distro }}
+        ARCH: ${{ inputs.arch }}
+        VARIANT: ${{ inputs.variant }}
+        CONTAINER: ${{ inputs.container }}
+        CONTAINER_LUT: ${{ inputs.container_lut }}
+      run: |
+        if [ -z "${CONTAINER}" ]; then
+          IDENTIFIER="${DISTRO}-${ARCH}${VARIANT:+-${VARIANT}}"
+        else
+          IDENTIFIER="${CONTAINER}"
+        fi
+        CONTAINER_URI=$(echo "$CONTAINER_LUT" | jq -r --arg key "$IDENTIFIER" '.[$key]')
+        if [ "${CONTAINER_URI}" = "null" ]; then
+          echo "$CONTAINER_LUT" | jq
+          echo "::error::Unable to find key '${IDENTIFIER}' in above container LUT"
+          exit 1
+        fi
+        echo "Using container ${CONTAINER_URI}"
+        if ! docker manifest inspect "${CONTAINER_URI}"; then
+          echo "::error::The requested image ${CONTAINER_URI} does not yet exist. Wait until the push pipeline is complete, then re-run this job."
+          exit 1
+        fi
+        echo "container_uri=${CONTAINER_URI}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,11 @@ jobs:
   openbmc:
     permissions:
       contents: read
-    needs: pre-commit
-    if: ${{ always() && (needs.pre-commit.result == 'success' || needs.pre-commit.result == 'skipped') }}
+    needs: [pre-commit, containers]
+    if: ${{ always() && (needs.pre-commit.result == 'success' || needs.pre-commit.result == 'skipped')  && needs.containers.result == 'success' }}
     uses: ./.github/workflows/openbmc.yml
+    with:
+      container_lut: ${{ needs.containers.outputs.container_lut }}
 
   snap:
     permissions:

--- a/.github/workflows/create_containers.yml
+++ b/.github/workflows/create_containers.yml
@@ -27,10 +27,10 @@ env:
   # The Arch container is force-rebuilt on schedule so we always run against the
   # latest one.
   ARCH_CONTAINER_TAG: "latest"
-  CENTOS_CONTAINER_TAG: "2026-09-10.0"
-  DEBIAN_CONTAINER_TAG: "2026-09-10.0"
-  UBUNTU_CONTAINER_TAG: "2026-09-10.0"
-  FEDORA_CONTAINER_TAG: "2026-09-10.0"
+  CENTOS_CONTAINER_TAG: "2026-09-10.2"
+  DEBIAN_CONTAINER_TAG: "2026-09-10.2"
+  UBUNTU_CONTAINER_TAG: "2026-09-10.2"
+  FEDORA_CONTAINER_TAG: "2026-09-10.2"
 
 jobs:
   push_to_registry:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -85,30 +85,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Find container image
         id: find_container
-        env:
-          DISTRO: ${{ matrix.env.DISTRO }}
-          ARCH: ${{ matrix.env.ARCH }}
-          VARIANT: ${{ matrix.env.VARIANT }}
-          CONTAINER: ${{ matrix.env.CONTAINER }}
-          CONTAINER_LUT: ${{ inputs.container_lut }}
-        run: |
-          if [ -z "${CONTAINER}" ]; then
-            IDENTIFIER="${DISTRO}-${ARCH}${VARIANT:+-${VARIANT}}"
-          else
-            IDENTIFIER="${CONTAINER}"
-          fi
-          CONTAINER_URI=$(echo "$CONTAINER_LUT" | jq -r --arg key "$IDENTIFIER" '.[$key]')
-          if [ "${CONTAINER_URI}" = "null" ]; then
-            echo "$CONTAINER_LUT" | jq
-            echo "::error::Unable to find key '${IDENTIFIER}' in above container LUT"
-            exit 1
-          fi
-          echo "Using container ${CONTAINER_URI}"
-          if ! docker manifest inspect "${CONTAINER_URI}"; then
-            echo "::error::The requested image ${CONTAINER_URI} does not yet exist. Wait until the push pipeline is complete, then re-run this job."
-            exit 1
-          fi
-          echo "container_uri=${CONTAINER_URI}" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/find-container
+        with:
+          distro: ${{ matrix.env.DISTRO }}
+          arch: ${{ matrix.env.ARCH }}
+          variant: ${{ matrix.env.VARIANT }}
+          container: ${{ matrix.env.CONTAINER }}
+          container_lut: ${{ inputs.container_lut }}
       - name: Download tarball
         if: matrix.env.DISTRO == 'fedora' || matrix.env.DISTRO == 'centos'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/openbmc.yml
+++ b/.github/workflows/openbmc.yml
@@ -1,7 +1,12 @@
 # This is more of an approximation for the sensible set of build options for openbmc but still
 # hosted on just plain ubuntu.
 
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      container_lut:
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -10,10 +15,33 @@ env:
   PYTHONWARNINGS: "ignore::DeprecationWarning:gi.events"
 
 jobs:
+  find-container:
+    runs-on: ubuntu-latest
+    outputs:
+      container_uri: ${{ steps.find_container.outputs.container_uri }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Find container image
+        id: find_container
+        uses: ./.github/actions/find-container
+        with:
+          distro: ubuntu
+          arch: amd64
+          container_lut: ${{ inputs.container_lut }}
+
   build:
     runs-on: ubuntu-latest
+    needs: find-container
     container:
-      image: ghcr.io/fwupd/fwupd/fwupd-ubuntu-amd64:latest # zizmor: ignore[unpinned-images]
+      image: ${{ needs.find-container.outputs.container_uri }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -1226,7 +1226,7 @@
       <package>py312-pip</package>
     </distro>
     <distro id="ubuntu">
-      <package variant="android">python3-pip</package>
+      <package>python3-pip</package>
     </distro>
   </dependency>
   <dependency id="python3-virtualenv">


### PR DESCRIPTION
Our containers have an apt db cache from whenever they are composed. Running apt install on a container will attempt to download the package from the compose time which may be superseded and 404 by the time we run the CI.

Let's make sure that our invocations of apt install do nothing.

See https://github.com/fwupd/fwupd/actions/runs/34421272474/job/102703939338 for a failed log.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
