### PR TITLE
Authentication fixes

### DIFF
--- a/data/bash-completion/fwupdmgr
+++ b/data/bash-completion/fwupdmgr
@@ -151,6 +151,7 @@ redfish_modify_config_opts=(
 	'IpmiDisableCreateUser'
 	'ManagerResetTimeout'
 	'Password'
+	'SessionKeyFile'
 	'Uri'
 	'Username'
 	'UserUri'

--- a/docs/fwupd.conf.md
+++ b/docs/fwupd.conf.md
@@ -327,6 +327,9 @@ The `[redfish]` section can contain the following parameters:
 
   The bearer token to use for authenticating to the Redfish service.
 
+  When set, it is used instead of `Username=` and `Password=` for HTTP authentication, and the
+  plugin will not create or modify a BMC user account using IPMI.
+
 **SessionKeyFile={{redfish_SessionKeyFile}}**
 
   Instead of storing a password as `Password=`, the plugin can reuse a Redfish `X-Auth-Token`

--- a/plugins/redfish/fu-redfish-backend.c
+++ b/plugins/redfish/fu-redfish-backend.c
@@ -724,6 +724,22 @@ fu_redfish_backend_set_bearer_token(FuRedfishBackend *self, const gchar *bearer_
 	g_set_str(&self->bearer_token, bearer_token);
 }
 
+/**
+ * fu_redfish_backend_has_bearer_token:
+ * @self: a #FuRedfishBackend
+ *
+ * Gets if a bearer token is configured, in which case it is used for
+ * authentication instead of the username and password.
+ *
+ * Returns: %TRUE if a bearer token is set
+ **/
+gboolean
+fu_redfish_backend_has_bearer_token(FuRedfishBackend *self)
+{
+	g_return_val_if_fail(FU_IS_REDFISH_BACKEND(self), FALSE);
+	return self->bearer_token != NULL;
+}
+
 void
 fu_redfish_backend_set_session_key_file(FuRedfishBackend *self, const gchar *session_key_file)
 {

--- a/plugins/redfish/fu-redfish-backend.h
+++ b/plugins/redfish/fu-redfish-backend.h
@@ -32,6 +32,8 @@ void
 fu_redfish_backend_set_password(FuRedfishBackend *self, const gchar *password);
 void
 fu_redfish_backend_set_bearer_token(FuRedfishBackend *self, const gchar *bearer_token);
+gboolean
+fu_redfish_backend_has_bearer_token(FuRedfishBackend *self);
 void
 fu_redfish_backend_set_session_key_file(FuRedfishBackend *self, const gchar *session_key_file);
 void

--- a/plugins/redfish/fu-redfish-plugin.c
+++ b/plugins/redfish/fu-redfish-plugin.c
@@ -97,8 +97,10 @@ fu_redfish_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError **erro
 
 	/* get the list of devices */
 	if (!fu_backend_coldplug(FU_BACKEND(self->backend), progress, &error_local)) {
-		/* did the user password expire? */
-		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_AUTH_EXPIRED)) {
+		/* did the user password expire? we cannot refresh a password that we do
+		 * not authenticate with */
+		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_AUTH_EXPIRED) &&
+		    !fu_redfish_backend_has_bearer_token(self->backend)) {
 			if (!fu_redfish_plugin_change_expired(plugin, error))
 				return FALSE;
 			if (!fu_backend_coldplug(FU_BACKEND(self->backend), progress, error)) {
@@ -422,23 +424,81 @@ fu_redfish_plugin_ipmi_create_user(FuPlugin *plugin, GError **error)
 
 	return TRUE;
 }
+
+/**
+ * fu_redfish_plugin_ensure_ipmi_user:
+ * @plugin: a #FuPlugin
+ * @username: (nullable): username from the config file
+ * @password: (nullable): password from the config file
+ * @error: (nullable): optional return location for an error
+ *
+ * Checks that the BMC user account we authenticate with is usable, creating one
+ * using IPMI KCS if the vendor quirk allows it and no working credentials are
+ * known.
+ *
+ * Returns: %TRUE for success
+ **/
+static gboolean
+fu_redfish_plugin_ensure_ipmi_user(FuPlugin *plugin,
+				   const gchar *username,
+				   const gchar *password,
+				   GError **error)
+{
+	FuRedfishPlugin *self = FU_REDFISH_PLUGIN(plugin);
+	gboolean credentials_invalid = FALSE;
+	g_autofree gchar *user_uri = NULL;
+
+	/* test if the existing credentials work */
+	user_uri = fu_plugin_get_config_value(plugin, "UserUri");
+	if (username != NULL && password != NULL && user_uri != NULL) {
+		g_autoptr(FuRedfishRequest) request = fu_redfish_backend_request_new(self->backend);
+		g_autoptr(GError) error_local = NULL;
+		if (!fu_redfish_request_perform(request,
+						user_uri,
+						FU_REDFISH_REQUEST_PERFORM_FLAG_LOAD_JSON,
+						&error_local)) {
+			if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_AUTH_FAILED)) {
+				credentials_invalid = TRUE;
+			} else {
+				g_propagate_prefixed_error(
+				    error,
+				    g_steal_pointer(&error_local),
+				    "existing username and password did not work: ");
+				return FALSE;
+			}
+		}
+	}
+
+	/* we got neither a type 42 entry or config value, lets try IPMI */
+	if (fu_redfish_backend_get_username(self->backend) == NULL || credentials_invalid) {
+		if (!fu_context_has_hwid_flag(fu_plugin_get_context(plugin), "ipmi-create-user")) {
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
+					    "no username and password specified, "
+					    "and no vendor quirk for 'ipmi-create-user'");
+			return FALSE;
+		}
+		if (!fu_plugin_get_config_value_boolean(plugin, "IpmiDisableCreateUser")) {
+			g_info("attempting to [re-]create user using IPMI");
+			if (!fu_redfish_plugin_ipmi_create_user(plugin, error))
+				return FALSE;
+		}
+	}
+
+	return TRUE;
+}
 #endif
 
 static gboolean
 fu_redfish_plugin_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	FuRedfishPlugin *self = FU_REDFISH_PLUGIN(plugin);
