### PR TITLE
ci: Always pass --platform to our Dockerfiles

### DIFF
--- a/.github/workflows/create_containers.yml
+++ b/.github/workflows/create_containers.yml
@@ -27,10 +27,10 @@ env:
   # The Arch container is force-rebuilt on schedule so we always run against the
   # latest one.
   ARCH_CONTAINER_TAG: "latest"
-  CENTOS_CONTAINER_TAG: "2026-09-10.3"
-  DEBIAN_CONTAINER_TAG: "2026-09-10.3"
-  UBUNTU_CONTAINER_TAG: "2026-09-10.3"
-  FEDORA_CONTAINER_TAG: "2026-09-10.3"
+  CENTOS_CONTAINER_TAG: "2026-09-10.4"
+  DEBIAN_CONTAINER_TAG: "2026-09-10.4"
+  UBUNTU_CONTAINER_TAG: "2026-09-10.4"
+  FEDORA_CONTAINER_TAG: "2026-09-10.4"
 
 jobs:
   find_or_create_container:
@@ -45,7 +45,7 @@ jobs:
           - { DISTRO: arch, VERSION: latest, ARCH: amd64 }
           - { DISTRO: centos, VERSION: stream9, ARCH: amd64 }
           - { DISTRO: debian, VERSION: testing, ARCH: amd64 }
-          - { DISTRO: debian, VERSION: testing, ARCH: amd64, VARIANT: i386 }
+          - { DISTRO: debian, VERSION: testing, ARCH: i386 }
           # - { DISTRO: debian, VERSION: unstable, ARCH: amd64, VARIANT: tartan }
           - { DISTRO: debian, VERSION: testing, ARCH: arm64 }
           - { DISTRO: debian, VERSION: testing, ARCH: arm64, VARIANT: cross-s390x }

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -64,7 +64,7 @@ jobs:
           - { DISTRO: arch, ARCH: amd64 }
           - { DISTRO: centos, ARCH: amd64 }
           - { DISTRO: debian, ARCH: amd64 }
-          - { DISTRO: debian, ARCH: amd64, VARIANT: i386 }
+          - { DISTRO: debian, ARCH: i386 }
           # - { DISTRO: debian, ARCH: amd64, VARIANT: tartan }
           - { DISTRO: debian, ARCH: arm64 }
           - { DISTRO: debian, ARCH: arm64, VARIANT: cross-s390x }

--- a/contrib/ci/Dockerfile-arch.in
+++ b/contrib/ci/Dockerfile-arch.in
@@ -1,5 +1,5 @@
 # -*- mode: dockerfile -*-
-FROM archlinux:{{VERSION}}
+FROM --platform=linux/{{ARCH}} archlinux:{{VERSION}}
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8

--- a/contrib/ci/Dockerfile-centos.in
+++ b/contrib/ci/Dockerfile-centos.in
@@ -1,5 +1,5 @@
 # -*- mode: dockerfile -*-
-FROM quay.io/centos/{{DISTRO}}:{{VERSION}}
+FROM --platform=linux/{{ARCH}} quay.io/centos/{{DISTRO}}:{{VERSION}}
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8

--- a/contrib/ci/Dockerfile-debian-tartan.in
+++ b/contrib/ci/Dockerfile-debian-tartan.in
@@ -1,5 +1,5 @@
 # -*- mode: dockerfile -*-
-FROM {% if PLATFORM %}--platform={{PLATFORM}} {% endif %}{{DISTRO}}:{{VERSION}}
+FROM --platform=linux/{{ARCH}} {{DISTRO}}:{{VERSION}}
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8

--- a/contrib/ci/Dockerfile-debian.in
+++ b/contrib/ci/Dockerfile-debian.in
@@ -1,5 +1,5 @@
 # -*- mode: dockerfile -*-
-FROM {% if PLATFORM %}--platform={{PLATFORM}} {% endif %}{{DISTRO}}:{{VERSION}}
+FROM --platform=linux/{{ARCH}} {{DISTRO}}:{{VERSION}}
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8

--- a/contrib/ci/Dockerfile-fedora.in
+++ b/contrib/ci/Dockerfile-fedora.in
@@ -1,5 +1,5 @@
 # -*- mode: dockerfile -*-
-FROM {% if PLATFORM %}--platform={{PLATFORM}} {% endif %}{{DISTRO}}:{{VERSION}}
+FROM --platform=linux/{{ARCH}} {{DISTRO}}:{{VERSION}}
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8

--- a/contrib/ci/Dockerfile-ubuntu.in
+++ b/contrib/ci/Dockerfile-ubuntu.in
@@ -1,5 +1,5 @@
 # -*- mode: dockerfile -*-
-FROM {% if PLATFORM %}--platform={{PLATFORM}} {% endif %}{{DISTRO}}:{{VERSION}}
+FROM --platform=linux/{{ARCH}} {{DISTRO}}:{{VERSION}}
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8

--- a/contrib/ci/generate_docker.py
+++ b/contrib/ci/generate_docker.py
@@ -51,16 +51,10 @@ def generate_dockerfile(
     data = {
         "VERSION": version,
         "DISTRO": distro,
+        "ARCH": arch,
     }
     if variant:
         data["VARIANT"] = variant
-
-    # special cases
-    match (distro, variant):
-        case ("debian", "i386"):
-            data["PLATFORM"] = "linux/i386"
-        case _:
-            pass
 
     if cross:
         data["CROSSARCH"] = cross


### PR DESCRIPTION
This has no effect on most of our calls because they're all amd64 anyway which is the default. But it makes future cleanup easier.

It does mean that we can use i386 as normal arch now instead of as variant on top of another arch.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