-#ifdef HAVE_LINUX_IPMI_H
-	gboolean credentials_invalid = FALSE;
-#endif
 	g_autofree gchar *password = NULL;
 	g_autofree gchar *bearer_token = NULL;
 	g_autofree gchar *session_key_file = NULL;
 	g_autofree gchar *redfish_uri = NULL;
 	g_autofree gchar *username = NULL;
-#ifdef HAVE_LINUX_IPMI_H
-	g_autofree gchar *user_uri = NULL;
-#endif
 	g_autoptr(GError) error_uefi = NULL;
 
 	/* optional */
@@ -520,42 +580,11 @@ fu_redfish_plugin_startup(FuPlugin *plugin, FuProgress *progress, GError **error
 		fu_redfish_backend_set_wildcard_targets(self->backend, TRUE);
 
 #ifdef HAVE_LINUX_IPMI_H
-	/* test if the existing credentials work */
-	user_uri = fu_plugin_get_config_value(plugin, "UserUri");
-	if (username != NULL && password != NULL && user_uri != NULL) {
-		g_autoptr(FuRedfishRequest) request = fu_redfish_backend_request_new(self->backend);
-		g_autoptr(GError) error_local = NULL;
-		if (!fu_redfish_request_perform(request,
-						user_uri,
-						FU_REDFISH_REQUEST_PERFORM_FLAG_LOAD_JSON,
-						&error_local)) {
-			if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_AUTH_FAILED)) {
-				credentials_invalid = TRUE;
-			} else {
-				g_propagate_prefixed_error(
-				    error,
-				    g_steal_pointer(&error_local),
-				    "existing username and password did not work: ");
-				return FALSE;
-			}
-		}
-	}
-
-	/* we got neither a type 42 entry or config value, lets try IPMI */
-	if (fu_redfish_backend_get_username(self->backend) == NULL || credentials_invalid) {
-		if (!fu_context_has_hwid_flag(fu_plugin_get_context(plugin), "ipmi-create-user")) {
-			g_set_error_literal(error,
-					    FWUPD_ERROR,
-					    FWUPD_ERROR_NOT_SUPPORTED,
-					    "no username and password specified, "
-					    "and no vendor quirk for 'ipmi-create-user'");
+	/* a bearer token replaces the BMC user account entirely, so there is
+	 * nothing to verify or create over IPMI */
+	if (!fu_redfish_backend_has_bearer_token(self->backend)) {
+		if (!fu_redfish_plugin_ensure_ipmi_user(plugin, username, password, error))
 			return FALSE;
-		}
-		if (!fu_plugin_get_config_value_boolean(plugin, "IpmiDisableCreateUser")) {
-			g_info("attempting to [re-]create user using IPMI");
-			if (!fu_redfish_plugin_ipmi_create_user(plugin, error))
-				return FALSE;
-		}
 	}
 #endif
 

--- a/plugins/redfish/fu-redfish-plugin.c
+++ b/plugins/redfish/fu-redfish-plugin.c
@@ -704,6 +704,7 @@ fu_redfish_plugin_modify_config(FuPlugin *plugin,
 			       "IpmiDisableCreateUser",
 			       "ManagerResetTimeout",
 			       "Password",
+			       "SessionKeyFile",
 			       "Uri",
 			       "Username",
 			       "UserUri",
@@ -747,6 +748,7 @@ fu_redfish_plugin_constructed(GObject *obj)
 	fu_plugin_set_config_default(plugin, "IpmiDisableCreateUser", "false");
 	fu_plugin_set_config_default(plugin, "ManagerResetTimeout", "1800"); /* seconds */
 	fu_plugin_set_config_default(plugin, "Password", NULL);
+	fu_plugin_set_config_default(plugin, "SessionKeyFile", NULL);
 	fu_plugin_set_config_default(plugin, "Uri", NULL);
 	fu_plugin_set_config_default(plugin, "Username", NULL);
 	fu_plugin_set_config_default(plugin, "UserUri", NULL);

--- a/plugins/redfish/fu-self-test.c
+++ b/plugins/redfish/fu-self-test.c
@@ -290,6 +290,45 @@ fu_redfish_backend_session_key_empty_func(void)
 }
 
 static void
+fu_redfish_bearer_token_func(void)
+{
+	gboolean ret;
+	g_autofree gchar *testdatadir = NULL;
+	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuPlugin) plugin = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	g_autoptr(FuTemporaryDirectory) tmpdir = NULL;
+	g_autoptr(GError) error = NULL;
+
+	/* set up test harness, using an empty sysfs directory so that the bearer token is the
+	 * only credential the plugin can find */
+	tmpdir = fu_temporary_directory_new("redfish", &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(tmpdir);
+	testdatadir = g_test_build_filename(G_TEST_DIST, "tests", NULL);
+	fu_context_set_path(ctx, FU_PATH_KIND_SYSFSDIR_FW, fu_temporary_directory_get_path(tmpdir));
+	fu_context_set_path(ctx, FU_PATH_KIND_SYSCONFDIR_PKG, testdatadir);
+	fu_context_add_flag(ctx, FU_CONTEXT_FLAG_NO_CACHE);
+
+	fu_config_set_basename(fu_context_get_config(ctx), "redfish-bearer-fwupd.conf");
+	ret = fu_context_load(ctx, progress, FU_CONTEXT_LOAD_FLAG_NONE, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* the bearer token replaces the BMC user account, so this should not fail trying to
+	 * verify or create one using IPMI */
+	plugin = fu_plugin_new_from_gtype(fu_redfish_plugin_get_type(), ctx);
+	ret = fu_plugin_runner_startup(plugin, progress, &error);
+	if (g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE)) {
+		g_debug("ignoring: %s", error->message);
+		g_test_skip("no redfish.py running");
+		return;
+	}
+	g_assert_no_error(error);
+	g_assert_true(ret);
+}
+
+static void
 fu_redfish_common_func(void)
 {
 	const guint8 buf[16] = {0x00,
@@ -763,6 +802,7 @@ main(int argc, char **argv)
 			fu_redfish_backend_session_key_valid_func);
 	g_test_add_func("/redfish/backend/session-key/empty",
 			fu_redfish_backend_session_key_empty_func);
+	g_test_add_func("/redfish/bearer-token", fu_redfish_bearer_token_func);
 	g_test_add_func("/redfish/common", fu_redfish_common_func);
 	g_test_add_func("/redfish/common/version", fu_redfish_common_version_func);
 	g_test_add_func("/redfish/common/lenovo", fu_redfish_common_lenovo_func);

--- a/plugins/redfish/meson.build
+++ b/plugins/redfish/meson.build
@@ -53,6 +53,11 @@ if get_option('tests')
     install_mode: 'rw-r-----',
   )
   install_data(
+    ['tests/redfish-bearer-fwupd.conf'],
+    install_dir: join_paths(installed_test_datadir, 'tests'),
+    install_mode: 'rw-r-----',
+  )
+  install_data(
     ['tests/efi/efivars/RedfishIndications-16faa37e-4b6a-4891-9028-242de65a3b70'],
     install_dir: join_paths(installed_test_datadir, 'tests', 'efi', 'efivars'),
   )

--- a/plugins/redfish/tests/redfish-bearer-fwupd.conf
+++ b/plugins/redfish/tests/redfish-bearer-fwupd.conf
@@ -1,0 +1,3 @@
+[redfish]
+Uri=http://localhost:4661
+BearerToken=token2

--- a/plugins/redfish/tests/redfish.py
+++ b/plugins/redfish/tests/redfish.py
@@ -11,18 +11,20 @@ from flask import Flask, Response, request
 
 app = Flask(__name__)
 
+HARDCODED_USERNAME = "username2"
 HARDCODED_SMC_USERNAME = "smc_username"
 HARDCODED_UNL_USERNAME = "unlicensed_username"
 HARDCODED_HPE_USERNAME = "hpe_username"
 HARDCODED_DELL_USERNAME = "dell_username"
 HARDCODED_USERNAMES = {
-    "username2",
+    HARDCODED_USERNAME,
     HARDCODED_SMC_USERNAME,
     HARDCODED_UNL_USERNAME,
     HARDCODED_HPE_USERNAME,
     HARDCODED_DELL_USERNAME,
 }
 HARDCODED_PASSWORD = "password2"
+HARDCODED_BEARER_TOKEN = "token2"
 
 app._percentage545: int = 0
 app._percentage546: int = 0
@@ -47,15 +49,23 @@ def index():
     app._hpeupdatestate = "Idle"
     app._hpeupdateresult = None
 
-    # check password from the config file
-    try:
-        if (
-            request.authorization["username"] not in HARDCODED_USERNAMES
-            or request.authorization["password"] != HARDCODED_PASSWORD
-        ):
+    # a bearer token is used instead of a username and password, e.g. when talking
+    # to a proxy that injects the real BMC credentials
+    if request.authorization is not None and request.authorization.type == "bearer":
+        if request.authorization.token != HARDCODED_BEARER_TOKEN:
             return _failure("unauthorised", status=401)
-    except (KeyError, TypeError):
-        return _failure("invalid")
+        username = HARDCODED_USERNAME
+    else:
+        # check password from the config file
+        try:
+            if (
+                request.authorization["username"] not in HARDCODED_USERNAMES
+                or request.authorization["password"] != HARDCODED_PASSWORD
+            ):
+                return _failure("unauthorised", status=401)
+        except (KeyError, TypeError):
+            return _failure("invalid")
+        username = request.authorization["username"]
 
     res = {
         "@odata.id": "/redfish/v1/",
@@ -65,13 +75,13 @@ def index():
         "UpdateService": {"@odata.id": "/redfish/v1/UpdateService"},
     }
 
-    if request.authorization["username"] == HARDCODED_HPE_USERNAME:
+    if username == HARDCODED_HPE_USERNAME:
         res["Vendor"] = "HPE"
 
-    if request.authorization["username"] == HARDCODED_DELL_USERNAME:
+    if username == HARDCODED_DELL_USERNAME:
         res["Vendor"] = "Dell"
 
-    if request.authorization["username"] in (
+    if username in (
         HARDCODED_SMC_USERNAME,
         HARDCODED_UNL_USERNAME,
     ):


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

When a bearer token is set, we shouldn't require username/password to load the redfish plugin, and we shouldn't attempt to refresh ipmi password either.
While at it, hook up missing runtime update capabilities for SessionKeyFile